### PR TITLE
chore: move langgraph to optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,6 @@ dependencies = [
     # LLM
     "anthropic>=0.40.0",
     "httpx>=0.28.0",
-    # Agents / Graphs
-    "langgraph>=0.2.0",
     # Email
     "resend>=2.0.0",
     # Utilities
@@ -45,6 +43,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+agents = [
+    "langgraph>=0.2.0",
+]
 mcp = [
     "mcp>=1.0.0",
 ]

--- a/tests/agents/test_graphs.py
+++ b/tests/agents/test_graphs.py
@@ -1053,6 +1053,7 @@ class TestSequentialFallback:
         result = graph.invoke({"count": 0})
         assert result["count"] == 11  # 0 + 1 + 10
 
+    @pytest.mark.skipif(not _HAS_LANGGRAPH, reason="langgraph not installed")
     def test_sequential_fallback_matches_langgraph(self) -> None:
         """Sequential fallback produces the same result as LangGraph for a simple case."""
         state = _make_initial_state(request_data={})
@@ -1090,11 +1091,11 @@ class TestSequentialFallback:
 
 
 class TestLangGraphAvailability:
-    """Verify that langgraph is detected correctly."""
+    """Verify that langgraph detection works correctly."""
 
-    def test_langgraph_is_available(self) -> None:
-        """In this test environment, langgraph should be installed."""
-        assert _HAS_LANGGRAPH is True
+    def test_langgraph_flag_is_bool(self) -> None:
+        """_HAS_LANGGRAPH is a boolean reflecting whether the optional dep is installed."""
+        assert isinstance(_HAS_LANGGRAPH, bool)
 
     def test_coordinator_state_is_typed_dict(self) -> None:
         """CoordinatorState is a TypedDict subclass."""


### PR DESCRIPTION
## Summary

Closes #122.

- **Moved `langgraph>=0.2.0` from core to optional deps** (`pip install alchymine[agents]`)
- All 5 coordinator graphs use strictly linear pipelines — the existing `_SequentialGraph` fallback (20 lines) handles this identically
- langgraph pulls in the entire LangChain ecosystem for zero added value in current usage
- Can be re-promoted to core if non-linear graph topologies are needed in the future

## Changes

- `pyproject.toml`: moved langgraph from `dependencies` → `[project.optional-dependencies.agents]`
- `tests/agents/test_graphs.py`: skipif guard on test requiring langgraph; relaxed availability assertion to boolean check

## Test plan

- [x] All 1904 tests pass locally
- [x] ruff lint clean
- [ ] CI confirms green

🤖 Generated with [Claude Code](https://claude.com/claude-code)