### PR TITLE
fix: resolve POST /reports 500 — session isolation for intake persistence

### DIFF
--- a/alchymine/api/routers/reports.py
+++ b/alchymine/api/routers/reports.py
@@ -122,9 +122,10 @@ async def create_report(
     report_id = str(uuid.uuid4())
     now = datetime.now(UTC).isoformat()
 
-    # Persist the report row so status queries work immediately.
-    # Commit explicitly before dispatching the Celery task so the
-    # task (which uses its own session) can find the row.
+    # Persist the report row and commit immediately so:
+    # 1. Status queries work right away
+    # 2. The Celery task (which uses its own session) can find the row
+    # 3. Optional intake persistence below can't corrupt this transaction
     await repository.create_report(
         session,
         report_id=report_id,
@@ -133,9 +134,11 @@ async def create_report(
         user_profile=request.user_profile,
         user_id=current_user["sub"],
     )
+    await session.commit()
 
     # Persist the intake data to the user's profile so it survives across
     # devices and sessions (sessionStorage is browser-tab-scoped).
+    # This is best-effort — failures must never block report creation.
     try:
         intake_persist = request.intake.model_dump(mode="json")
         # Convert date/time strings back to proper types for the ORM
@@ -151,19 +154,20 @@ async def create_report(
         if hasattr(intake_persist.get("intention"), "value"):
             intake_persist["intention"] = intake_persist["intention"]
         await repository.update_layer(session, current_user["sub"], "intake", intake_persist)
+        await session.commit()
     except LookupError:
         # User row doesn't exist — JWT sub doesn't match a DB user.
+        await session.rollback()
         logger.warning(
             "Cannot persist intake for user %s: user row not found in DB",
             current_user["sub"],
         )
     except Exception:
+        await session.rollback()
         logger.exception(
             "Failed to persist intake data for user %s",
             current_user["sub"],
         )
-
-    await session.commit()
 
     # Build a profile dict from the intake data so the orchestrator's
     # engine nodes have the fields they need (full_name, birth_date, etc.)

--- a/tests/api/test_reports_router.py
+++ b/tests/api/test_reports_router.py
@@ -419,9 +419,57 @@ class TestIntakePersistence:
         assert resp.status_code == 202
         assert any("user row not found" in r.message for r in caplog.records)
 
-    def test_intake_retrievable_via_profile_after_report(
-        self, seeded_client, engine
+    def test_post_reports_returns_202_when_update_layer_raises(self, client: TestClient) -> None:
+        """POST /reports must return 202 even if update_layer raises an unexpected DB error.
+
+        This is the root-cause regression test for the production 500.
+        Previously, update_layer failures would dirty the SQLAlchemy session,
+        and the subsequent session.commit() would raise PendingRollbackError,
+        turning the whole request into a 500.
+        """
+        payload = _intake_report_payload()
+        with patch(
+            "alchymine.api.routers.reports.repository.update_layer",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("simulated DB error in update_layer"),
+        ):
+            resp = client.post("/api/v1/reports", json=payload)
+        assert resp.status_code == 202, f"Expected 202, got {resp.status_code}: {resp.text}"
+        data = resp.json()
+        assert data["status"] == "pending"
+        assert "id" in data
+
+    def test_post_reports_report_persisted_despite_update_layer_failure(
+        self, client: TestClient, engine
     ) -> None:
+        """The report row must be committed even when intake persistence fails."""
+        payload = _intake_report_payload()
+        with patch(
+            "alchymine.api.routers.reports.repository.update_layer",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("simulated DB error"),
+        ):
+            resp = client.post("/api/v1/reports", json=payload)
+        assert resp.status_code == 202
+        report_id = resp.json()["id"]
+
+        # Verify the report row was actually committed to the DB
+        from alchymine.workers.tasks import _run_async
+
+        async def _check():
+            from alchymine.db.base import get_async_session_factory
+
+            factory = get_async_session_factory(engine)
+            async with factory() as sess:
+                return await repository.get_report(sess, report_id)
+
+        report = _run_async(_check())
+        assert report is not None, "Report row should exist despite update_layer failure"
+        # In eager mode, the Celery task runs synchronously and may update
+        # the status before we check.  The key assertion is the row exists.
+        assert report.status in ("pending", "generating", "complete", "failed")
+
+    def test_intake_retrievable_via_profile_after_report(self, seeded_client, engine) -> None:
         """After POST /reports, GET /profile/{id} should return saved intake data."""
         payload = _intake_report_payload()
         resp = seeded_client.post("/api/v1/reports", json=payload)


### PR DESCRIPTION
## Summary

- **Root cause**: When `update_layer()` failed during optional intake persistence (no user row, DB error, encryption issue), the SQLAlchemy session entered a dirty state. The `except` blocks caught the Python exception but didn't rollback the session. The subsequent `session.commit()` raised `PendingRollbackError`, which the error middleware returned as a generic 500.
- **Fix**: Commit the report row **first** before attempting intake persistence. Intake persistence now runs in its own try/commit/rollback block, so failures can never corrupt the report transaction.
- Added 2 regression tests that mock `update_layer` to raise and verify the endpoint still returns 202 with a persisted report row.

## What changed

| File | Change |
|------|--------|
| `alchymine/api/routers/reports.py` | Move `session.commit()` immediately after `create_report()`. Wrap intake persistence in separate commit/rollback. |
| `tests/api/test_reports_router.py` | Add `test_post_reports_returns_202_when_update_layer_raises` and `test_post_reports_report_persisted_despite_update_layer_failure` |

## Test plan

- [x] All 23 reports router tests pass (including 2 new regression tests)
- [x] Full test suite: 1231 passed, 0 failures
- [x] `ruff check` + `ruff format` clean
- [ ] CI green on this PR
- [ ] Deploy and verify POST /reports returns 202 for user `6160d894-68ec-46d2-8098-578995262b85`

🤖 Generated with [Claude Code](https://claude.com/claude-code)