### PR TITLE
fix: security hardening phase 2

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -118,7 +118,7 @@ jobs:
           cat changelog.md
 
       - name: Create draft release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.0.8
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.0.8
         with:
           tag_name: v${{ steps.version.outputs.next_version }}
           name: "Alchymine v${{ steps.version.outputs.next_version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,13 +85,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up QEMU (multi-arch)
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3.2.0
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.7.1
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.7.1
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.3.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.3.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -99,7 +99,7 @@ jobs:
 
       - name: Generate Docker metadata
         id: docker-meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5.5.1
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.5.1
         with:
           images: ${{ env.IMAGE_PREFIX }}-${{ matrix.image }}
           tags: |
@@ -110,7 +110,7 @@ jobs:
             type=sha,prefix=,format=short
 
       - name: Build and push ${{ matrix.image }}
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6.9.0
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.9.0
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
@@ -138,7 +138,7 @@ jobs:
       contents: write
     steps:
       - name: Append Docker image info to release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.0.8
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.0.8
         with:
           tag_name: ${{ github.event.release.tag_name }}
           append_body: true
@@ -164,7 +164,7 @@ jobs:
       contents: read
     steps:
       - name: Deploy via SSH
-        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2  # v1.0.3
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.0.3
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}
@@ -195,7 +195,7 @@ jobs:
             echo "Deploy complete. Waiting for health checks..."
 
       - name: Verify deployment health
-        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2  # v1.0.3
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.0.3
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -194,7 +194,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run TruffleHog (filesystem scan)
-        uses: trufflesecurity/trufflehog@041f07e9df901a1038a528e5525b0226d04dd5ea  # main
+        uses: trufflesecurity/trufflehog@041f07e9df901a1038a528e5525b0226d04dd5ea # main
         with:
           extra_args: --results=verified,unverified --json
         continue-on-error: false
@@ -259,10 +259,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.7.1
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.7.1
 
       - name: Build ${{ matrix.image }} image for scanning
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6.9.0
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.9.0
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
@@ -272,7 +272,7 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.image }}
 
       - name: Run Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478  # master (0.29.0)
+        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # master (0.29.0)
         with:
           image-ref: alchymine-${{ matrix.image }}:scan
           format: table
@@ -284,7 +284,7 @@ jobs:
 
       - name: Run Trivy (SARIF output)
         if: always()
-        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478  # master (0.29.0)
+        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # master (0.29.0)
         with:
           image-ref: alchymine-${{ matrix.image }}:scan
           format: sarif

--- a/alchymine/api/auth.py
+++ b/alchymine/api/auth.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 
 import bcrypt
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordBearer
 from jose import JWTError, jwt
 
@@ -33,7 +33,7 @@ REFRESH_TOKEN_EXPIRE_DAYS: int = _settings.refresh_token_expire_days
 
 # ─── Password Hashing ────────────────────────────────────────────────────
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/login")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/login", auto_error=False)
 
 
 def hash_password(password: str) -> str:
@@ -113,8 +113,9 @@ def create_refresh_token(data: dict) -> str:
         The encoded JWT string.
     """
     to_encode = data.copy()
-    expire = datetime.now(UTC) + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
-    to_encode.update({"exp": expire, "type": "refresh"})
+    now = datetime.now(UTC)
+    expire = now + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
+    to_encode.update({"exp": expire, "iat": now, "type": "refresh"})
     return jwt.encode(to_encode, JWT_SECRET_KEY, algorithm=JWT_ALGORITHM)
 
 
@@ -150,13 +151,22 @@ def decode_token(token: str) -> dict:
 # ─── FastAPI Dependencies ─────────────────────────────────────────────────
 
 
-async def get_current_user(token: str = Depends(oauth2_scheme)) -> dict:
-    """FastAPI dependency that extracts the current user from a bearer token.
+async def get_current_user(
+    request: Request,
+    bearer_token: str | None = Depends(oauth2_scheme),
+) -> dict:
+    """FastAPI dependency that extracts the current user from a bearer token or cookie.
+
+    Checks the ``Authorization: Bearer`` header first. If absent, falls back to
+    reading the ``access_token`` httpOnly cookie so cookie-based auth works
+    transparently alongside legacy header-based clients.
 
     Parameters
     ----------
-    token:
-        The JWT bearer token extracted from the Authorization header.
+    request:
+        The incoming HTTP request (used to read cookies).
+    bearer_token:
+        The JWT bearer token extracted from the Authorization header, or None.
 
     Returns
     -------
@@ -166,8 +176,15 @@ async def get_current_user(token: str = Depends(oauth2_scheme)) -> dict:
     Raises
     ------
     HTTPException
-        If the token is missing, expired, or invalid.
+        If no valid token is found in either the header or cookie.
     """
+    token = bearer_token or request.cookies.get("access_token")
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Could not validate credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
     payload = decode_token(token)
     user_id: str | None = payload.get("sub")
     if user_id is None:

--- a/alchymine/api/routers/auth.py
+++ b/alchymine/api/routers/auth.py
@@ -1,8 +1,9 @@
-"""Authentication router — register, login, refresh, password reset, and user info endpoints.
+"""Authentication router — register, login, refresh, logout, password reset, and user info endpoints.
 
 Endpoints:
-- ``POST /auth/register``        — Create a new user and return tokens.
-- ``POST /auth/login``           — Authenticate and return tokens.
+- ``POST /auth/register``        — Create a new user and return tokens (+ set httpOnly cookies).
+- ``POST /auth/login``           — Authenticate and return tokens (+ set httpOnly cookies).
+- ``POST /auth/logout``          — Clear auth cookies.
 - ``POST /auth/refresh``         — Exchange a refresh token for a new access token.
 - ``GET  /auth/me``              — Return current user info (protected).
 - ``POST /auth/forgot-password`` — Request a password reset token.
@@ -17,7 +18,7 @@ import secrets
 from collections.abc import AsyncGenerator
 from datetime import UTC, datetime, timedelta
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from pydantic import BaseModel, EmailStr, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -57,9 +58,13 @@ class LoginRequest(BaseModel):
 
 
 class RefreshRequest(BaseModel):
-    """Request body for token refresh."""
+    """Request body for token refresh.
 
-    refresh_token: str
+    ``refresh_token`` is optional when a ``refresh_token`` httpOnly cookie is
+    present on the request — the endpoint will fall back to reading the cookie.
+    """
+
+    refresh_token: str | None = None
 
 
 class TokenResponse(BaseModel):
@@ -120,12 +125,49 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
         yield session
 
 
+# ─── Cookie helpers ───────────────────────────────────────────────────────
+
+_ACCESS_TOKEN_MAX_AGE = 1800  # 30 minutes
+_REFRESH_TOKEN_MAX_AGE = 7 * 24 * 60 * 60  # 7 days
+
+
+def _set_auth_cookies(response: Response, access_token: str, refresh_token: str) -> None:
+    """Attach httpOnly auth cookies to *response* (in addition to the JSON body)."""
+    settings = get_settings()
+    secure = settings.environment != "development"
+    response.set_cookie(
+        key="access_token",
+        value=access_token,
+        httponly=True,
+        secure=secure,
+        samesite="lax",
+        max_age=_ACCESS_TOKEN_MAX_AGE,
+        path="/",
+    )
+    response.set_cookie(
+        key="refresh_token",
+        value=refresh_token,
+        httponly=True,
+        secure=secure,
+        samesite="lax",
+        max_age=_REFRESH_TOKEN_MAX_AGE,
+        path="/api/v1/auth/refresh",
+    )
+
+
+def _clear_auth_cookies(response: Response) -> None:
+    """Remove auth cookies from the client."""
+    response.delete_cookie(key="access_token", path="/")
+    response.delete_cookie(key="refresh_token", path="/api/v1/auth/refresh")
+
+
 # ─── Endpoints ────────────────────────────────────────────────────────────
 
 
 @router.post("/register", response_model=TokenResponse, status_code=status.HTTP_201_CREATED)
 async def register(
     body: RegisterRequest,
+    response: Response,
     db: AsyncSession = Depends(get_db),
 ) -> TokenResponse:
     """Register a new user.
@@ -167,6 +209,8 @@ async def register(
     access_token = create_access_token(token_data)
     refresh_token = create_refresh_token(token_data)
 
+    _set_auth_cookies(response, access_token, refresh_token)
+
     return TokenResponse(
         access_token=access_token,
         refresh_token=refresh_token,
@@ -176,6 +220,7 @@ async def register(
 @router.post("/login", response_model=TokenResponse)
 async def login(
     body: LoginRequest,
+    response: Response,
     db: AsyncSession = Depends(get_db),
 ) -> TokenResponse:
     """Authenticate a user and return tokens.
@@ -205,25 +250,51 @@ async def login(
     access_token = create_access_token(token_data)
     refresh_token = create_refresh_token(token_data)
 
+    _set_auth_cookies(response, access_token, refresh_token)
+
     return TokenResponse(
         access_token=access_token,
         refresh_token=refresh_token,
     )
 
 
+@router.post("/logout", response_model=MessageResponse)
+async def logout(response: Response) -> MessageResponse:
+    """Clear auth cookies to log the user out.
+
+    This removes the httpOnly access and refresh token cookies from the
+    client.  Callers using header-based auth should also discard their
+    locally stored tokens.
+    """
+    _clear_auth_cookies(response)
+    return MessageResponse(message="Logged out successfully.")
+
+
 @router.post("/refresh", response_model=TokenResponse)
 async def refresh(
+    request: Request,
+    response: Response,
     body: RefreshRequest,
     db: AsyncSession = Depends(get_db),
 ) -> TokenResponse:
     """Exchange a refresh token for a new access token.
 
-    Validates the refresh token, verifies the user still exists,
-    and returns a new access + refresh token pair.
+    Accepts the refresh token from either the JSON body or the ``refresh_token``
+    httpOnly cookie.  Validates the token, verifies the user still exists, checks
+    that the token was issued after the last password change, and returns a new
+    access + refresh token pair (also setting fresh cookies).
 
-    Returns 401 if the refresh token is invalid or the user no longer exists.
+    Returns 401 if the refresh token is invalid, the user no longer exists, or
+    the token predates the most recent password change.
     """
-    payload = decode_token(body.refresh_token)
+    raw_refresh = body.refresh_token or request.cookies.get("refresh_token")
+    if not raw_refresh:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Refresh token is required",
+        )
+
+    payload = decode_token(raw_refresh)
 
     # Ensure it is a refresh token
     if payload.get("type") != "refresh":
