### PR TITLE
fix: add retry logic to deploy git fetch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,7 +183,19 @@ jobs:
             cd /home/alchymine/Alchymine
 
             # Fetch latest code and checkout the release tag
-            git fetch --tags
+            # Retry up to 3 times to handle transient GitHub 500 errors
+            for attempt in 1 2 3; do
+              echo "git fetch --tags (attempt ${attempt}/3)..."
+              if git fetch --tags; then
+                break
+              fi
+              if [ "$attempt" = "3" ]; then
+                echo "ERROR: git fetch failed after 3 attempts"
+                exit 1
+              fi
+              echo "Retrying in 10s..."
+              sleep 10
+            done
             git checkout "${TAG}"
 
             # Verify production env file exists


### PR DESCRIPTION
## Summary
- Adds 3-attempt retry with 10s backoff to `git fetch --tags` in the deploy step
- Prevents transient GitHub HTTP 500 errors from killing the entire deployment (as happened with v0.3.4)
- The droplet's git remote has also been switched to SSH for additional resilience

## Root cause
The v0.3.4 release deploy failed because GitHub returned a transient HTTP 500 on `git fetch --tags` via HTTPS. The repo is public and all secrets resolved correctly — v0.3.3 deployed successfully 2 hours earlier with the same workflow.

## Test plan
- [ ] Verify workflow YAML syntax is valid
- [ ] Next release deploy should show retry logging (`git fetch --tags (attempt 1/3)...`)
- [ ] If GitHub returns a transient error, deploy retries instead of failing immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)