### PR TITLE
fix: harden deploy pipeline to prevent recurring release failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,36 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ matrix.image }}
 
   # ──────────────────────────────────────────────
+  # Smoke test: verify built images actually start
+  # ──────────────────────────────────────────────
+  smoke-test:
+    name: "Smoke test: images"
+    runs-on: ubuntu-latest
+    needs: [validate, build-release]
+    permissions:
+      packages: read
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.3.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull and verify API image starts
+        run: |
+          IMAGE="${{ env.IMAGE_PREFIX }}-api:${{ needs.validate.outputs.version }}"
+          docker pull "$IMAGE"
+          # Verify the app module can be imported (catches missing deps, syntax errors)
+          docker run --rm "$IMAGE" python -c "from alchymine.api.main import app; print('API smoke test passed')"
+
+      - name: Pull and verify Worker image starts
+        run: |
+          IMAGE="${{ env.IMAGE_PREFIX }}-worker:${{ needs.validate.outputs.version }}"
+          docker pull "$IMAGE"
+          docker run --rm "$IMAGE" python -c "from alchymine.workers.celery_app import app; print('Worker smoke test passed')"
+
+  # ──────────────────────────────────────────────
   # Update GitHub Release with Docker image info
   # ──────────────────────────────────────────────
   update-release:
@@ -175,7 +205,7 @@ jobs:
   deploy:
     name: "Deploy to production"
     runs-on: ubuntu-latest
-    needs: [validate, build-release]
+    needs: [validate, build-release, smoke-test]
     environment: production
     permissions:
       contents: read
@@ -189,7 +219,7 @@ jobs:
           passphrase: ${{ secrets.DEPLOY_SSH_PASSPHRASE }}
           command_timeout: 20m
           script: |
-            set -e
+            set -euo pipefail
             TAG="${{ github.event.release.tag_name }}"
             VERSION="${TAG#v}"
             echo "Deploying Alchymine ${TAG} (zero-downtime)..."
@@ -197,11 +227,24 @@ jobs:
             cd /home/alchymine/Alchymine
 
             # Download release tarball for updated compose files, scripts, nginx config
+            # --fail: return exit code 22 on HTTP errors (instead of saving error HTML)
+            # --retry: retry transient failures
             echo "Downloading ${TAG} tarball..."
-            curl -sL "https://github.com/realsammyt/Alchymine/archive/refs/tags/${TAG}.tar.gz" \
-              -o "/tmp/alchymine-${TAG}.tar.gz"
-            tar xzf "/tmp/alchymine-${TAG}.tar.gz" --strip-components=1 -C /home/alchymine/Alchymine
-            rm -f "/tmp/alchymine-${TAG}.tar.gz"
+            TARBALL="/tmp/alchymine-${TAG}.tar.gz"
+            curl --fail --silent --show-error --location --retry 3 --retry-delay 5 \
+              "https://github.com/realsammyt/Alchymine/archive/refs/tags/${TAG}.tar.gz" \
+              -o "${TARBALL}"
+
+            # Validate the tarball is actually a gzip file before extracting
+            if ! file "${TARBALL}" | grep -q 'gzip'; then
+              echo "ERROR: Downloaded file is not a valid gzip tarball."
+              echo "Content: $(head -c 200 "${TARBALL}")"
+              rm -f "${TARBALL}"
+              exit 1
+            fi
+
+            tar xzf "${TARBALL}" --strip-components=1 -C /home/alchymine/Alchymine
+            rm -f "${TARBALL}"
 
             # Verify production env file exists
             if [ ! -f .env.production ]; then

--- a/infrastructure/docker/Dockerfile.api
+++ b/infrastructure/docker/Dockerfile.api
@@ -22,40 +22,23 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /build
 
 # Copy dependency specification first (layer caching)
-COPY pyproject.toml ./
+COPY pyproject.toml README.md ./
+
+# Create stub package so hatchling can resolve the package metadata.
+# This lets `pip install .` read deps from pyproject.toml without needing
+# the full source tree — no more fragile fallback dependency lists.
+RUN mkdir -p alchymine && echo '__version__ = "0.1.0"' > alchymine/__init__.py
 
 # Install Python dependencies into a virtual environment
 RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
 # Upgrade build tools to fix vendored vulnerabilities
-# (jaraco.context CVE-2026-23949, wheel CVE-2026-24049)
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel
 