@@ -248,10 +319,30 @@ async def refresh(
             detail="User no longer exists",
         )
 
+    # Reject tokens issued before (or at the same second as) the last
+    # password change.  JWT ``iat`` is an integer epoch, so we truncate
+    # ``password_changed_at`` to whole seconds for a fair comparison.
+    # Using ``<=`` means tokens minted in the same calendar second as
+    # the change are also revoked — the user must log in again, which
+    # is the safe default.
+    if user.password_changed_at is not None:
+        token_iat = payload.get("iat")
+        changed_at = user.password_changed_at
+        if changed_at.tzinfo is None:
+            changed_at = changed_at.replace(tzinfo=UTC)
+        changed_at_truncated = changed_at.replace(microsecond=0)
+        if token_iat is None or datetime.fromtimestamp(token_iat, tz=UTC) <= changed_at_truncated:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Token has been revoked — please log in again",
+            )
+
     # Issue new tokens
     token_data = {"sub": user.id, "email": user.email}
     access_token = create_access_token(token_data)
     new_refresh_token = create_refresh_token(token_data)
+
+    _set_auth_cookies(response, access_token, new_refresh_token)
 
     return TokenResponse(
         access_token=access_token,
@@ -369,8 +460,10 @@ async def reset_password(
             detail="Invalid or expired reset token",
         )
 
-    # Update password and clear the token
+    # Update password, record the change timestamp (invalidates existing refresh tokens),
+    # and clear the one-time reset token.
     user.password_hash = hash_password(body.new_password)
+    user.password_changed_at = datetime.now(UTC)
     user.password_reset_token = None
     user.password_reset_expires = None
     await db.commit()

--- a/alchymine/api/routers/journal.py
+++ b/alchymine/api/routers/journal.py
@@ -7,21 +7,17 @@ across all five Alchymine systems.
 
 from __future__ import annotations
 
-import uuid
-from datetime import UTC, datetime
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from alchymine.api.auth import get_current_user
+from alchymine.api.deps import get_db_session
+from alchymine.db import repository
 
 router = APIRouter()
-
-# ── In-memory store (swap for DB later) ─────────────────────────────────
-
-_journal_store: dict[str, dict[str, Any]] = {}
-"""Module-level dict holding journal entries keyed by entry ID."""
 
 
 # ── Request / Response models ───────────────────────────────────────────
@@ -89,6 +85,36 @@ class JournalStatsResponse(BaseModel):
     tags_used: list[str]
 
 
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _entry_to_response(entry: Any) -> JournalEntryResponse:
+    """Convert an ORM JournalEntry to a JournalEntryResponse."""
+    tags = entry.tags if isinstance(entry.tags, list) else []
+    created = (
+        entry.created_at.isoformat()
+        if hasattr(entry.created_at, "isoformat")
+        else str(entry.created_at)
+    )
+    updated = (
+        entry.updated_at.isoformat()
+        if hasattr(entry.updated_at, "isoformat")
+        else str(entry.updated_at)
+    )
+    return JournalEntryResponse(
+        id=entry.id,
+        user_id=entry.user_id,
+        system=entry.system,
+        entry_type=entry.entry_type,
+        title=entry.title,
+        content=entry.content,
+        tags=tags,
+        mood_score=entry.mood_score,
+        created_at=created,
+        updated_at=updated,
+    )
+
+
 # ── Endpoints ───────────────────────────────────────────────────────────
 
 
@@ -96,6 +122,7 @@ class JournalStatsResponse(BaseModel):
 async def create_journal_entry(
     entry: JournalEntryCreate,
     current_user: dict = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db_session),
 ) -> JournalEntryResponse:
     """Create a new journal entry.
 
@@ -104,40 +131,52 @@ async def create_journal_entry(
     """
     if current_user["sub"] != entry.user_id:
         raise HTTPException(status_code=403, detail="Access denied")
-    now = datetime.now(UTC).isoformat()
-    entry_id = str(uuid.uuid4())
 
-    record: dict[str, Any] = {
-        "id": entry_id,
-        "user_id": entry.user_id,
-        "system": entry.system,
-        "entry_type": entry.entry_type,
-        "title": entry.title,
-        "content": entry.content,
-        "tags": entry.tags,
-        "mood_score": entry.mood_score,
-        "created_at": now,
-        "updated_at": now,
-    }
+    db_entry = await repository.create_journal_entry(
+        session,
+        user_id=entry.user_id,
+        title=entry.title,
+        content=entry.content,
+        system=entry.system,
+        entry_type=entry.entry_type,
+        tags=entry.tags,
+        mood_score=entry.mood_score,
+    )
+    return _entry_to_response(db_entry)
 
-    _journal_store[entry_id] = record
 
-    return JournalEntryResponse(**record)
+@router.get("/journal/stats/{user_id}")
+async def get_journal_stats(
+    user_id: str,
+    current_user: dict = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db_session),
+) -> JournalStatsResponse:
+    """Get summary statistics for a user's journal.
+
+    Returns entry counts by system and type, average mood score,
+    and a list of all tags used.
+    """
+    if current_user["sub"] != user_id:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    stats = await repository.get_journal_stats(session, user_id)
+    return JournalStatsResponse(**stats)
 
 
 @router.get("/journal/{entry_id}")
 async def get_journal_entry(
     entry_id: str,
     current_user: dict = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db_session),
 ) -> JournalEntryResponse:
     """Retrieve a single journal entry by ID."""
-    if entry_id not in _journal_store:
+    db_entry = await repository.get_journal_entry(session, entry_id)
+    if db_entry is None:
         raise HTTPException(status_code=404, detail="Journal entry not found")
 
-    entry = _journal_store[entry_id]
-    if current_user["sub"] != entry["user_id"]:
+    if current_user["sub"] != db_entry.user_id:
         raise HTTPException(status_code=403, detail="Access denied")
-    return JournalEntryResponse(**entry)
+    return _entry_to_response(db_entry)
 
 
 @router.put("/journal/{entry_id}")
@@ -145,42 +184,46 @@ async def update_journal_entry(
     entry_id: str,
     update: JournalEntryUpdate,
     current_user: dict = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db_session),
 ) -> JournalEntryResponse:
     """Update an existing journal entry."""
-    if entry_id not in _journal_store:
+    db_entry = await repository.get_journal_entry(session, entry_id)
+    if db_entry is None:
         raise HTTPException(status_code=404, detail="Journal entry not found")
 
-    record = _journal_store[entry_id]
-    if current_user["sub"] != record["user_id"]:
+    if current_user["sub"] != db_entry.user_id:
         raise HTTPException(status_code=403, detail="Access denied")
 
+    changes: dict[str, Any] = {}
     if update.title is not None:
-        record["title"] = update.title
+        changes["title"] = update.title
     if update.content is not None:
-        record["content"] = update.content
+        changes["content"] = update.content
     if update.tags is not None:
-        record["tags"] = update.tags
+        changes["tags"] = update.tags
     if update.mood_score is not None:
-        record["mood_score"] = update.mood_score
+        changes["mood_score"] = update.mood_score
 
-    record["updated_at"] = datetime.now(UTC).isoformat()
-
-    return JournalEntryResponse(**record)
+    updated = await repository.update_journal_entry(session, entry_id, **changes)
+    assert updated is not None
+    return _entry_to_response(updated)
 
 
 @router.delete("/journal/{entry_id}", status_code=204)
 async def delete_journal_entry(
     entry_id: str,
     current_user: dict = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db_session),
 ) -> None:
     """Delete a journal entry."""
-    if entry_id not in _journal_store:
+    db_entry = await repository.get_journal_entry(session, entry_id)
+    if db_entry is None:
         raise HTTPException(status_code=404, detail="Journal entry not found")
 
-    record = _journal_store[entry_id]
-    if current_user["sub"] != record["user_id"]:
+    if current_user["sub"] != db_entry.user_id:
         raise HTTPException(status_code=403, detail="Access denied")
-    del _journal_store[entry_id]
+
+    await repository.delete_journal_entry(session, entry_id)
 
 
 @router.get("/journal")
@@ -191,6 +234,7 @@ async def list_journal_entries(
     page: int = Query(1, ge=1, description="Page number"),
     per_page: int = Query(20, ge=1, le=100, description="Items per page"),
     current_user: dict = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db_session),
 ) -> JournalListResponse:
     """List journal entries for a user with optional filters.
 
@@ -199,97 +243,20 @@ async def list_journal_entries(
     """
     if current_user["sub"] != user_id:
         raise HTTPException(status_code=403, detail="Access denied")
-    # Filter entries belonging to the user
-    user_entries = [e for e in _journal_store.values() if e["user_id"] == user_id]
 
