### PR TITLE
fix: add SSH passphrase support for deploy action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,7 @@ jobs:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
+          passphrase: ${{ secrets.DEPLOY_SSH_PASSPHRASE }}
           script: |
             set -e
             TAG="${{ github.event.release.tag_name }}"
@@ -192,6 +193,7 @@ jobs:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
+          passphrase: ${{ secrets.DEPLOY_SSH_PASSPHRASE }}
           script: |
             set -e
             echo "Checking API health..."

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Set these in **GitHub → Settings → Secrets and variables → Actions**:
 | `DEPLOY_HOST` | DigitalOcean droplet IP address |
 | `DEPLOY_USER` | `alchymine` (deploy user) |
 | `DEPLOY_SSH_KEY` | Private SSH key (full PEM content) |
+| `DEPLOY_SSH_PASSPHRASE` | Passphrase for the SSH key (if password-protected) |
 
 ### Manual deployment
 

--- a/docs/guides/deployment-guide.md
+++ b/docs/guides/deployment-guide.md
@@ -484,6 +484,7 @@ and add these three secrets:
 | `DEPLOY_HOST` | Droplet IP address (e.g., `164.92.xxx.xxx`) | DigitalOcean dashboard → Droplets |
 | `DEPLOY_USER` | `alchymine` | The deploy user created by `deploy-digitalocean.sh` |
 | `DEPLOY_SSH_KEY` | Private SSH key (full PEM content) | Generate with `ssh-keygen -t ed25519`, add public key to droplet's `~alchymine/.ssh/authorized_keys` |
+| `DEPLOY_SSH_PASSPHRASE` | Passphrase for the SSH key | The password you set when generating the key (if any) |
 
 #### GitHub Environment (optional)
 


### PR DESCRIPTION
## Summary

- Add `passphrase` parameter to both SSH action steps in `release.yml`, referencing `DEPLOY_SSH_PASSPHRASE` secret
- Document the new secret in README and deployment guide

Fixes the `ssh: no key found` error from release run #22595292822 — the deploy key is password-protected.

## Test plan

- [ ] Add `DEPLOY_SSH_PASSPHRASE` secret in GitHub → Settings → Secrets
- [ ] Merge this PR
- [ ] Re-run the failed deploy job on the v0.1.0 release (or create a new release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)