### PR TITLE
fix: createReport no longer throws on 202 success response

### DIFF
--- a/alchymine/web/src/lib/api.ts
+++ b/alchymine/web/src/lib/api.ts
@@ -316,7 +316,11 @@ function getLegacyAuthHeaders(): Record<string, string> {
   return token ? { Authorization: `Bearer ${token}` } : {};
 }
 
-async function request<T>(url: string, options?: RequestInit): Promise<T> {
+async function request<T>(
+  url: string,
+  options?: RequestInit,
+  allow202 = false,
+): Promise<T> {
   const res = await fetch(url, {
     ...options,
     credentials: "include",
@@ -327,8 +331,10 @@ async function request<T>(url: string, options?: RequestInit): Promise<T> {
     },
   });
 
-  // 202 is used for "still generating" status — we handle it differently
-  if (res.status === 202) {
+  // 202 is used for "still generating" status — throw so callers can
+  // handle polling.  Callers that expect 202 as a success (e.g. report
+  // creation) pass allow202=true to receive the parsed body instead.
+  if (res.status === 202 && !allow202) {
     const body = await res.json();
     throw new ApiError(202, body.detail || "Still processing");
   }
@@ -389,10 +395,14 @@ export async function createReport(
   modules: string[] = ["full"],
   tone: string = "balanced",
 ): Promise<ReportStatus> {
-  return request<ReportStatus>(`${BASE}/reports`, {
-    method: "POST",
-    body: JSON.stringify({ intake, modules, tone }),
-  });
+  return request<ReportStatus>(
+    `${BASE}/reports`,
+    {
+      method: "POST",
+      body: JSON.stringify({ intake, modules, tone }),
+    },
+    true, // POST /reports returns 202 on success — don't throw
+  );
 }
 
 export async function getReport(id: string): Promise<ReportResponse> {

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -64,8 +64,7 @@ def _clear_rate_limit_state(obj: object) -> None:
     from alchymine.api.middleware import RateLimitMiddleware
 
     if isinstance(obj, RateLimitMiddleware):
-        # The rate limiter may use an in-memory dict or Redis.
-        # Clear the in-memory store if present; otherwise skip.
+        # Clear both the legacy _requests dict and the current _local_counts dict.
         requests_dict = getattr(obj, "_requests", None)
         if requests_dict is not None:
             requests_dict.clear()


### PR DESCRIPTION
## Summary

- **Root cause**: The generic `request()` function in `api.ts` threw `ApiError(202)` for ALL 202 responses. But `POST /api/v1/reports` returns 202 on success (the report is queued). So `createReport()` always threw, the catch block showed "Still processing" as an error, and the user never got redirected to the generating page.
- **Fix**: Added `allow202` parameter to `request()`. `createReport()` now passes `true` to treat 202 as a successful response and parse the body (which contains the report ID).
- The `getReport()` polling path is unaffected — it still throws on 202 so the caller can handle the retry loop.

## Impact

This was the critical bug preventing the entire intake → assessment → report flow from working. The backend was correctly creating reports, but the frontend discarded the response.

## Test plan

- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] Frontend builds (`npm run build`)
- [x] 184 frontend tests pass (`npm test`)
- [x] 1952 backend tests pass (`pytest tests/ -x -q`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)