-    # Apply filters
-    if system:
-        user_entries = [e for e in user_entries if e["system"] == system]
-    if entry_type:
-        user_entries = [e for e in user_entries if e["entry_type"] == entry_type]
-
-    # Sort by created_at descending
-    user_entries.sort(key=lambda e: e["created_at"], reverse=True)
-
-    total = len(user_entries)
-
-    # Paginate
-    start = (page - 1) * per_page
-    end = start + per_page
-    page_entries = user_entries[start:end]
+    offset = (page - 1) * per_page
+    entries, total = await repository.list_journal_entries(
+        session,
+        user_id,
+        system=system,
+        entry_type=entry_type,
+        offset=offset,
+        limit=per_page,
+    )
 
     return JournalListResponse(
-        entries=[JournalEntryResponse(**e) for e in page_entries],
+        entries=[_entry_to_response(e) for e in entries],
         total=total,
         page=page,
         per_page=per_page,
-    )
-
-
-@router.get("/journal/stats/{user_id}")
-async def get_journal_stats(
-    user_id: str,
-    current_user: dict = Depends(get_current_user),
-) -> JournalStatsResponse:
-    """Get summary statistics for a user's journal.
-
-    Returns entry counts by system and type, average mood score,
-    and a list of all tags used.
-    """
-    if current_user["sub"] != user_id:
-        raise HTTPException(status_code=403, detail="Access denied")
-    user_entries = [e for e in _journal_store.values() if e["user_id"] == user_id]
-
-    if not user_entries:
-        return JournalStatsResponse(
-            total_entries=0,
-            entries_by_system={},
-            entries_by_type={},
-            average_mood=None,
-            streak_days=0,
-            tags_used=[],
-        )
-
-    # Count by system
-    by_system: dict[str, int] = {}
-    for entry in user_entries:
-        sys = entry["system"]
-        by_system[sys] = by_system.get(sys, 0) + 1
-
-    # Count by type
-    by_type: dict[str, int] = {}
-    for entry in user_entries:
-        et = entry["entry_type"]
-        by_type[et] = by_type.get(et, 0) + 1
-
-    # Average mood
-    moods = [e["mood_score"] for e in user_entries if e.get("mood_score") is not None]
-    avg_mood = sum(moods) / len(moods) if moods else None
-
-    # Collect unique tags
-    all_tags: set[str] = set()
-    for entry in user_entries:
-        all_tags.update(entry.get("tags", []))
-
-    # Calculate streak (consecutive days with entries)
-    dates = sorted({e["created_at"][:10] for e in user_entries}, reverse=True)
-    streak = 0
-    today = datetime.now(UTC).strftime("%Y-%m-%d")
-    if dates and dates[0] == today:
-        streak = 1
-        for i in range(1, len(dates)):
-            prev = datetime.strptime(dates[i - 1], "%Y-%m-%d")  # noqa: DTZ007
-            curr = datetime.strptime(dates[i], "%Y-%m-%d")  # noqa: DTZ007
-            if (prev - curr).days == 1:
-                streak += 1
-            else:
-                break
-
-    return JournalStatsResponse(
-        total_entries=len(user_entries),
-        entries_by_system=by_system,
-        entries_by_type=by_type,
-        average_mood=avg_mood,
-        streak_days=streak,
-        tags_used=sorted(all_tags),
     )

--- a/alchymine/db/models.py
+++ b/alchymine/db/models.py
@@ -86,6 +86,9 @@ class User(Base):
     password_reset_expires: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    password_changed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     # Cross-system fields
     active_plan_day: Mapped[int | None] = mapped_column(Integer, nullable=True)
@@ -269,10 +272,10 @@ class WealthProfile(Base):
     lever_priorities: Mapped[dict | None] = mapped_column(
         JSONColumn, nullable=True, comment="Ordered WealthLever list"
     )
-    # TODO(#36): Encrypt financial_distress_detected — changing Boolean to
-    # EncryptedString is a breaking schema migration with multiple callers
-    # (engine/profile.py WealthLayer, tests). Requires a data migration.
-    financial_distress_detected: Mapped[bool] = mapped_column(Boolean, default=False)
+    # SENSITIVE — encrypted; stored as "true" / "false" strings
+    financial_distress_detected: Mapped[str] = mapped_column(
+        EncryptedString(), default="false", comment="SENSITIVE — encrypted boolean flag"
+    )
     disclaimer_acknowledged: Mapped[bool] = mapped_column(Boolean, default=False)
 
     # Relationship
@@ -404,3 +407,35 @@ class Report(Base):
 
     def __repr__(self) -> str:
         return f"<Report id={self.id!r} status={self.status!r}>"
+
+
+# ─── JournalEntry ──────────────────────────────────────────────────────
+
+
+class JournalEntry(Base):
+    """Journal entry — user reflections, reframes, gratitude, and progress notes.
+
+    Content is encrypted at rest (PII classification).
+    """
+
+    __tablename__ = "journal_entries"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    user_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
+    system: Mapped[str] = mapped_column(String(50), default="general")
+    entry_type: Mapped[str] = mapped_column(String(50), default="reflection")
+    title: Mapped[str] = mapped_column(String(200), nullable=False)
+    content: Mapped[str] = mapped_column(EncryptedString(), nullable=False)
+    tags: Mapped[dict | None] = mapped_column(JSONColumn, nullable=True)
+    mood_score: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), index=True
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    def __repr__(self) -> str:
+        return f"<JournalEntry id={self.id!r} user_id={self.user_id!r}>"

--- a/alchymine/db/repository.py
+++ b/alchymine/db/repository.py
@@ -20,14 +20,23 @@ Functions — Reports
 - ``list_reports_by_user``   — paginated reports for a given user
 - ``update_report_status``   — change status (and optionally error)
 - ``update_report_content``  — set result / html_content on completion
