### PR TITLE
fix: repair report generation pipeline

### DIFF
--- a/alchymine/agents/orchestrator/intent.py
+++ b/alchymine/agents/orchestrator/intent.py
@@ -192,6 +192,56 @@ _SYSTEM_KEYWORDS: dict[SystemIntent, list[str]] = {
     ],
 }
 
+# ─── Intention → System mapping ──────────────────────────────────────
+
+# Maps user-facing intention values (from the Intention enum in
+# alchymine.engine.profile) to the system coordinators that should
+# process them.  Used when the report endpoint provides explicit
+# intentions so we can skip keyword-based classification.
+
+_INTENTION_TO_SYSTEMS: dict[str, list[SystemIntent]] = {
+    "career": [SystemIntent.INTELLIGENCE, SystemIntent.PERSPECTIVE],
+    "love": [SystemIntent.INTELLIGENCE, SystemIntent.HEALING],
+    "purpose": [SystemIntent.INTELLIGENCE, SystemIntent.CREATIVE, SystemIntent.PERSPECTIVE],
+    "money": [SystemIntent.WEALTH, SystemIntent.INTELLIGENCE],
+    "health": [SystemIntent.HEALING, SystemIntent.INTELLIGENCE],
+    "family": [SystemIntent.HEALING, SystemIntent.PERSPECTIVE],
+    "business": [SystemIntent.WEALTH, SystemIntent.CREATIVE],
+    "legacy": [SystemIntent.WEALTH, SystemIntent.PERSPECTIVE, SystemIntent.CREATIVE],
+}
+
+
+def intentions_to_systems(intentions: list[str]) -> list[SystemIntent]:
+    """Map a list of user intention strings to unique SystemIntents.
+
+    Always includes INTELLIGENCE as the base system (numerology/astrology
+    are computed for every report).
+
+    Parameters
+    ----------
+    intentions:
+        List of intention value strings (e.g. ``["health", "money"]``).
+
+    Returns
+    -------
+    list[SystemIntent]
+        Deduplicated list of systems to invoke, with INTELLIGENCE first.
+    """
+    systems: list[SystemIntent] = []
+    seen: set[SystemIntent] = set()
+    # Always include intelligence (numerology/astrology are core)
+    systems.append(SystemIntent.INTELLIGENCE)
+    seen.add(SystemIntent.INTELLIGENCE)
+
+    for intention in intentions:
+        for system in _INTENTION_TO_SYSTEMS.get(intention.lower(), []):
+            if system not in seen:
+                systems.append(system)
+                seen.add(system)
+
+    return systems
+
+
 # Threshold: if the top score and runner-up are within this ratio,
 # classify as MULTI_SYSTEM.
 _MULTI_SYSTEM_RATIO_THRESHOLD = 0.7

--- a/alchymine/agents/orchestrator/orchestrator.py
+++ b/alchymine/agents/orchestrator/orchestrator.py
@@ -22,7 +22,7 @@ from .coordinator import (
     PerspectiveCoordinator,
     WealthCoordinator,
 )
-from .intent import IntentResult, SystemIntent, classify_intent
+from .intent import IntentResult, SystemIntent, classify_intent, intentions_to_systems
 
 logger = logging.getLogger(__name__)
 
@@ -124,8 +124,19 @@ class MasterOrchestrator:
 
         user_id = request_data.get("id", "anonymous")
 
-        # Determine which coordinators to invoke
-        if intent_result.intent == SystemIntent.UNKNOWN:
+        # Determine which coordinators to invoke.
+        # When explicit intentions are provided (from the intake form),
+        # use intention-based routing which maps intentions directly to
+        # system coordinators.  This bypasses keyword classification
+        # which fails for generic strings like "Generate my full report".
+        if intentions:
+            systems_to_invoke = intentions_to_systems(intentions)
+            logger.info(
+                "Intention-based routing: %s → %s",
+                intentions,
+                [s.value for s in systems_to_invoke],
+            )
+        elif intent_result.intent == SystemIntent.UNKNOWN:
             return OrchestratorResult(
                 request_id=request_id,
                 intent=intent_result,
@@ -133,8 +144,7 @@ class MasterOrchestrator:
                 synthesis=None,
                 quality_passed=True,
             )
-
-        if intent_result.intent == SystemIntent.MULTI_SYSTEM:
+        elif intent_result.intent == SystemIntent.MULTI_SYSTEM:
             systems_to_invoke = intent_result.secondary_intents
         else:
             systems_to_invoke = [intent_result.intent]

--- a/alchymine/api/routers/reports.py
+++ b/alchymine/api/routers/reports.py
@@ -107,11 +107,17 @@ async def create_report(
     )
     await session.commit()
 
-    # Dispatch Celery task with intention(s)
+    # Build a profile dict from the intake data so the orchestrator's
+    # engine nodes have the fields they need (full_name, birth_date, etc.)
+    intake_dict = request.intake.model_dump(mode="json")
+    profile_data = request.user_profile or {}
+    profile_data.update(intake_dict)
+
+    # Dispatch Celery task with intention(s) + full intake context
     generate_report_task.delay(
         report_id,
         request.user_input,
-        request.user_profile,
+        profile_data,
         request.intake.intention.value,
         [i.value for i in request.intake.intentions],
     )

