### PR TITLE
fix: report flow status mismatch, discover nav, disable 422 endpoints

### DIFF
--- a/alchymine/web/src/app/creative/page.tsx
+++ b/alchymine/web/src/app/creative/page.tsx
@@ -116,24 +116,14 @@ export default function CreativePage() {
 
   const intakeKey = intake?.intentions?.join(",") ?? intake?.intention ?? "";
 
-  const style = useApi<StyleFingerprintResponse>(
-    hasIntake
-      ? () =>
-          getCreativeStyle({
-            intention: intake!.intentions?.[0] ?? intake!.intention,
-          })
-      : null,
-    [intakeKey],
-  );
+  // NOTE: Creative endpoints require computed profile data (guilford_scores,
+  // creative_dna) that only exists after report generation.  Raw intake data
+  // causes 422 errors.  Disabled until we plumb report-derived data into
+  // these pages.
+  const style = useApi<StyleFingerprintResponse>(null, [intakeKey]);
 
   const projects = useApi<ProjectListResponse>(
-    hasIntake
-      ? () =>
-          getCreativeProjects({
-            intention: intake!.intentions?.[0] ?? intake!.intention,
-            style: style.data?.creative_style,
-          })
-      : null,
+    null,
     [intakeKey, style.data?.creative_style],
   );
 

--- a/alchymine/web/src/app/discover/generating/[id]/page.tsx
+++ b/alchymine/web/src/app/discover/generating/[id]/page.tsx
@@ -124,7 +124,7 @@ export default function GeneratingPage() {
     pollRef.current = setInterval(async () => {
       try {
         const report = await getReport(reportId);
-        if (report.status === "completed") {
+        if (report.status === "complete") {
           setOverallProgress(100);
           if (pollRef.current) clearInterval(pollRef.current);
           if (animationRef.current) clearInterval(animationRef.current);

--- a/alchymine/web/src/app/perspective/page.tsx
+++ b/alchymine/web/src/app/perspective/page.tsx
@@ -134,15 +134,11 @@ export default function PerspectivePage() {
 
   const intakeKey = intake?.intentions?.join(",") ?? intake?.intention ?? "";
 
-  const kegan = useApi<KeganAssessResponse>(
-    hasIntake
-      ? () =>
-          getKeganAssessment({
-            intention: intake!.intentions?.[0] ?? intake!.intention,
-          })
-      : null,
-    [intakeKey],
-  );
+  // NOTE: Kegan endpoint requires computed assessment responses
+  // (dimension scores 1-5) that only exist after report generation.
+  // Raw intake data causes 422 errors.  Disabled until we plumb
+  // report-derived data into these pages.
+  const kegan = useApi<KeganAssessResponse>(null, [intakeKey]);
 
   return (
     <ProtectedRoute>

--- a/alchymine/web/src/app/wealth/page.tsx
+++ b/alchymine/web/src/app/wealth/page.tsx
@@ -669,18 +669,22 @@ export default function WealthPage() {
   const intakeIntentions =
     intake?.intentions ?? (intake?.intention ? [intake.intention] : []);
 
+  // NOTE: Wealth endpoints require computed profile data (life_path,
+  // archetype_primary, risk_tolerance) that only exists after report
+  // generation.  Raw intake data causes 422 errors.  Disabled until we
+  // plumb report-derived data into these pages.
   const wealthProfile = useApi<WealthProfileResponse>(
-    hasIntake ? () => getWealthProfile({ intentions: intakeIntentions }) : null,
+    null,
     [intakeIntentions.join(",")],
   );
 
   const levers = useApi<LeverResponse>(
-    hasIntake ? () => getWealthLevers({ intentions: intakeIntentions }) : null,
+    null,
     [intakeIntentions.join(",")],
   );
 
   const wealthPlan = useApi<WealthPlanResponse>(
-    hasIntake ? () => getWealthPlan({ intentions: intakeIntentions }) : null,
+    null,
     [intakeIntentions.join(",")],
   );
 

--- a/alchymine/web/src/components/shared/Navigation.tsx
+++ b/alchymine/web/src/components/shared/Navigation.tsx
@@ -21,6 +21,12 @@ const NAV_ITEMS: NavItem[] = [
     label: "Dashboard overview",
   },
   {
+    name: "Discover",
+    href: "/discover",
+    icon: "spiral",
+    label: "Intake and assessment flow",
+  },
+  {
     name: "Intelligence",
     href: "/intelligence",
     icon: "brain",
@@ -88,6 +94,24 @@ function NavIcon({
         >
           <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
           <polyline points="9 22 9 12 15 12 15 22" />
+        </svg>
+      );
+    case "spiral":
+      return (
+        <svg
+          className={baseClass}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M12 22c-4.97 0-9-4.03-9-9 0-3.87 2.55-7.16 6-8.27" />
+          <path d="M12 18a6 6 0 0 1-6-6c0-2.58 1.67-4.78 4-5.6" />
+          <path d="M12 14a2 2 0 0 1-2-2c0-.87.56-1.61 1.33-1.89" />
+          <circle cx="12" cy="12" r="1" fill="currentColor" />
         </svg>
       );
     case "brain":
@@ -515,6 +539,7 @@ export default function Navigation() {
                     {(
                       {
                         Dashboard: "Home",
+                        Discover: "Discover",
                         Intelligence: "Mind",
                         Healing: "Heal",
                         Wealth: "Wealth",

--- a/alchymine/web/src/lib/api.ts
+++ b/alchymine/web/src/lib/api.ts
@@ -24,7 +24,7 @@ export interface ReportRequest {
 
 export interface ReportStatus {
   id: string;
-  status: "queued" | "generating" | "completed" | "failed";
+  status: "pending" | "generating" | "complete" | "failed";
   progress: number;
   created_at: string;
   completed_at: string | null;


### PR DESCRIPTION
## Summary

- **Fix critical report status mismatch**: The generating page polled for `report.status === "completed"` but the backend sets status to `"complete"`. This caused the page to stay stuck at "Still Processing" **forever**, even after successful report generation. Also fixes the `ReportStatus` TypeScript type (`"queued"` → `"pending"`, `"completed"` → `"complete"`).
- **Add Discover link to navigation**: Users had no way to return to the intake/assessment flow (`/discover`) after navigating away. Added "Discover" item with spiral icon to both desktop sidebar and mobile navigation.
- **Disable broken dashboard API calls**: The wealth, creative, and perspective pages sent raw intake data (just `intention` string) to endpoints requiring computed profile data (`life_path`, `guilford_scores`, `kegan_responses`), producing 422 errors. Disabled these calls with explanatory comments — pages now show their static educational content without errors.

## Test plan

- [x] TypeScript type-check passes (`npx tsc --noEmit`)
- [x] All 184 frontend tests pass (`npx jest`)
- [ ] Verify generating page transitions to report view when backend returns `status: "complete"`
- [ ] Verify "Discover" link appears in sidebar and mobile nav
- [ ] Verify wealth/creative/perspective pages load without 422 errors
- [ ] Deploy with PR #72 (backend fix) for full end-to-end intake → report flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)