### PR TITLE
fix: pass dummy env vars in CI smoke test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,14 +159,20 @@ jobs:
         run: |
           IMAGE="${{ env.IMAGE_PREFIX }}-api:${{ needs.validate.outputs.version }}"
           docker pull "$IMAGE"
-          # Verify the app module can be imported (catches missing deps, syntax errors)
-          docker run --rm "$IMAGE" python -c "from alchymine.api.main import app; print('API smoke test passed')"
+          # Dummy env vars satisfy pydantic-settings validators at import time
+          docker run --rm \
+            -e JWT_SECRET_KEY="smoke-test-dummy-key-that-is-at-least-32-chars-long" \
+            -e SIGNUP_PROMO_CODE="smoke-test-code" \
+            "$IMAGE" python -c "from alchymine.api.main import app; print('API smoke test passed')"
 
       - name: Pull and verify Worker image starts
         run: |
           IMAGE="${{ env.IMAGE_PREFIX }}-worker:${{ needs.validate.outputs.version }}"
           docker pull "$IMAGE"
-          docker run --rm "$IMAGE" python -c "from alchymine.workers.celery_app import app; print('Worker smoke test passed')"
+          docker run --rm \
+            -e JWT_SECRET_KEY="smoke-test-dummy-key-that-is-at-least-32-chars-long" \
+            -e SIGNUP_PROMO_CODE="smoke-test-code" \
+            "$IMAGE" python -c "from alchymine.workers.celery_app import app; print('Worker smoke test passed')"
 
   # ──────────────────────────────────────────────
   # Update GitHub Release with Docker image info


### PR DESCRIPTION
## Summary

- Smoke test in v0.9.1 release failed because `get_settings()` runs at import time and rejects default `JWT_SECRET_KEY` / empty `SIGNUP_PROMO_CODE`
- Pass dummy env vars via `docker run -e` flags so the import succeeds in CI

Follow-up to #68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)