### PR TITLE
fix: copy README.md into Docker images for hatchling build

### DIFF
--- a/infrastructure/Dockerfile.api
+++ b/infrastructure/Dockerfile.api
@@ -85,7 +85,7 @@ WORKDIR /app
 
 # Copy application code
 COPY alchymine/ ./alchymine/
-COPY pyproject.toml ./
+COPY pyproject.toml README.md ./
 
 # Install the project in the venv (editable-like, just the package reference)
 RUN pip install --no-cache-dir --no-deps -e .

--- a/infrastructure/docker/Dockerfile.api
+++ b/infrastructure/docker/Dockerfile.api
@@ -86,7 +86,7 @@ WORKDIR /app
 
 # Copy application code
 COPY alchymine/ ./alchymine/
-COPY pyproject.toml ./
+COPY pyproject.toml README.md ./
 
 # Install the project in the venv (editable-like, just the package reference)
 RUN pip install --no-cache-dir --no-deps -e .

--- a/infrastructure/docker/Dockerfile.worker
+++ b/infrastructure/docker/Dockerfile.worker
@@ -80,7 +80,7 @@ WORKDIR /app
 
 # Copy application code
 COPY alchymine/ ./alchymine/
-COPY pyproject.toml ./
+COPY pyproject.toml README.md ./
 
 # Install the project package
 RUN pip install --no-cache-dir --no-deps -e .


### PR DESCRIPTION
## Summary
- Adds `README.md` to the `COPY` line in all three Dockerfiles (api, worker, docker/api)
- Hatchling requires README.md (declared in `pyproject.toml`) to generate package metadata; without it `pip install -e .` fails during Docker build

## Test plan
- [ ] Re-run `docker compose build` on the droplet — all three images should build successfully

https://claude.ai/code/session_01Tp8x6a8t32yNaDQAdPRBuU