### PR TITLE
fix: disable arm64 for web Docker build (QEMU segfault)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,18 +78,23 @@ jobs:
           - image: api
             context: .
             dockerfile: infrastructure/docker/Dockerfile.api
+            platforms: linux/amd64,linux/arm64
             build_args: ""
           - image: web
             context: .
             dockerfile: infrastructure/docker/Dockerfile.web
+            # arm64 disabled: QEMU-emulated npm ci segfaults on GitHub Actions
+            platforms: linux/amd64
             build_args: APP_VERSION=${{ needs.validate.outputs.version }}
           - image: worker
             context: .
             dockerfile: infrastructure/docker/Dockerfile.worker
+            platforms: linux/amd64,linux/arm64
             build_args: ""
           - image: pdf
             context: .
             dockerfile: infrastructure/docker/Dockerfile.pdf
+            platforms: linux/amd64,linux/arm64
             build_args: ""
     steps:
       - uses: actions/checkout@v4
@@ -124,7 +129,7 @@ jobs:
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platforms }}
           push: true
           tags: ${{ steps.docker-meta.outputs.tags }}
           labels: |


### PR DESCRIPTION
## Summary

- The Release workflow `Build & Push: web` job hangs indefinitely because QEMU-emulated `npm ci` segfaults on arm64 (`qemu: uncaught target signal 11 (Segmentation fault)`)
- Root cause: `platforms: linux/amd64,linux/arm64` was hardcoded for all images, but the web image's heavy `npm ci` step is incompatible with QEMU arm64 emulation on GitHub Actions runners
- Fix: Made `platforms` a per-image matrix variable. Web builds `linux/amd64` only; api/worker/pdf keep `linux/amd64,linux/arm64`
- The deployment target (DigitalOcean droplet) is amd64 — arm64 web images were never used

## Test plan

- [x] Verified the cancelled run (22802021087) shows web stuck at arm64 `npm ci` with QEMU segfault
- [x] api, worker, pdf images all completed successfully with both platforms
- [x] Workflow YAML is valid (matrix.platforms referenced correctly in build step)
- [ ] Re-run release after merge to confirm web builds complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)