--- a/alchymine/workers/tasks.py
+++ b/alchymine/workers/tasks.py
@@ -290,9 +290,11 @@ def generate_report(
 
     except Exception as exc:
         # Non-transient failure — record and do not retry
-        _run_async(_db_set_failed(report_id, str(exc)))
-
         logger.exception("Report %s failed: %s", report_id, exc)
+        try:
+            _run_async(_db_set_failed(report_id, str(exc)))
+        except Exception as db_exc:
+            logger.error("Failed to persist error status for %s: %s", report_id, db_exc)
         return {
             "error": str(exc),
             "report_id": report_id,

--- a/tests/agents/test_orchestrator.py
+++ b/tests/agents/test_orchestrator.py
@@ -26,6 +26,7 @@ from alchymine.agents.orchestrator.intent import (
     IntentResult,
     SystemIntent,
     classify_intent,
+    intentions_to_systems,
 )
 from alchymine.agents.orchestrator.orchestrator import (
     MasterOrchestrator,
@@ -798,3 +799,70 @@ class TestOrchestratorInit:
         assert isinstance(
             orchestrator._coordinators[SystemIntent.PERSPECTIVE], PerspectiveCoordinator
         )
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Section 11: Intention-based routing
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestIntentionsToSystems:
+    """intentions_to_systems maps user intention values to SystemIntent lists."""
+
+    def test_health_intention_includes_healing(self) -> None:
+        systems = intentions_to_systems(["health"])
+        assert SystemIntent.INTELLIGENCE in systems
+        assert SystemIntent.HEALING in systems
+
+    def test_money_intention_includes_wealth(self) -> None:
+        systems = intentions_to_systems(["money"])
+        assert SystemIntent.INTELLIGENCE in systems
+        assert SystemIntent.WEALTH in systems
+
+    def test_multiple_intentions_deduplicated(self) -> None:
+        systems = intentions_to_systems(["health", "money"])
+        # INTELLIGENCE should appear only once even though both map to it
+        assert systems.count(SystemIntent.INTELLIGENCE) == 1
+        assert SystemIntent.HEALING in systems
+        assert SystemIntent.WEALTH in systems
+
+    def test_intelligence_always_first(self) -> None:
+        systems = intentions_to_systems(["health"])
+        assert systems[0] == SystemIntent.INTELLIGENCE
+
+    def test_unknown_intention_still_has_intelligence(self) -> None:
+        systems = intentions_to_systems(["unknown_xyz"])
+        assert systems == [SystemIntent.INTELLIGENCE]
+
+    def test_case_insensitive(self) -> None:
+        systems = intentions_to_systems(["HEALTH"])
+        assert SystemIntent.HEALING in systems
+
+
+class TestOrchestratorIntentionRouting:
+    """Orchestrator uses intentions for routing when provided."""
+
+    async def test_intentions_bypass_keyword_classification(self) -> None:
+        """When intentions are provided, keyword classification is bypassed."""
+        orchestrator = MasterOrchestrator()
+
+        mock_result = CoordinatorResult(
+            system="intelligence",
+            status=CoordinatorStatus.SUCCESS.value,
+            data={"numerology": {"life_path": 3}},
+            quality_passed=True,
+        )
+
+        # Mock all coordinators
+        for system in SystemIntent:
+            if system in orchestrator._coordinators:
+                mock_coord = MagicMock()
+                mock_coord.process = AsyncMock(return_value=mock_result)
+                orchestrator._coordinators[system] = mock_coord
+
+        # "random gibberish" would normally be UNKNOWN, but intentions override
+        result = await orchestrator.process_request(
+            "random gibberish",
+            intentions=["health"],
+        )
+        assert len(result.coordinator_results) >= 1


### PR DESCRIPTION
## Summary

- **Root cause**: Three cascading bugs prevented the intake form → report generation flow from ever producing results
  - Intent classifier returned `UNKNOWN` for default `user_input` ("Generate my full Alchymine report") — no coordinators were invoked
  - Intake data (name, birth date, assessment responses) was received by the API but never passed to the Celery task
  - Engine graph nodes got empty `request_data` so all calculations were silently skipped
- **Fix**: Added intention-based routing that maps user intentions directly to system coordinators, pass full intake data through the pipeline, and harden error handling in the task runner
- 7 new tests added, all 1894 existing tests still pass

## Changes

| File | Change |
|------|--------|
| `intent.py` | New `intentions_to_systems()` maps intention values → SystemIntent coordinators |
| `orchestrator.py` | Bypasses keyword classification when explicit intentions provided |
| `reports.py` | Passes full `IntakeData` dict as `user_profile` to Celery task |
| `tasks.py` | Wraps `_db_set_failed` in try/except to prevent silent error handler crashes |
| `test_orchestrator.py` | 7 new tests for intention mapping and routing |

## Test plan

- [x] All 1894 existing tests pass
- [x] 7 new tests for `intentions_to_systems` and intention-based orchestrator routing
- [x] Ruff check + format clean
- [ ] Deploy to production and verify intake form → report generation flow completes
- [ ] Verify reports transition from `pending` → `generating` → `complete`

🤖 Generated with [Claude Code](https://claude.com/claude-code)