### PR TITLE
fix: ALLOWED_ORIGINS must be JSON array for pydantic-settings

### DIFF
--- a/alchymine/config.py
+++ b/alchymine/config.py
@@ -63,6 +63,14 @@ class Settings(BaseSettings):
 
     # ── Validators ───────────────────────────────────────────────────────
 
+    @field_validator("allowed_origins", mode="before")
+    @classmethod
+    def parse_allowed_origins(cls, v: object) -> object:
+        """Accept a bare string (e.g. ``https://example.com``) and wrap it in a list."""
+        if isinstance(v, str) and not v.startswith("["):
+            return [origin.strip() for origin in v.split(",") if origin.strip()]
+        return v
+
     @field_validator("jwt_secret_key")
     @classmethod
     def validate_jwt_secret(cls, v: str, info: object) -> str:  # noqa: ANN001

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - ENVIRONMENT=${ENVIRONMENT:-production}
       - LOG_LEVEL=${LOG_LEVEL:-WARNING}
       - API_SECRET_KEY=${API_SECRET_KEY:-changeme_generate_with_openssl_rand_hex_32}
-      - API_CORS_ORIGINS=${API_CORS_ORIGINS:-["http://localhost:3000"]}
+      - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-["http://localhost:3000"]}
     depends_on:
       db:
         condition: service_healthy

--- a/infrastructure/scripts/deploy-digitalocean.sh
+++ b/infrastructure/scripts/deploy-digitalocean.sh
@@ -258,7 +258,7 @@ SSL_EMAIL=${SSL_EMAIL}
 # ── Application ──────────────────────────────────────────────────────────────
 ENVIRONMENT=production
 LOG_LEVEL=WARNING
-ALLOWED_ORIGINS=https://${DOMAIN}
+ALLOWED_ORIGINS=["https://${DOMAIN}","https://www.${DOMAIN}"]
 
 # ── API Security ─────────────────────────────────────────────────────────────
 API_SECRET_KEY=${API_SECRET}
@@ -266,7 +266,6 @@ JWT_SECRET_KEY=${JWT_SECRET}
 JWT_ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 REFRESH_TOKEN_EXPIRE_DAYS=7
-API_CORS_ORIGINS=["https://${DOMAIN}","https://www.${DOMAIN}"]
 
 # ── Data Encryption ──────────────────────────────────────────────────────────
 ENCRYPTION_KEY=${ENCRYPTION_KEY}


### PR DESCRIPTION
## Summary
- Deploy script wrote `ALLOWED_ORIGINS=https://domain` (bare string) but Settings types it as `list[str]`, causing a pydantic-settings parse error on startup
- Fixed the deploy script to write a JSON array: `["https://domain","https://www.domain"]`
- Removed redundant `API_CORS_ORIGINS` env var (pydantic reads `ALLOWED_ORIGINS`, not `API_CORS_ORIGINS`)
- Renamed the compose env var from `API_CORS_ORIGINS` to `ALLOWED_ORIGINS` to match the Settings field
- Added a defensive `@field_validator` that auto-wraps bare strings into a list

## Test plan
- [ ] Re-generate `.env.production` on the droplet (re-run deploy script, or manually fix the line)
- [ ] `docker compose ... up` — API container should start and pass health check

https://claude.ai/code/session_01Tp8x6a8t32yNaDQAdPRBuU