### PR TITLE
fix: remove invalid ufw comment args in deploy script

### DIFF
--- a/infrastructure/scripts/deploy-digitalocean.sh
+++ b/infrastructure/scripts/deploy-digitalocean.sh
@@ -149,11 +149,11 @@ ufw default deny incoming
 ufw default allow outgoing
 
 # SSH — rate limit to slow brute force
-ufw limit 22/tcp comment "SSH (rate limited)"
+ufw limit 22/tcp
 
 # HTTP + HTTPS — required for web traffic and Let's Encrypt
-ufw allow 80/tcp comment "HTTP (Let's Encrypt + redirect)"
-ufw allow 443/tcp comment "HTTPS"
+ufw allow 80/tcp
+ufw allow 443/tcp
 
 # Enable firewall
 ufw --force enable


### PR DESCRIPTION
## Summary
- Removes invalid `comment` arguments from `ufw` rules in `deploy-digitalocean.sh`
- UFW does not support inline `comment` syntax, causing `ERROR: Invalid syntax` during firewall setup

## Test plan
- [ ] Re-run deploy script on DigitalOcean droplet — UFW step should complete without errors

https://claude.ai/code/session_01Tp8x6a8t32yNaDQAdPRBuU