### PR TITLE
fix: resolve 429 polling errors and frozen progress during report generation

### DIFF
--- a/alchymine/api/middleware.py
+++ b/alchymine/api/middleware.py
@@ -134,9 +134,11 @@ TRUSTED_PROXY_NETWORKS: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = [
 ]
 
 # Default per-prefix limits: (max_requests, window_seconds)
+# Order matters — first match wins.
 DEFAULT_ROUTE_LIMITS: dict[str, tuple[int, int]] = {
     "/api/v1/auth/": (20, 60),
     "/api/v1/admin/": (30, 60),
+    "/api/v1/reports/": (200, 60),  # Higher limit for report status polling
     "/api/v1/": (100, 60),
 }
 

--- a/alchymine/web/src/app/discover/generating/[id]/page.tsx
+++ b/alchymine/web/src/app/discover/generating/[id]/page.tsx
@@ -6,11 +6,11 @@ import { getReport, ApiError } from "@/lib/api";
 import { MotionReveal } from "@/components/shared/MotionReveal";
 
 const GENERATION_STEPS = [
-  { label: "Calculating numerology...", icon: "numerology", duration: 2000 },
-  { label: "Mapping astrology...", icon: "astrology", duration: 3000 },
-  { label: "Analyzing personality...", icon: "personality", duration: 2500 },
-  { label: "Mapping archetypes...", icon: "archetype", duration: 2000 },
-  { label: "Building your profile...", icon: "profile", duration: 3000 },
+  { label: "Calculating numerology...", icon: "numerology", duration: 8000 },
+  { label: "Mapping astrology...", icon: "astrology", duration: 12000 },
+  { label: "Analyzing personality...", icon: "personality", duration: 10000 },
+  { label: "Mapping archetypes...", icon: "archetype", duration: 10000 },
+  { label: "Building your profile...", icon: "profile", duration: 20000 },
 ];
 
 function StepIcon({ icon, className }: { icon: string; className?: string }) {
@@ -78,7 +78,7 @@ export default function GeneratingPage() {
   const [currentStep, setCurrentStep] = useState(0);
   const [overallProgress, setOverallProgress] = useState(0);
   const [error, setError] = useState<string | null>(null);
-  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const animationRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   // Animate through the visual steps
@@ -121,31 +121,49 @@ export default function GeneratingPage() {
   useEffect(() => {
     if (!reportId) return;
 
-    pollRef.current = setInterval(async () => {
+    let delay = 4000; // Start at 4s, back off on 429
+    let stopped = false;
+
+    const poll = async () => {
+      if (stopped) return;
       try {
         const report = await getReport(reportId);
         if (report.status === "complete") {
           setOverallProgress(100);
-          if (pollRef.current) clearInterval(pollRef.current);
+          stopped = true;
           if (animationRef.current) clearInterval(animationRef.current);
           setTimeout(() => {
             router.push(`/discover/report/${reportId}`);
           }, 800);
+          return;
         } else if (report.status === "failed") {
           setError("Report generation failed. Please try again.");
-          if (pollRef.current) clearInterval(pollRef.current);
+          stopped = true;
           if (animationRef.current) clearInterval(animationRef.current);
-        }
-      } catch (err) {
-        if (err instanceof ApiError && err.status === 202) {
           return;
         }
-        console.error("Polling error:", err);
+        // Reset delay on success
+        delay = 4000;
+      } catch (err) {
+        if (err instanceof ApiError && err.status === 202) {
+          // Still generating — normal
+        } else if (err instanceof ApiError && err.status === 429) {
+          // Rate limited — back off
+          delay = Math.min(delay * 2, 30000);
+        } else {
+          console.error("Polling error:", err);
+        }
       }
-    }, 2000);
+      if (!stopped) {
+        pollRef.current = setTimeout(poll, delay);
+      }
+    };
+
+    pollRef.current = setTimeout(poll, delay);
 
     return () => {
-      if (pollRef.current) clearInterval(pollRef.current);
+      stopped = true;
+      if (pollRef.current) clearTimeout(pollRef.current);
     };
   }, [reportId, router]);
 


### PR DESCRIPTION
## Summary
- **Rate limiter**: Added `/api/v1/reports/` prefix with 200 req/60s (vs 100 for general `/api/v1/`). Status polling was exhausting the shared rate limit, causing 429 errors during generation.
- **Polling backoff**: Switched from fixed 2s `setInterval` to adaptive `setTimeout` starting at 4s. On 429, doubles delay up to 30s max. Resets to 4s on successful response.
- **Progress animation**: Extended step durations from 12.5s total to 60s total. The progress bar caps at 90% while waiting for backend LLM narrative generation (typically 30-120s) — the old 12.5s animation hit 90% almost immediately, making it look frozen.

## Root cause
The generating page polled `GET /reports/{id}` every 2 seconds (30 req/min), sharing a 100 req/60s limit with all other `/api/v1/` traffic. After ~3 minutes of polling, rate limit was exhausted. Meanwhile, the progress animation finished in 12.5s and froze at 90%.

## Test plan
- [x] All 1944 tests pass
- [x] TypeScript compiles clean
- [x] 23 middleware tests pass (rate limit tests)
- [ ] After deploy: generate report, verify no 429 errors and smooth progress animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)