### PR TITLE
fix: nginx 502 after deploy and unhealthy health check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,6 +216,12 @@ jobs:
               -f infrastructure/docker-compose.yml \
               -f infrastructure/docker-compose.prod.yml up -d --remove-orphans
 
+            # Restart nginx so it resolves new container IPs immediately
+            docker compose \
+              --env-file .env.production \
+              -f infrastructure/docker-compose.yml \
+              -f infrastructure/docker-compose.prod.yml restart nginx
+
             # Clean up old images
             docker image prune -f
 

--- a/infrastructure/nginx/nginx.conf
+++ b/infrastructure/nginx/nginx.conf
@@ -64,6 +64,12 @@ http {
     # Login/auth rate limit: 5 requests/sec per IP
     limit_req_zone $binary_remote_addr zone=auth:10m rate=5r/s;
 
+    # ── Docker DNS resolver ────────────────────────────────────────────────
+    # Re-resolve container hostnames every 10s so nginx picks up new IPs
+    # after containers are rebuilt (e.g. during deploys).
+    resolver 127.0.0.11 valid=10s ipv6=off;
+    resolver_timeout 5s;
+
     # ── Upstream definitions ─────────────────────────────────────────────────
     upstream nextjs {
         server web:3000;
@@ -85,6 +91,14 @@ http {
         listen 80;
         listen [::]:80;
         server_name alchymine.com www.alchymine.com;
+
+        # Health check — must be on port 80 so Docker health check works
+        # without TLS (wget http://localhost/nginx-health)
+        location /nginx-health {
+            access_log off;
+            return 200 "OK\n";
+            add_header Content-Type text/plain;
+        }
 
         # Let's Encrypt ACME challenge
         location /.well-known/acme-challenge/ {


### PR DESCRIPTION
## Summary
- Add Docker DNS resolver (`127.0.0.11 valid=10s`) to nginx so it re-resolves container IPs after rebuilds instead of caching stale IPs forever
- Move `/nginx-health` endpoint to the HTTP server block (port 80) so Docker's health check doesn't get 301 redirected to HTTPS — fixes nginx always reporting `(unhealthy)`
- Add `docker compose restart nginx` to the deploy script after `up -d` for immediate IP resolution

## Root cause
After `docker compose up -d` rebuilds api/web containers, they get new internal IPs. Nginx (which wasn't rebuilt) still has the old IPs cached from startup, causing `connect() failed (111: Connection refused)` → 502 Bad Gateway.

## Test plan
- [ ] After deploy, nginx immediately resolves new container IPs (no 502)
- [ ] `docker compose ps` shows nginx as `(healthy)` instead of `(unhealthy)`
- [ ] `/nginx-health` on port 80 returns 200 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)