+
+Functions — Journal Entries
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- ``create_journal_entry``   — insert a new JournalEntry row
+- ``get_journal_entry``      — fetch a JournalEntry by id
+- ``list_journal_entries``   — paginated entries for a user with optional filters
+- ``update_journal_entry``   — update fields on an existing entry
+- ``delete_journal_entry``   — hard-delete an entry
+- ``get_journal_stats``      — summary statistics for a user's journal
 """
 
 from __future__ import annotations
 
-from datetime import date, time
+from datetime import UTC, date, datetime, time
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -36,6 +45,7 @@ from alchymine.db.models import (
     HealingProfile,
     IdentityProfile,
     IntakeData,
+    JournalEntry,
     PerspectiveProfile,
     Report,
     User,
@@ -364,3 +374,235 @@ async def update_report_content(
     await session.flush()
     await session.refresh(report)
     return report
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Journal Entry CRUD
+# ═══════════════════════════════════════════════════════════════════════
+
+
+async def create_journal_entry(
+    session: AsyncSession,
+    *,
+    user_id: str,
+    title: str,
+    content: str,
+    system: str = "general",
+    entry_type: str = "reflection",
+    tags: list[str] | None = None,
+    mood_score: int | None = None,
+) -> JournalEntry:
+    """Insert a new journal entry row.
+
+    Parameters
+    ----------
+    session:
+        Active async session.
+    user_id:
+        The owner of the entry.
+    title:
+        Entry title (max 200 chars).
+    content:
+        Entry body text — encrypted at rest.
+    system:
+        System this entry relates to (default ``"general"``).
+    entry_type:
+        Entry type (default ``"reflection"``).
+    tags:
+        Optional list of tag strings; stored as a JSON list.
+    mood_score:
+        Optional mood rating (1-10).
+
+    Returns
+    -------
+    JournalEntry
+        The newly created row.
+    """
+    entry = JournalEntry(
+        user_id=user_id,
+        title=title,
+        content=content,
+        system=system,
+        entry_type=entry_type,
+        tags=tags or [],
+        mood_score=mood_score,
+    )
+    session.add(entry)
+    await session.flush()
+    await session.refresh(entry)
+    return entry
+
+
+async def get_journal_entry(session: AsyncSession, entry_id: str) -> JournalEntry | None:
+    """Fetch a single journal entry by id.
+
+    Returns ``None`` if the entry does not exist.
+    """
+    result = await session.execute(select(JournalEntry).where(JournalEntry.id == entry_id))
+    return result.scalar_one_or_none()
+
+
+async def list_journal_entries(
+    session: AsyncSession,
+    user_id: str,
+    *,
+    system: str | None = None,
+    entry_type: str | None = None,
+    offset: int = 0,
+    limit: int = 20,
+) -> tuple[list[JournalEntry], int]:
+    """Return a paginated list of journal entries for *user_id*.
+
+    Entries are returned in reverse chronological order (most recent first).
+
+    Parameters
+    ----------
+    session:
+        Active async session.
+    user_id:
+        The user whose entries to list.
+    system:
+        Optional filter by system name.
+    entry_type:
+        Optional filter by entry type.
+    offset:
+        Number of rows to skip.
+    limit:
+        Maximum number of rows to return.
+
+    Returns
+    -------
+    tuple[list[JournalEntry], int]
+        ``(entries, total_count)`` where *total_count* is the unfiltered
+        count matching the query (before pagination).
+    """
+    base_filter = [JournalEntry.user_id == user_id]
+    if system is not None:
+        base_filter.append(JournalEntry.system == system)
+    if entry_type is not None:
+        base_filter.append(JournalEntry.entry_type == entry_type)
+
+    count_result = await session.execute(
+        select(func.count()).select_from(JournalEntry).where(*base_filter)
+    )
+    total = count_result.scalar_one()
+
+    rows_result = await session.execute(
+        select(JournalEntry)
+        .where(*base_filter)
+        .order_by(JournalEntry.created_at.desc())
+        .offset(offset)
+        .limit(limit)
+    )
+    entries = list(rows_result.scalars().all())
+    return entries, total
+
+
+async def update_journal_entry(
+    session: AsyncSession,
+    entry_id: str,
+    **kwargs: Any,
+) -> JournalEntry | None:
+    """Update fields on an existing journal entry.
+
+    Only the fields present in *kwargs* are updated.  Unknown keys are
+    silently ignored.  Returns the updated entry, or ``None`` if not found.
+    """
+    entry = await get_journal_entry(session, entry_id)
+    if entry is None:
+        return None
+
+    allowed = {"title", "content", "tags", "mood_score", "system", "entry_type"}
+    for key, value in kwargs.items():
+        if key in allowed:
+            setattr(entry, key, value)
+
+    await session.flush()
+    await session.refresh(entry)
+    return entry
+
+
+async def delete_journal_entry(session: AsyncSession, entry_id: str) -> bool:
+    """Delete a journal entry by id.
+
+    Returns ``True`` if the entry was deleted, ``False`` if not found.
+    """
+    entry = await get_journal_entry(session, entry_id)
+    if entry is None:
+        return False
+    await session.delete(entry)
+    await session.flush()
+    return True
+
+
+async def get_journal_stats(session: AsyncSession, user_id: str) -> dict[str, Any]:
+    """Return summary statistics for a user's journal.
+
+    Returns a dict with:
+    - ``total_entries`` — total entry count
+    - ``entries_by_system`` — count per system name
+    - ``entries_by_type`` — count per entry type
+    - ``average_mood`` — mean mood_score (or ``None`` if no scored entries)
+    - ``tags_used`` — sorted list of unique tags
+    - ``streak_days`` — consecutive days with at least one entry ending today
+    """
+    entries_result = await session.execute(
+        select(JournalEntry).where(JournalEntry.user_id == user_id)
+    )
+    entries = list(entries_result.scalars().all())
+
+    if not entries:
+        return {
+            "total_entries": 0,
+            "entries_by_system": {},
+            "entries_by_type": {},
+            "average_mood": None,
+            "streak_days": 0,
+            "tags_used": [],
+        }
+
+    by_system: dict[str, int] = {}
+    by_type: dict[str, int] = {}
+    all_tags: set[str] = set()
+    moods: list[int] = []
+
+    for entry in entries:
+        by_system[entry.system] = by_system.get(entry.system, 0) + 1
+        by_type[entry.entry_type] = by_type.get(entry.entry_type, 0) + 1
+        if entry.mood_score is not None:
+            moods.append(entry.mood_score)
+        if entry.tags:
+            all_tags.update(entry.tags if isinstance(entry.tags, list) else [])
+
+    avg_mood = sum(moods) / len(moods) if moods else None
+
+    # Streak: consecutive days with entries ending today
+    dates = sorted(
+        {
+            e.created_at.strftime("%Y-%m-%d")
+            if hasattr(e.created_at, "strftime")
+            else str(e.created_at)[:10]
+            for e in entries
+        },
+        reverse=True,
+    )
+    today = datetime.now(UTC).strftime("%Y-%m-%d")
+    streak = 0
+    if dates and dates[0] == today:
+        streak = 1
+        for i in range(1, len(dates)):
+            prev = datetime.strptime(dates[i - 1], "%Y-%m-%d")  # noqa: DTZ007
+            curr = datetime.strptime(dates[i], "%Y-%m-%d")  # noqa: DTZ007
+            if (prev - curr).days == 1:
+                streak += 1
+            else:
+                break
+
+    return {
+        "total_entries": len(entries),
+        "entries_by_system": by_system,
+        "entries_by_type": by_type,
+        "average_mood": avg_mood,
+        "streak_days": streak,
+        "tags_used": sorted(all_tags),
+    }

--- a/alchymine/engine/profile.py
+++ b/alchymine/engine/profile.py
@@ -18,7 +18,7 @@ from datetime import date, datetime, time
 from enum import StrEnum
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 # ─── Enums ──────────────────────────────────────────────────────────────
 
@@ -239,6 +239,20 @@ class WealthLayer(BaseModel):
     )
     financial_distress_detected: bool = Field(False)
     disclaimer_acknowledged: bool = Field(False)
+
+    @field_validator("financial_distress_detected", mode="before")
+    @classmethod
+    def _coerce_distress_flag(cls, v: object) -> bool:
+        """Accept encrypted-string values ("true"/"false") from the ORM layer.
+
+        The WealthProfile ORM model stores this flag as an EncryptedString
+        to protect sensitive financial information.  When the value is
+        deserialized from the database it arrives as a plain string;
+        this validator normalises it back to a Python bool.
+        """
+        if isinstance(v, str):
+            return v.lower() == "true"
+        return bool(v)
 
 
 # ─── Layer 4: Creative (v7) ─────────────────────────────────────────────

--- a/alchymine/web/next.config.mjs
+++ b/alchymine/web/next.config.mjs
@@ -15,7 +15,10 @@ const nextConfig = {
           { key: "X-Content-Type-Options", value: "nosniff" },
           { key: "X-Frame-Options", value: "DENY" },
           { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
-          { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=()",
+          },
         ],
       },
     ];

--- a/alchymine/web/public/sw.js
+++ b/alchymine/web/public/sw.js
@@ -46,7 +46,10 @@ self.addEventListener("fetch", (event) => {
           const clone = response.clone();
           caches.open(CACHE_NAME).then((cache) => {
             // Only cache unauthenticated GET responses
-            if (event.request.method === "GET" && !event.request.headers.get("Authorization")) {
+            if (
+              event.request.method === "GET" &&
+              !event.request.headers.get("Authorization")
+            ) {
               cache.put(event.request, clone);
             }
           });

--- a/alchymine/web/src/app/dashboard/page.tsx
+++ b/alchymine/web/src/app/dashboard/page.tsx
@@ -177,276 +177,282 @@ export default function DashboardPage() {
           </div>
         </div>
       ) : (
-      <div className="flex-1 px-6 py-12">
-        <div className="max-w-4xl mx-auto">
-          {/* Header */}
-          <div className="text-center mb-10">
-            <p className="text-sm uppercase tracking-[0.2em] text-primary mb-3">
-              Dashboard
-            </p>
-            <h1 className="text-3xl sm:text-4xl font-bold mb-2">
-              <span className="text-gradient-gold">Progress Tracker</span>
-            </h1>
-            <p className="text-text/50">
-              Your journey across all five Alchymine systems
-            </p>
-          </div>
+        <div className="flex-1 px-6 py-12">
+          <div className="max-w-4xl mx-auto">
+            {/* Header */}
+            <div className="text-center mb-10">
+              <p className="text-sm uppercase tracking-[0.2em] text-primary mb-3">
+                Dashboard
+              </p>
+              <h1 className="text-3xl sm:text-4xl font-bold mb-2">
+                <span className="text-gradient-gold">Progress Tracker</span>
+              </h1>
+              <p className="text-text/50">
+                Your journey across all five Alchymine systems
+              </p>
+            </div>
 
-          {/* Tab navigation */}
-          <div className="flex items-center justify-center gap-4 mb-8">
-            <button
-              onClick={() => setActiveTab("overview")}
-              className={`px-4 py-2 rounded-lg text-sm font-medium transition ${
-                activeTab === "overview"
-                  ? "bg-primary/20 text-primary border border-primary/30"
-                  : "text-text/50 hover:text-text/70"
-              }`}
-            >
-              Overview
-            </button>
-            <button
-              onClick={() => setActiveTab("journal")}
-              className={`px-4 py-2 rounded-lg text-sm font-medium transition ${
-                activeTab === "journal"
-                  ? "bg-primary/20 text-primary border border-primary/30"
-                  : "text-text/50 hover:text-text/70"
-              }`}
-            >
-              Journal Stats
-            </button>
-          </div>
+            {/* Tab navigation */}
+            <div className="flex items-center justify-center gap-4 mb-8">
+              <button
+                onClick={() => setActiveTab("overview")}
+                className={`px-4 py-2 rounded-lg text-sm font-medium transition ${
+                  activeTab === "overview"
+                    ? "bg-primary/20 text-primary border border-primary/30"
+                    : "text-text/50 hover:text-text/70"
+                }`}
+              >
+                Overview
+              </button>
+              <button
+                onClick={() => setActiveTab("journal")}
+                className={`px-4 py-2 rounded-lg text-sm font-medium transition ${
+                  activeTab === "journal"
+                    ? "bg-primary/20 text-primary border border-primary/30"
+                    : "text-text/50 hover:text-text/70"
+                }`}
+              >
+                Journal Stats
+              </button>
+            </div>
 
-          {activeTab === "overview" && (
-            <div className="space-y-6">
-              {/* Overall Score */}
-              <Card title="Overall Progress">
-                {outcomes.loading ? (
-                  <div className="flex justify-center py-6">
-                    <div className="w-8 h-8 rounded-full border-2 border-primary border-t-transparent animate-spin" />
-                  </div>
-                ) : outcomes.error ? (
-                  <div className="text-center py-8">
-                    <p className="text-text/50 mb-2">
-                      No outcome data yet — start using the systems!
-                    </p>
-                    <p className="text-xs text-text/30">
-                      Your progress will appear here as you complete milestones
-                      and engage with the platform.
-                    </p>
-                  </div>
-                ) : outcomes.data ? (
-                  <div>
-                    <div className="flex items-center justify-center mb-6">
-                      <ProgressRing
-                        value={outcomes.data.overall_score}
-                        label="Overall Score"
-                        size={100}
-                      />
+            {activeTab === "overview" && (
+              <div className="space-y-6">
+                {/* Overall Score */}
+                <Card title="Overall Progress">
+                  {outcomes.loading ? (
+                    <div className="flex justify-center py-6">
+                      <div className="w-8 h-8 rounded-full border-2 border-primary border-t-transparent animate-spin" />
                     </div>
-                    <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 text-center">
-                      <div>
-                        <div className="text-2xl font-bold text-primary">
-                          {outcomes.data.completed_milestones}
-                        </div>
-                        <div className="text-xs text-text/50">
-                          Milestones Complete
-                        </div>
+                  ) : outcomes.error ? (
+                    <div className="text-center py-8">
+                      <p className="text-text/50 mb-2">
+                        No outcome data yet — start using the systems!
+                      </p>
+                      <p className="text-xs text-text/30">
+                        Your progress will appear here as you complete
+                        milestones and engage with the platform.
+                      </p>
+                    </div>
+                  ) : outcomes.data ? (
+                    <div>
+                      <div className="flex items-center justify-center mb-6">
+                        <ProgressRing
+                          value={outcomes.data.overall_score}
+                          label="Overall Score"
+                          size={100}
+                        />
                       </div>
-                      <div>
-                        <div className="text-2xl font-bold text-primary">
-                          {outcomes.data.total_milestones}
+                      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 text-center">
+                        <div>
+                          <div className="text-2xl font-bold text-primary">
+                            {outcomes.data.completed_milestones}
+                          </div>
+                          <div className="text-xs text-text/50">
+                            Milestones Complete
+                          </div>
                         </div>
-                        <div className="text-xs text-text/50">
-                          Total Milestones
+                        <div>
+                          <div className="text-2xl font-bold text-primary">
+                            {outcomes.data.total_milestones}
+                          </div>
+                          <div className="text-xs text-text/50">
+                            Total Milestones
+                          </div>
                         </div>
-                      </div>
-                      <div>
-                        <div className="text-2xl font-bold text-primary">
-                          {outcomes.data.systems.length}
+                        <div>
+                          <div className="text-2xl font-bold text-primary">
+                            {outcomes.data.systems.length}
+                          </div>
+                          <div className="text-xs text-text/50">
+                            Systems Active
+                          </div>
                         </div>
-                        <div className="text-xs text-text/50">
-                          Systems Active
+                        <div>
+                          <div className="text-2xl font-bold text-primary">
+                            {outcomes.data.active_plan_day ?? "—"}
+                          </div>
+                          <div className="text-xs text-text/50">Plan Day</div>
                         </div>
-                      </div>
-                      <div>
-                        <div className="text-2xl font-bold text-primary">
-                          {outcomes.data.active_plan_day ?? "—"}
-                        </div>
-                        <div className="text-xs text-text/50">Plan Day</div>
                       </div>
                     </div>
-                  </div>
-                ) : null}
-              </Card>
+                  ) : null}
+                </Card>
 
-              {/* Per-system progress */}
-              {outcomes.data && outcomes.data.systems.length > 0 && (
-                <Card
-                  title="System Progress"
-                  subtitle="Engagement and milestones per system"
-                >
-                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                    {outcomes.data.systems.map((sys) => (
-                      <SystemCard
-                        key={sys.system}
-                        system={sys.system}
-                        engagement={sys.engagement_score}
-                        milestonesCompleted={sys.milestones_completed}
-                        milestonesTotal={sys.milestones_total}
-                        activeDays={sys.active_days}
-                      />
-                    ))}
+                {/* Per-system progress */}
+                {outcomes.data && outcomes.data.systems.length > 0 && (
+                  <Card
+                    title="System Progress"
+                    subtitle="Engagement and milestones per system"
+                  >
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                      {outcomes.data.systems.map((sys) => (
+                        <SystemCard
+                          key={sys.system}
+                          system={sys.system}
+                          engagement={sys.engagement_score}
+                          milestonesCompleted={sys.milestones_completed}
+                          milestonesTotal={sys.milestones_total}
+                          activeDays={sys.active_days}
+                        />
+                      ))}
+                    </div>
+                  </Card>
+                )}
+
+                {/* Quick actions */}
+                <Card title="Quick Actions">
+                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                    <Link href="/healing">
+                      <div className="bg-green-500/10 border border-green-500/20 rounded-xl p-4 text-center hover:bg-green-500/15 transition cursor-pointer">
+                        <div className="text-green-400 font-medium">
+                          Healing
+                        </div>
+                        <div className="text-xs text-text/40 mt-1">
+                          Start a practice session
+                        </div>
+                      </div>
+                    </Link>
+                    <Link href="/wealth">
+                      <div className="bg-yellow-500/10 border border-yellow-500/20 rounded-xl p-4 text-center hover:bg-yellow-500/15 transition cursor-pointer">
+                        <div className="text-yellow-400 font-medium">
+                          Wealth
+                        </div>
+                        <div className="text-xs text-text/40 mt-1">
+                          Review your plan
+                        </div>
+                      </div>
+                    </Link>
+                    <Link href="/creative">
+                      <div className="bg-purple-500/10 border border-purple-500/20 rounded-xl p-4 text-center hover:bg-purple-500/15 transition cursor-pointer">
+                        <div className="text-purple-400 font-medium">
+                          Creative
+                        </div>
+                        <div className="text-xs text-text/40 mt-1">
+                          Explore your style
+                        </div>
+                      </div>
+                    </Link>
                   </div>
                 </Card>
-              )}
+              </div>
+            )}
 
-              {/* Quick actions */}
-              <Card title="Quick Actions">
-                <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-                  <Link href="/healing">
-                    <div className="bg-green-500/10 border border-green-500/20 rounded-xl p-4 text-center hover:bg-green-500/15 transition cursor-pointer">
-                      <div className="text-green-400 font-medium">Healing</div>
-                      <div className="text-xs text-text/40 mt-1">
-                        Start a practice session
-                      </div>
+            {activeTab === "journal" && (
+              <div className="space-y-6">
+                <Card title="Journal Overview">
+                  {journalStats.loading ? (
+                    <div className="flex justify-center py-6">
+                      <div className="w-8 h-8 rounded-full border-2 border-primary border-t-transparent animate-spin" />
                     </div>
-                  </Link>
-                  <Link href="/wealth">
-                    <div className="bg-yellow-500/10 border border-yellow-500/20 rounded-xl p-4 text-center hover:bg-yellow-500/15 transition cursor-pointer">
-                      <div className="text-yellow-400 font-medium">Wealth</div>
-                      <div className="text-xs text-text/40 mt-1">
-                        Review your plan
-                      </div>
+                  ) : journalStats.error ? (
+                    <div className="text-center py-8">
+                      <p className="text-text/50 mb-2">
+                        No journal entries yet — start writing!
+                      </p>
+                      <p className="text-xs text-text/30">
+                        Journal entries help track your reflections, reframes,
+                        and progress across all systems.
+                      </p>
                     </div>
-                  </Link>
-                  <Link href="/creative">
-                    <div className="bg-purple-500/10 border border-purple-500/20 rounded-xl p-4 text-center hover:bg-purple-500/15 transition cursor-pointer">
-                      <div className="text-purple-400 font-medium">
-                        Creative
+                  ) : journalStats.data ? (
+                    <div>
+                      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 text-center mb-6">
+                        <div>
+                          <div className="text-2xl font-bold text-primary">
+                            {journalStats.data.total_entries}
+                          </div>
+                          <div className="text-xs text-text/50">
+                            Total Entries
+                          </div>
+                        </div>
+                        <div>
+                          <div className="text-2xl font-bold text-primary">
+                            {journalStats.data.streak_days}
+                          </div>
+                          <div className="text-xs text-text/50">Day Streak</div>
+                        </div>
+                        <div>
+                          <div className="text-2xl font-bold text-primary">
+                            {journalStats.data.average_mood
+                              ? journalStats.data.average_mood.toFixed(1)
+                              : "—"}
+                          </div>
+                          <div className="text-xs text-text/50">Avg Mood</div>
+                        </div>
+                        <div>
+                          <div className="text-2xl font-bold text-primary">
+                            {journalStats.data.tags_used.length}
+                          </div>
+                          <div className="text-xs text-text/50">Tags Used</div>
+                        </div>
                       </div>
-                      <div className="text-xs text-text/40 mt-1">
-                        Explore your style
-                      </div>
+
+                      {/* Entries by system */}
+                      {Object.keys(journalStats.data.entries_by_system).length >
+                        0 && (
+                        <div className="mb-4">
+                          <h4 className="text-sm text-text/50 mb-2">
+                            By System
+                          </h4>
+                          <div className="flex flex-wrap gap-2">
+                            {Object.entries(
+                              journalStats.data.entries_by_system,
+                            ).map(([sys, count]) => (
+                              <span
+                                key={sys}
+                                className="px-3 py-1 bg-primary/10 border border-primary/20 rounded-full text-xs text-primary"
+                              >
+                                {sys}: {count}
+                              </span>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+
+                      {/* Entries by type */}
+                      {Object.keys(journalStats.data.entries_by_type).length >
+                        0 && (
+                        <div className="mb-4">
+                          <h4 className="text-sm text-text/50 mb-2">By Type</h4>
+                          <div className="flex flex-wrap gap-2">
+                            {Object.entries(
+                              journalStats.data.entries_by_type,
+                            ).map(([type, count]) => (
+                              <span
+                                key={type}
+                                className="px-3 py-1 bg-secondary/10 border border-secondary/20 rounded-full text-xs text-secondary"
+                              >
+                                {type}: {count}
+                              </span>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+
+                      {/* Tags */}
+                      {journalStats.data.tags_used.length > 0 && (
+                        <div>
+                          <h4 className="text-sm text-text/50 mb-2">Tags</h4>
+                          <div className="flex flex-wrap gap-2">
+                            {journalStats.data.tags_used.map((tag) => (
+                              <span
+                                key={tag}
+                                className="px-3 py-1 bg-white/5 border border-white/10 rounded-full text-xs text-text/60"
+                              >
+                                {tag}
+                              </span>
+                            ))}
+                          </div>
+                        </div>
+                      )}
                     </div>
-                  </Link>
-                </div>
-              </Card>
-            </div>
-          )}
-
-          {activeTab === "journal" && (
-            <div className="space-y-6">
-              <Card title="Journal Overview">
-                {journalStats.loading ? (
-                  <div className="flex justify-center py-6">
-                    <div className="w-8 h-8 rounded-full border-2 border-primary border-t-transparent animate-spin" />
-                  </div>
-                ) : journalStats.error ? (
-                  <div className="text-center py-8">
-                    <p className="text-text/50 mb-2">
-                      No journal entries yet — start writing!
-                    </p>
-                    <p className="text-xs text-text/30">
-                      Journal entries help track your reflections, reframes, and
-                      progress across all systems.
-                    </p>
-                  </div>
-                ) : journalStats.data ? (
-                  <div>
-                    <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 text-center mb-6">
-                      <div>
-                        <div className="text-2xl font-bold text-primary">
-                          {journalStats.data.total_entries}
-                        </div>
-                        <div className="text-xs text-text/50">
-                          Total Entries
-                        </div>
-                      </div>
-                      <div>
-                        <div className="text-2xl font-bold text-primary">
-                          {journalStats.data.streak_days}
-                        </div>
-                        <div className="text-xs text-text/50">Day Streak</div>
-                      </div>
-                      <div>
-                        <div className="text-2xl font-bold text-primary">
-                          {journalStats.data.average_mood
-                            ? journalStats.data.average_mood.toFixed(1)
-                            : "—"}
-                        </div>
-                        <div className="text-xs text-text/50">Avg Mood</div>
-                      </div>
-                      <div>
-                        <div className="text-2xl font-bold text-primary">
-                          {journalStats.data.tags_used.length}
-                        </div>
-                        <div className="text-xs text-text/50">Tags Used</div>
-                      </div>
-                    </div>
-
-                    {/* Entries by system */}
-                    {Object.keys(journalStats.data.entries_by_system).length >
-                      0 && (
-                      <div className="mb-4">
-                        <h4 className="text-sm text-text/50 mb-2">By System</h4>
-                        <div className="flex flex-wrap gap-2">
-                          {Object.entries(
-                            journalStats.data.entries_by_system,
-                          ).map(([sys, count]) => (
-                            <span
-                              key={sys}
-                              className="px-3 py-1 bg-primary/10 border border-primary/20 rounded-full text-xs text-primary"
-                            >
-                              {sys}: {count}
-                            </span>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-
-                    {/* Entries by type */}
-                    {Object.keys(journalStats.data.entries_by_type).length >
-                      0 && (
-                      <div className="mb-4">
-                        <h4 className="text-sm text-text/50 mb-2">By Type</h4>
-                        <div className="flex flex-wrap gap-2">
-                          {Object.entries(
-                            journalStats.data.entries_by_type,
-                          ).map(([type, count]) => (
-                            <span
-                              key={type}
-                              className="px-3 py-1 bg-secondary/10 border border-secondary/20 rounded-full text-xs text-secondary"
-                            >
-                              {type}: {count}
-                            </span>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-
-                    {/* Tags */}
-                    {journalStats.data.tags_used.length > 0 && (
-                      <div>
-                        <h4 className="text-sm text-text/50 mb-2">Tags</h4>
-                        <div className="flex flex-wrap gap-2">
-                          {journalStats.data.tags_used.map((tag) => (
-                            <span
-                              key={tag}
-                              className="px-3 py-1 bg-white/5 border border-white/10 rounded-full text-xs text-text/60"
-                            >
-                              {tag}
-                            </span>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                ) : null}
-              </Card>
-            </div>
-          )}
+                  ) : null}
+                </Card>
+              </div>
+            )}
+          </div>
         </div>
-      </div>
       )}
     </ProtectedRoute>
   );

--- a/alchymine/web/src/app/discover/report/[id]/page.tsx
+++ b/alchymine/web/src/app/discover/report/[id]/page.tsx
@@ -467,7 +467,8 @@ export default function ReportPage() {
               being configured.
             </p>
             <p className="text-text/50 text-sm mb-6">
-              Your report is being processed. Some sections may still be generating.
+              Your report is being processed. Some sections may still be
+              generating.
             </p>
           </div>
         )}

--- a/alchymine/web/src/lib/AuthContext.tsx
+++ b/alchymine/web/src/lib/AuthContext.tsx
@@ -9,7 +9,13 @@ import {
   useState,
 } from "react";
 import type { ReactNode } from "react";
-import { loginUser, registerUser, getMe, ApiError } from "@/lib/api";
+import {
+  loginUser,
+  logoutUser,
+  registerUser,
+  getMe,
+  ApiError,
+} from "@/lib/api";
 import type { AuthUser } from "@/lib/api";
 
 interface AuthContextValue {
@@ -21,7 +27,7 @@ interface AuthContextValue {
     password: string,
     promoCode: string,
   ) => Promise<void>;
-  logout: () => void;
+  logout: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null);
@@ -30,16 +36,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<AuthUser | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
-  // Check for existing session on mount
+  // Check for existing session on mount.  Auth is now cookie-based so we
+  // always try /me — the httpOnly access_token cookie is sent automatically.
+  // Legacy localStorage tokens are left in place for the migration fallback
+  // path in api.ts and will be cleaned up on next explicit login/logout.
   useEffect(() => {
-    const token = localStorage.getItem("access_token");
-    if (!token) {
-      setIsLoading(false);
-      return;
-    }
     getMe()
       .then(setUser)
       .catch(() => {
+        // No valid session — clean up any residual localStorage tokens
         localStorage.removeItem("access_token");
         localStorage.removeItem("refresh_token");
       })
@@ -47,6 +52,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const login = useCallback(async (email: string, password: string) => {
+    // Tokens are returned in the JSON body for the migration fallback path
+    // and also set as httpOnly cookies by the server automatically.
     const tokens = await loginUser(email, password);
     localStorage.setItem("access_token", tokens.access_token);
     localStorage.setItem("refresh_token", tokens.refresh_token);
@@ -65,7 +72,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     [],
   );
 
-  const logout = useCallback(() => {
+  const logout = useCallback(async () => {
+    // Ask the server to clear the httpOnly cookies, then clean up local state.
+    try {
+      await logoutUser();
+    } catch {
+      // Best-effort — proceed with local cleanup even if the API call fails
+    }
     localStorage.removeItem("access_token");
     localStorage.removeItem("refresh_token");
     setUser(null);

--- a/alchymine/web/src/lib/api.ts
+++ b/alchymine/web/src/lib/api.ts
@@ -2,7 +2,8 @@
  * Alchymine API client — typed fetch wrappers for the FastAPI backend.
  */
 
-const BASE = (process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000") + "/api/v1";
+const BASE =
+  (process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000") + "/api/v1";
 
 // ─── Shared types ────────────────────────────────────────────────────
 
@@ -277,7 +278,10 @@ class ApiError extends Error {
   }
 }
 
-function getAuthHeaders(): Record<string, string> {
+// Provide the Authorization header as a migration fallback when a token is
+// still present in localStorage.  New sessions rely on httpOnly cookies sent
+// automatically via credentials: "include".
+function getLegacyAuthHeaders(): Record<string, string> {
   if (typeof window === "undefined") return {};
   const token = localStorage.getItem("access_token");
   return token ? { Authorization: `Bearer ${token}` } : {};
@@ -286,9 +290,10 @@ function getAuthHeaders(): Record<string, string> {
 async function request<T>(url: string, options?: RequestInit): Promise<T> {
   const res = await fetch(url, {
     ...options,
+    credentials: "include",
     headers: {
       "Content-Type": "application/json",
-      ...getAuthHeaders(),
+      ...getLegacyAuthHeaders(),
       ...options?.headers,
     },
   });
@@ -299,38 +304,44 @@ async function request<T>(url: string, options?: RequestInit): Promise<T> {
     throw new ApiError(202, body.detail || "Still processing");
   }
 
-  // Attempt token refresh on 401
+  // Attempt token refresh on 401.  The refresh request uses credentials: "include"
+  // so the httpOnly refresh_token cookie is sent automatically.  As a migration
+  // fallback we also pass the stored refresh token in the JSON body.
   if (res.status === 401 && typeof window !== "undefined") {
-    const refreshToken = localStorage.getItem("refresh_token");
-    if (refreshToken) {
-      try {
-        const refreshRes = await fetch(`${BASE}/auth/refresh`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ refresh_token: refreshToken }),
+    const legacyRefreshToken = localStorage.getItem("refresh_token");
+    try {
+      const refreshRes = await fetch(`${BASE}/auth/refresh`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          refresh_token: legacyRefreshToken ?? undefined,
+        }),
+      });
+      if (refreshRes.ok) {
+        const tokens = await refreshRes.json();
+        // Persist to localStorage for the header-based fallback path so that
+        // the migration window works correctly; cookies are set by the server.
+        localStorage.setItem("access_token", tokens.access_token);
+        localStorage.setItem("refresh_token", tokens.refresh_token);
+        // Retry the original request
+        const retryRes = await fetch(url, {
+          ...options,
+          credentials: "include",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${tokens.access_token}`,
+            ...options?.headers,
+          },
         });
-        if (refreshRes.ok) {
-          const tokens = await refreshRes.json();
-          localStorage.setItem("access_token", tokens.access_token);
-          localStorage.setItem("refresh_token", tokens.refresh_token);
-          // Retry the original request with new token
-          const retryRes = await fetch(url, {
-            ...options,
-            headers: {
-              "Content-Type": "application/json",
-              Authorization: `Bearer ${tokens.access_token}`,
-              ...options?.headers,
-            },
-          });
-          if (retryRes.ok) return retryRes.json();
-        }
-        // Refresh failed — clear tokens
-        localStorage.removeItem("access_token");
-        localStorage.removeItem("refresh_token");
-      } catch {
-        localStorage.removeItem("access_token");
-        localStorage.removeItem("refresh_token");
+        if (retryRes.ok) return retryRes.json();
       }
+      // Refresh failed — clear legacy localStorage tokens
+      localStorage.removeItem("access_token");
+      localStorage.removeItem("refresh_token");
+    } catch {
+      localStorage.removeItem("access_token");
+      localStorage.removeItem("refresh_token");
     }
   }
 
@@ -645,6 +656,12 @@ export async function loginUser(
 
 export async function getMe(): Promise<AuthUser> {
   return request<AuthUser>(`${BASE}/auth/me`);
+}
+
+export async function logoutUser(): Promise<{ message: string }> {
+  return request<{ message: string }>(`${BASE}/auth/logout`, {
+    method: "POST",
+  });
 }
 
 export async function forgotPassword(

--- a/infrastructure/docker-compose.prod.yml
+++ b/infrastructure/docker-compose.prod.yml
@@ -205,9 +205,25 @@ services:
         max-size: "10m"
         max-file: "3"
 
-  # NOTE: PDF service production overrides will be added here once the pdf
-  # service is defined in the base docker-compose.yml. Dockerfile exists at
-  # infrastructure/docker/Dockerfile.pdf and is ready to be wired up.
+  # ─── PDF Service — production settings ──────────────────────────────────
+  pdf-service:
+    restart: always
+    env_file:
+      - path: ../.env.production
+        required: true
+    deploy:
+      resources:
+        limits:
+          memory: 1g
+          cpus: "1.0"
+        reservations:
+          memory: 512m
+          cpus: "0.5"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   # ─── PostgreSQL — production settings ────────────────────────────────
   db:

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -26,6 +26,8 @@ services:
       - LOG_LEVEL=${LOG_LEVEL:-WARNING}
       - API_SECRET_KEY=${API_SECRET_KEY:?API_SECRET_KEY must be set}
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-["http://localhost:3000"]}
+      - PDF_SERVICE_TOKEN=${PDF_SERVICE_TOKEN:?PDF_SERVICE_TOKEN must be set}
+      - PDF_SERVICE_URL=http://pdf-service:3001
     depends_on:
       db:
         condition: service_healthy
@@ -52,6 +54,7 @@ services:
         max-file: "3"
     networks:
       - alchymine-net
+      - pdf-net
 
   # ─── Web (Next.js Frontend) ──────────────────────────────────────────────
   web:
@@ -183,6 +186,8 @@ services:
       - CELERY_RESULT_BACKEND=redis://:${REDIS_PASSWORD}@redis:6379/1
       - ENVIRONMENT=${ENVIRONMENT:-production}
       - LOG_LEVEL=${LOG_LEVEL:-WARNING}
+      - PDF_SERVICE_TOKEN=${PDF_SERVICE_TOKEN:?PDF_SERVICE_TOKEN must be set}
+      - PDF_SERVICE_URL=http://pdf-service:3001
     depends_on:
       db:
         condition: service_healthy
@@ -219,12 +224,61 @@ services:
         max-file: "3"
     networks:
       - alchymine-net
+      - pdf-net
+
+  # ─── PDF Service (Puppeteer) ──────────────────────────────────────────────
+  pdf-service:
+    build:
+      context: ..
+      dockerfile: infrastructure/docker/Dockerfile.pdf
+    container_name: alchymine-pdf
+    restart: unless-stopped
+    environment:
+      - PDF_SERVICE_TOKEN=${PDF_SERVICE_TOKEN:?PDF_SERVICE_TOKEN must be set}
+      - PDF_PORT=3001
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:3001/health",
+        ]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+    deploy:
+      resources:
+        limits:
+          memory: 1g
+          cpus: "1.0"
+        reservations:
+          memory: 512m
+          cpus: "0.5"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    # pdf-service is intentionally NOT on alchymine-net — it is only reachable
+    # from api and worker via the isolated pdf-net bridge.
+    networks:
+      - pdf-net
 
 # ─── Networks ────────────────────────────────────────────────────────────────
 networks:
   alchymine-net:
     driver: bridge
     name: alchymine-net
+  # Isolated network for PDF service — only api and worker can reach it.
+  # The PDF service is not on alchymine-net so web/nginx cannot call it directly.
+  pdf-net:
+    driver: bridge
+    name: alchymine-pdf-net
+    internal: true
 
 # ─── Volumes ─────────────────────────────────────────────────────────────────
 volumes:

--- a/infrastructure/docker/pdf-service/server.js
+++ b/infrastructure/docker/pdf-service/server.js
@@ -6,6 +6,24 @@ const puppeteer = require("puppeteer-core");
 const app = express();
 const PORT = process.env.PDF_PORT || 3001;
 
+// Require a shared secret token for all non-health requests.
+// The API service must set the same PDF_SERVICE_TOKEN in its environment
+// and pass it as "Authorization: Bearer <token>" on every request.
+const PDF_SERVICE_TOKEN = process.env.PDF_SERVICE_TOKEN;
+if (!PDF_SERVICE_TOKEN) {
+  console.error("FATAL: PDF_SERVICE_TOKEN environment variable is not set.");
+  process.exit(1);
+}
+
+function requireBearerToken(req, res, next) {
+  const authHeader = req.headers["authorization"] || "";
+  const [scheme, token] = authHeader.split(" ");
+  if (scheme !== "Bearer" || token !== PDF_SERVICE_TOKEN) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+  next();
+}
+
 app.use(express.json({ limit: "10mb" }));
 
 let browser;
@@ -33,8 +51,8 @@ app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "alchymine-pdf" });
 });
 
-// PDF generation endpoint
-app.post("/generate", async (req, res) => {
+// PDF generation endpoint — requires valid bearer token
+app.post("/generate", requireBearerToken, async (req, res) => {
   let page;
   try {
     const { html, options = {} } = req.body;

--- a/infrastructure/nginx/nginx.conf
+++ b/infrastructure/nginx/nginx.conf
@@ -113,11 +113,20 @@ http {
         # ── Security headers ────────────────────────────────────────────────
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header X-Content-Type-Options    "nosniff" always;
-        add_header X-Frame-Options           "SAMEORIGIN" always;
+        # X-Frame-Options is kept for older browsers; frame-ancestors 'none' in CSP is the modern equivalent.
+        add_header X-Frame-Options           "DENY" always;
         add_header X-XSS-Protection          "1; mode=block" always;
         add_header Referrer-Policy           "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy        "camera=(), microphone=(), geolocation=()" always;
-        add_header Content-Security-Policy   "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://api.anthropic.com; frame-ancestors 'self'; base-uri 'self'; form-action 'self'" always;
+        # Content-Security-Policy notes:
+        #   script-src: 'unsafe-inline' is required because Next.js 14 App Router injects
+        #     inline scripts for hydration (__NEXT_DATA__, React server component payloads).
+        #     'unsafe-eval' has been removed — it is not needed for production Next.js builds.
+        #     To fully eliminate 'unsafe-inline', add a nonce-based CSP middleware to the
+        #     Next.js app (see docs/adr for future work).
+        #   style-src: 'unsafe-inline' is kept for Tailwind CSS, which generates inline styles.
+        #   frame-ancestors: 'none' — this application is never embedded in a frame.
+        add_header Content-Security-Policy   "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://api.anthropic.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
 
         # ── Request size limits ─────────────────────────────────────────────
         client_max_body_size 10m;

--- a/infrastructure/scripts/deploy-digitalocean.sh
+++ b/infrastructure/scripts/deploy-digitalocean.sh
@@ -246,6 +246,7 @@ DB_PASSWORD=$(openssl rand -hex 24)
 REDIS_PASSWORD=$(openssl rand -hex 24)
 ENCRYPTION_KEY=$(openssl rand -hex 32)
 FINANCIAL_KEY=$(openssl rand -hex 32)
+PDF_SERVICE_TOKEN=$(openssl rand -hex 32)
 
 cat > "${ENV_FILE}" << ENVEOF
 # ============================================================================
@@ -302,6 +303,12 @@ API_PORT=8000
 ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
 LLM_PROVIDER=anthropic
 LLM_MODEL=claude-sonnet-4-20250514
+
+# ── PDF Service ──────────────────────────────────────────────────────────────
+# Shared bearer token used by the API/worker to authenticate with the PDF service.
+# Generated automatically during deployment — never share or commit this value.
+PDF_SERVICE_TOKEN=${PDF_SERVICE_TOKEN}
+PDF_SERVICE_URL=http://pdf-service:3001
 
 # ── Backup ───────────────────────────────────────────────────────────────────
 BACKUP_RETENTION=30
@@ -431,6 +438,7 @@ echo "    - Celery     (4 workers)"
 echo "    - PostgreSQL (tuned for production)"
 echo "    - Redis      (AOF + RDB persistence)"
 echo "    - Certbot    (auto-renewal every 12h)"
+echo "    - PDF        (Puppeteer, internal-only network)"
 echo ""
 echo "  Security:"
 echo "    - UFW firewall (SSH, HTTP, HTTPS only)"

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -373,6 +373,69 @@ class TestRefresh:
         assert me_resp.status_code == 200
         assert me_resp.json()["email"] == "test@example.com"
 
+    def test_refresh_with_missing_token_rejected(self, client: TestClient):
+        """Refreshing without a token in body or cookie should return 401."""
+        response = client.post(
+            "/api/v1/auth/refresh",
+            json={},
+        )
+        assert response.status_code == 401
+
+
+# ─── Cookie Tests ─────────────────────────────────────────────────────────
+
+
+class TestAuthCookies:
+    """Tests that login and register set httpOnly auth cookies."""
+
+    def test_login_sets_cookies(self, client: TestClient, registered_user: dict):
+        """Login should set access_token and refresh_token cookies."""
+        response = client.post(
+            "/api/v1/auth/login",
+            json={"email": "test@example.com", "password": "securepassword123"},
+        )
+        assert response.status_code == 200
+        assert "access_token" in response.cookies
+        assert "refresh_token" in response.cookies
+
+    def test_register_sets_cookies(self, client: TestClient):
+        """Register should set access_token and refresh_token cookies."""
+        response = client.post(
+            "/api/v1/auth/register",
+            json={
+                "email": "cookie@example.com",
+                "password": "password123",
+                "promo_code": "alchyours",
+            },
+        )
+        assert response.status_code == 201
+        assert "access_token" in response.cookies
+        assert "refresh_token" in response.cookies
+
+    def test_me_with_cookie_auth(self, client: TestClient, registered_user: dict):
+        """GET /me should accept the access_token cookie instead of Bearer header."""
+        # Log in to obtain cookies
+        login_resp = client.post(
+            "/api/v1/auth/login",
+            json={"email": "test@example.com", "password": "securepassword123"},
+        )
+        assert login_resp.status_code == 200
+        cookie_value = login_resp.cookies["access_token"]
+
+        # Use cookie instead of Authorization header
+        response = client.get(
+            "/api/v1/auth/me",
+            cookies={"access_token": cookie_value},
+        )
+        assert response.status_code == 200
+        assert response.json()["email"] == "test@example.com"
+
+    def test_logout_clears_cookies(self, client: TestClient, registered_user: dict):
+        """POST /auth/logout should clear auth cookies."""
+        response = client.post("/api/v1/auth/logout")
+        assert response.status_code == 200
+        assert response.json()["message"] == "Logged out successfully."
+
 
 # ─── Forgot Password Tests ──────────────────────────────────────────────
 
@@ -492,3 +555,118 @@ class TestResetPassword:
             json={"token": raw_token, "new_password": "another-password"},
         )
         assert reuse_resp.status_code == 400
+
+
+# ─── Token Revocation Tests ──────────────────────────────────────────────
+
+
+class TestTokenRevocationOnPasswordReset:
+    """Tests that refresh tokens issued before a password reset are invalidated."""
+
+    def test_refresh_token_revoked_after_password_reset(
+        self, client: TestClient, registered_user: dict
+    ):
+        """A refresh token obtained before a password reset should be rejected."""
+        import asyncio
+        import secrets
+
+        from sqlalchemy import select
+
+        from alchymine.api.routers.auth import _hash_reset_token, get_db
+        from alchymine.db.models import User
+
+        old_refresh_token = registered_user["refresh_token"]
+
+        # Verify the old refresh token works before the reset
+        pre_reset_resp = client.post(
+            "/api/v1/auth/refresh",
+            json={"refresh_token": old_refresh_token},
+        )
+        assert pre_reset_resp.status_code == 200
+
+        # Trigger a password reset via the forgot/reset flow
+        client.post(
+            "/api/v1/auth/forgot-password",
+            json={"email": "test@example.com"},
+        )
+
+        raw_token = secrets.token_urlsafe(32)
+        token_hash = _hash_reset_token(raw_token)
+
+        async def _set_reset_token() -> None:
+            async for db in app.dependency_overrides[get_db]():
+                result = await db.execute(select(User).where(User.email == "test@example.com"))
+                user = result.scalar_one()
+                user.password_reset_token = token_hash
+                user.password_reset_expires = datetime.now(UTC) + timedelta(hours=1)
+                await db.commit()
+
+        asyncio.get_event_loop().run_until_complete(_set_reset_token())
+
+        reset_resp = client.post(
+            "/api/v1/auth/reset-password",
+            json={"token": raw_token, "new_password": "brand-new-password-2"},
+        )
+        assert reset_resp.status_code == 200
+
+        # The old refresh token should now be rejected
+        post_reset_resp = client.post(
+            "/api/v1/auth/refresh",
+            json={"refresh_token": old_refresh_token},
+        )
+        assert post_reset_resp.status_code == 401
+        assert "revoked" in post_reset_resp.json()["detail"].lower()
+
+    def test_new_refresh_token_works_after_password_reset(
+        self, client: TestClient, registered_user: dict
+    ):
+        """A refresh token issued after a password reset should be accepted."""
+        import asyncio
+        import secrets
+
+        from sqlalchemy import select
+
+        from alchymine.api.routers.auth import _hash_reset_token, get_db
+        from alchymine.db.models import User
+
+        client.post("/api/v1/auth/forgot-password", json={"email": "test@example.com"})
+
+        raw_token = secrets.token_urlsafe(32)
+        token_hash = _hash_reset_token(raw_token)
+
+        async def _set_reset_token() -> None:
+            async for db in app.dependency_overrides[get_db]():
+                result = await db.execute(select(User).where(User.email == "test@example.com"))
+                user = result.scalar_one()
+                user.password_reset_token = token_hash
+                user.password_reset_expires = datetime.now(UTC) + timedelta(hours=1)
+                await db.commit()
+
+        asyncio.get_event_loop().run_until_complete(_set_reset_token())
+
+        client.post(
+            "/api/v1/auth/reset-password",
+            json={"token": raw_token, "new_password": "post-reset-password"},
+        )
+
+        # Wait so the new login token's ``iat`` (integer seconds) falls
+        # strictly after the password_changed_at second.
+        import time
+
+        time.sleep(1.1)
+
+        # Log in with the new password to get a fresh refresh token
+        login_resp = client.post(
+            "/api/v1/auth/login",
+            json={"email": "test@example.com", "password": "post-reset-password"},
+        )
+        assert login_resp.status_code == 200
+        new_refresh_token = login_resp.json()["refresh_token"]
+
+        # New refresh token should work
+        refresh_resp = client.post(
+            "/api/v1/auth/refresh",
+            json={"refresh_token": new_refresh_token},
+        )
+        assert refresh_resp.status_code == 200
+        assert "access_token" in refresh_resp.json()

--- a/tests/api/test_journal.py
+++ b/tests/api/test_journal.py
@@ -8,22 +8,68 @@ Covers:
 
 from __future__ import annotations
 
-import pytest
-from fastapi.testclient import TestClient
+import asyncio
+from collections.abc import AsyncGenerator
 
+import pytest
+from cryptography.fernet import Fernet
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+import alchymine.db.models  # noqa: F401
+from alchymine.api.deps import get_db_session
 from alchymine.api.main import app
-from alchymine.api.routers.journal import _journal_store
+from alchymine.db.base import Base
+
+
+@pytest.fixture(autouse=True)
+def _set_encryption_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure a valid Fernet key is available for encryption in tests."""
+    key = Fernet.generate_key().decode()
+    monkeypatch.setenv("ALCHYMINE_ENCRYPTION_KEY", key)
 
 
 @pytest.fixture
 def client() -> TestClient:
