### PR TITLE
feat: display version number in website footer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,8 @@ jobs:
             org.opencontainers.image.version=${{ needs.validate.outputs.version }}
             org.opencontainers.image.created=${{ needs.validate.outputs.build_date }}
             org.opencontainers.image.revision=${{ github.sha }}
+          build-args: |
+            APP_VERSION=${{ needs.validate.outputs.version }}
           cache-from: type=gha,scope=${{ matrix.image }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image }}
 
@@ -167,6 +169,7 @@ jobs:
           script: |
             set -e
             TAG="${{ github.event.release.tag_name }}"
+            VERSION="${TAG#v}"
             echo "Deploying Alchymine ${TAG}..."
 
             cd /home/alchymine/Alchymine
@@ -175,9 +178,9 @@ jobs:
             git fetch --tags
             git checkout "${TAG}"
 
-            # Pull updated images and restart the stack
-            docker compose -f infrastructure/docker-compose.yml \
-                           -f infrastructure/docker-compose.prod.yml pull
+            # Build images with version and restart the stack
+            APP_VERSION="${VERSION}" docker compose -f infrastructure/docker-compose.yml \
+                           -f infrastructure/docker-compose.prod.yml build
 
             docker compose -f infrastructure/docker-compose.yml \
                            -f infrastructure/docker-compose.prod.yml up -d --remove-orphans

--- a/alchymine/web/next.config.mjs
+++ b/alchymine/web/next.config.mjs
@@ -1,11 +1,12 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: 'standalone',
+  output: "standalone",
   images: {
     unoptimized: true,
   },
   env: {
-    API_URL: process.env.API_URL || 'http://localhost:8000',
+    API_URL: process.env.API_URL || "http://localhost:8000",
+    NEXT_PUBLIC_APP_VERSION: process.env.APP_VERSION || "dev",
   },
 };
 

--- a/alchymine/web/src/app/layout.tsx
+++ b/alchymine/web/src/app/layout.tsx
@@ -53,6 +53,9 @@ export default function RootLayout({
           <div className="lg:ml-64 pt-14 pb-16 lg:pt-0 lg:pb-0 min-h-screen">
             {children}
           </div>
+          <footer className="lg:ml-64 pb-16 lg:pb-0 text-center py-2 text-xs text-text/30">
+            v{process.env.NEXT_PUBLIC_APP_VERSION}
+          </footer>
         </Providers>
       </body>
     </html>

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -58,6 +58,8 @@ services:
     build:
       context: ..
       dockerfile: infrastructure/docker/Dockerfile.web
+      args:
+        APP_VERSION: ${APP_VERSION:-dev}
     container_name: alchymine-web
     restart: unless-stopped
     ports:

--- a/infrastructure/docker/Dockerfile.web
+++ b/infrastructure/docker/Dockerfile.web
@@ -31,9 +31,13 @@ COPY --from=deps /app/node_modules ./node_modules
 # Copy application source
 COPY alchymine/web/ ./
 
+# Accept version from build args
+ARG APP_VERSION=dev
+
 # Set build-time environment variables
 ENV NEXT_TELEMETRY_DISABLED=1 \
-    NODE_ENV=production
+    NODE_ENV=production \
+    APP_VERSION=${APP_VERSION}
 
 # Build the Next.js application
 RUN npm run build


### PR DESCRIPTION
## Summary

- Add version stamp (`v0.2.0`, etc.) to the website footer for deployment verification
- Version injected at build time via `APP_VERSION` env var through Docker build args
- Release workflow passes the semver tag into the Docker build
- Deploy script changed from `pull` to `build` (droplet builds locally, not from GHCR)
- Shows "dev" for local development builds

## Test plan

- [ ] Merge → draft release auto-created
- [ ] Publish release → deploy runs
- [ ] Check live site footer shows the version number

🤖 Generated with [Claude Code](https://claude.com/claude-code)