### PR TITLE
fix: use full natal chart with birth_time and birth_city

### DIFF
--- a/alchymine/agents/orchestrator/graphs.py
+++ b/alchymine/agents/orchestrator/graphs.py
@@ -198,22 +198,30 @@ def _intelligence_astrology(state: CoordinatorState) -> CoordinatorState:
 
     try:
         from datetime import date as date_type
+        from datetime import time as time_type
 
-        from alchymine.engine.astrology import (
-            approximate_sun_degree,
-            approximate_sun_sign,
-        )
+        from alchymine.engine.astrology import calculate_natal_chart
 
         birth_date = request_data.get("birth_date")
         if birth_date:
             if isinstance(birth_date, str):
                 birth_date = date_type.fromisoformat(birth_date)
-            sun_sign = approximate_sun_sign(birth_date)
-            sun_degree = approximate_sun_degree(birth_date)
-            results["astrology"] = {
-                "sun_sign": sun_sign,
-                "sun_degree": sun_degree,
-            }
+
+            # Extract optional birth_time and birth_city for full chart
+            birth_time = request_data.get("birth_time")
+            if isinstance(birth_time, str) and birth_time:
+                birth_time = time_type.fromisoformat(birth_time)
+            elif not isinstance(birth_time, time_type):
+                birth_time = None
+
+            birth_city = request_data.get("birth_city")
+
+            chart = calculate_natal_chart(
+                birth_date,
+                birth_time=birth_time,
+                birth_city=birth_city,
+            )
+            results["astrology"] = chart
         else:
             errors.append("Intelligence: missing birth_date for astrology")
     except ImportError:

--- a/alchymine/agents/orchestrator/orchestrator.py
+++ b/alchymine/agents/orchestrator/orchestrator.py
@@ -167,6 +167,7 @@ class MasterOrchestrator:
                 numerology = result.data.get("numerology", {})
                 archetype_data = result.data.get("archetype", {})
                 personality_data = result.data.get("personality", {})
+                astrology_data = result.data.get("astrology", {})
                 if numerology.get("life_path"):
                     request_data["life_path"] = numerology["life_path"]
                 if archetype_data.get("primary"):
@@ -175,6 +176,14 @@ class MasterOrchestrator:
                     request_data["archetype_secondary"] = archetype_data.get("secondary")
                 if personality_data:
                     request_data["big_five"] = personality_data
+                if astrology_data:
+                    request_data["astrology"] = astrology_data
+                    if astrology_data.get("sun_sign"):
+                        request_data["sun_sign"] = astrology_data["sun_sign"]
+                    if astrology_data.get("moon_sign"):
+                        request_data["moon_sign"] = astrology_data["moon_sign"]
+                    if astrology_data.get("rising_sign"):
+                        request_data["rising_sign"] = astrology_data["rising_sign"]
 
         # Synthesize if multi-system
         synthesis = None

--- a/tests/agents/test_graphs.py
+++ b/tests/agents/test_graphs.py
@@ -249,7 +249,7 @@ class TestIntelligenceGraphTransitions:
                 return_value=mock_profile,
             ),
             patch(
-                "alchymine.engine.astrology.approximate_sun_sign",
+                "alchymine.engine.astrology.calculate_natal_chart",
                 side_effect=ImportError("swisseph not installed"),
             ),
         ):


### PR DESCRIPTION
## Summary

- **Astrology node upgraded**: Replaced `approximate_sun_sign()` + `approximate_sun_degree()` with `calculate_natal_chart(birth_date, birth_time, birth_city)` — now computes moon sign, rising sign, planetary aspects, and house placements when birth time/city are provided
- **Downstream enrichment**: Orchestrator now passes `sun_sign`, `moon_sign`, `rising_sign`, and full `astrology` dict to Healing, Wealth, Creative, and Perspective coordinators
- **Test updated**: Mock target changed to `calculate_natal_chart`

## What was broken

Users who entered their birth time and city during intake got **only** a sun sign approximation. The full `calculate_natal_chart()` engine function — which supports moon sign, rising sign, aspects, house cusps — was never called by the report pipeline.

## Test plan

- [x] `ruff check` — 0 errors
- [x] `pytest tests/` — 1952 passed
- [x] Graph tests (50 passed) — including degraded astrology scenario
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)