-    return TestClient(app)
+    """Provide a TestClient wired to an in-memory SQLite engine."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        connect_args={"check_same_thread": False},
+        echo=False,
+    )
+
+    # Create tables synchronously before entering the async context
+    loop = asyncio.new_event_loop()
+    loop.run_until_complete(_create_tables(engine))
+
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def _override_get_db_session() -> AsyncGenerator[AsyncSession, None]:
+        async with factory() as session:
+            try:
+                yield session
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                raise
+
+    app.dependency_overrides[get_db_session] = _override_get_db_session
+    tc = TestClient(app)
+    yield tc
+    app.dependency_overrides.pop(get_db_session, None)
+
+    loop.run_until_complete(engine.dispose())
+    loop.close()
 
 
-@pytest.fixture(autouse=True)
-def _clear_store() -> None:
-    """Clear journal store between tests."""
-    _journal_store.clear()
+async def _create_tables(engine: AsyncEngine) -> None:
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
 
 
 class TestJournalCreate:

--- a/tests/db/test_models.py
+++ b/tests/db/test_models.py
@@ -307,7 +307,7 @@ async def test_wealth_defaults(session: AsyncSession) -> None:
     await session.flush()
 
     assert wealth.risk_tolerance == "moderate"
-    assert wealth.financial_distress_detected is False
+    assert wealth.financial_distress_detected == "false"
     assert wealth.disclaimer_acknowledged is False
 
 


### PR DESCRIPTION
## Summary

Completes the remaining 6 security audit tasks from the Phase 2/3 backlog:

- **#15** Move JWT tokens from localStorage to httpOnly cookies (SameSite=Lax, Secure, path-scoped refresh token)
- **#30** Add refresh token revocation on password change (iat vs password_changed_at)
- **#16** Add shared-secret Bearer auth to PDF service + network isolation via internal `pdf-net` bridge
- **#33** Tighten nginx CSP (remove `unsafe-eval`, `frame-ancestors 'none'`, `X-Frame-Options: DENY`)
- **#35** Persist journal entries to PostgreSQL (new `JournalEntry` ORM model, encrypted content, full CRUD via repository)
- **#36** Encrypt `financial_distress_detected` as `EncryptedString` with Pydantic validator for bool coercion

### Key design decisions

- **Cookie migration**: Bearer header remains as fallback so existing clients continue working; `credentials: "include"` on all fetch calls sends cookies automatically
- **Token revocation**: Uses `<=` comparison with second-truncated `password_changed_at` — tokens issued in the same calendar second as the change are also revoked (safe default)
- **PDF network isolation**: `pdf-service` container only on `pdf-net` (internal, no internet); only `api` and `worker` can reach it
- **Journal encryption**: Content column uses `EncryptedString()` type decorator for at-rest encryption
- **Financial boolean**: `financial_distress_detected` stored as encrypted `"true"`/`"false"` strings; Pydantic `field_validator` transparently coerces back to `bool`

## Test plan

- [x] 1842 Python tests passing (0 failures)
- [x] 102 frontend tests passing (10 suites)
- [x] Next.js build succeeds (19 pages)
- [x] `ruff check` + `ruff format` clean
- [ ] CI pipeline (lint, type-check, test-python, test-frontend, ethics, security)

🤖 Generated with [Claude Code](https://claude.com/claude-code)