-# Install the project dependencies (without the project itself yet)
-RUN pip install --no-cache-dir . 2>/dev/null || \
-    pip install --no-cache-dir \
-    "fastapi>=0.115.0" \
-    "uvicorn[standard]>=0.32.0" \
-    "pydantic[email]>=2.10.0" \
-    "pydantic-settings>=2.6.0" \
-    "celery[redis]>=5.4.0" \
-    "redis>=5.2.0" \
-    "sqlalchemy>=2.0.0" \
-    "asyncpg>=0.30.0" \
-    "alembic>=1.14.0" \
-    "pyswisseph>=2.10.0" \
-    "cryptography>=43.0.0" \
-    "python-jose[cryptography]>=3.3.0" \
-    "passlib[bcrypt]>=1.7.4" \
-    "anthropic>=0.40.0" \
-    "httpx>=0.28.0" \
-    "resend>=2.0.0" \
-    "pyyaml>=6.0.0" \
-    "python-multipart>=0.0.12" \
-    "jinja2>=3.1.0" \
-    "uvloop" \
-    "httptools"
+# Install all project dependencies from pyproject.toml (single source of truth)
+RUN pip install --no-cache-dir . && \
+    pip install --no-cache-dir uvloop httptools
 
 # ─── Stage 2: Runtime ─────────────────────────────────────────────────────
 FROM python:3.11-slim AS runtime

--- a/infrastructure/docker/Dockerfile.worker
+++ b/infrastructure/docker/Dockerfile.worker
@@ -21,34 +21,23 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /build
 
-COPY pyproject.toml ./
+COPY pyproject.toml README.md ./
+
+# Create stub package so hatchling can resolve the package metadata.
+# This lets `pip install .` read deps from pyproject.toml without needing
+# the full source tree — no more fragile fallback dependency lists.
+RUN mkdir -p alchymine && echo '__version__ = "0.1.0"' > alchymine/__init__.py
 
 # Install Python dependencies into a virtual environment
 RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-RUN pip install --no-cache-dir . 2>/dev/null || \
-    pip install --no-cache-dir \
-    "fastapi>=0.115.0" \
-    "uvicorn[standard]>=0.32.0" \
-    "pydantic[email]>=2.10.0" \
-    "pydantic-settings>=2.6.0" \
-    "celery[redis]>=5.4.0" \
-    "redis>=5.2.0" \
-    "sqlalchemy>=2.0.0" \
-    "asyncpg>=0.30.0" \
-    "alembic>=1.14.0" \
-    "pyswisseph>=2.10.0" \
-    "cryptography>=43.0.0" \
-    "python-jose[cryptography]>=3.3.0" \
-    "passlib[bcrypt]>=1.7.4" \
-    "anthropic>=0.40.0" \
-    "httpx>=0.28.0" \
-    "resend>=2.0.0" \
-    "pyyaml>=6.0.0" \
-    "python-multipart>=0.0.12" \
-    "jinja2>=3.1.0" \
-    "watchdog"
+# Upgrade build tools
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel
+
+# Install all project dependencies from pyproject.toml (single source of truth)
+RUN pip install --no-cache-dir . && \
+    pip install --no-cache-dir watchdog
 
 # ─── Stage 2: Runtime ─────────────────────────────────────────────────────
 FROM python:3.11-slim AS runtime


### PR DESCRIPTION
## Summary

Three consecutive deploy failures (v0.8.0, v0.8.1, v0.9.0) revealed systemic fragility in the release pipeline. This PR addresses all root causes:

- **Dockerfiles**: Eliminate the fragile `pip install . || pip install <manual list>` pattern. The builder stage now creates a stub `alchymine/__init__.py` so hatchling can resolve the package, and `pip install .` reads all deps from `pyproject.toml` — single source of truth, no more stale fallback lists
- **CI smoke test**: New `smoke-test` job pulls built images and runs `python -c "from alchymine.api.main import app"` to verify imports work before deploying. Catches missing deps, syntax errors, and broken module references
- **Deploy gated on smoke test**: The `deploy` job now depends on `smoke-test` passing
- **Tarball download hardening**: Uses `curl --fail` (returns exit 22 on HTTP errors instead of saving HTML), adds `--retry 3`, and validates the downloaded file is actually gzip before extraction

## Test plan

- [ ] Merge PR and create v0.9.1 release
- [ ] Verify `build-release` job completes (Dockerfiles build successfully with stub package)
- [ ] Verify `smoke-test` job passes (API and worker images start)
- [ ] Verify `deploy` job succeeds (tarball downloads correctly, zero-downtime deploy runs)
- [ ] Run Alembic migration on droplet: `alembic upgrade head`
- [ ] Bootstrap admin user: `ADMIN_EMAIL=tyler@futuretalk.ca python -m alchymine.cli.bootstrap_admin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)