### PR TITLE
feat: structured logging across LLM pipeline

### DIFF
--- a/alchymine/llm/client.py
+++ b/alchymine/llm/client.py
@@ -352,31 +352,43 @@ class LLMClient:
             self._last_backend = LLMBackend.NONE.value
             return self._fallback_response()
 
+        import time as _time
+
         # Try Claude first
         if self._forced_backend in (None, LLMBackend.CLAUDE) and self._anthropic_key:
             try:
+                logger.info("[LLM] Sending request to Claude (max_tokens=%d, temp=%.1f)", max_tokens, temperature)
+                t0 = _time.monotonic()
                 result = await self._generate_claude(
                     system_prompt, user_prompt, max_tokens, temperature
                 )
+                elapsed = _time.monotonic() - t0
                 self._last_backend = LLMBackend.CLAUDE.value
-                logger.info("LLM generation completed via Claude backend")
+                logger.info(
+                    "[LLM] Claude response received in %.1fs — model=%s, in=%d tok, out=%d tok",
+                    elapsed, result.model, result.input_tokens, result.output_tokens,
+                )
                 return result
             except Exception as exc:
-                logger.warning("Claude API failed, trying Ollama fallback: %s", exc)
+                logger.warning("[LLM] Claude API failed: %s — trying Ollama fallback", exc)
 
         # Try Ollama
         if self._forced_backend in (None, LLMBackend.OLLAMA):
             try:
+                logger.info("[LLM] Sending request to Ollama at %s", self._ollama_url)
+                t0 = _time.monotonic()
                 result = await self._generate_ollama(
                     system_prompt, user_prompt, max_tokens, temperature
                 )
+                elapsed = _time.monotonic() - t0
                 self._last_backend = LLMBackend.OLLAMA.value
-                logger.info("LLM generation completed via Ollama backend")
+                logger.info("[LLM] Ollama response received in %.1fs", elapsed)
                 return result
             except Exception as exc:
-                logger.warning("Ollama failed: %s", exc)
+                logger.warning("[LLM] Ollama failed: %s", exc)
 
         # Graceful degradation
+        logger.warning("[LLM] All backends exhausted — returning static fallback response")
         self._last_backend = LLMBackend.NONE.value
         return self._fallback_response()
 
@@ -518,6 +530,7 @@ class LLMClient:
 
         for model in self.CLAUDE_MODELS:
             try:
+                logger.info("[LLM] Trying Claude model: %s", model)
                 response = await client.messages.create(
                     model=model,
                     max_tokens=max_tokens,
@@ -531,7 +544,10 @@ class LLMClient:
                     if hasattr(block, "text"):
                         text += block.text
 
-                logger.info("Claude generation succeeded with model %s", model)
+                logger.info(
+                    "[LLM] Claude model %s succeeded — %d input tokens, %d output tokens",
+                    model, response.usage.input_tokens, response.usage.output_tokens,
+                )
                 return LLMResponse(
                     text=text,
                     backend=LLMBackend.CLAUDE.value,

--- a/alchymine/llm/narrative.py
+++ b/alchymine/llm/narrative.py
@@ -186,10 +186,15 @@ class NarrativeGenerator:
         disclaimers = template.get("disclaimers", [])
 
         # Generate
+        logger.info("[narrative] Requesting LLM narrative for system=%s", system)
         llm_response = await self._client.generate(
             system_prompt=system_prompt,
             user_prompt=user_prompt,
             temperature=temperature,
+        )
+        logger.info(
+            "[narrative] Received narrative for system=%s — backend=%s, model=%s, %d chars",
+            system, llm_response.backend, llm_response.model, len(llm_response.text),
         )
 
         # Validate ethics
@@ -232,10 +237,16 @@ class NarrativeGenerator:
             Map of system name → NarrativeResult.
         """
         import asyncio
+        import time as _time
+
+        logger.info("[narrative] Generating narratives for %d systems: %s", len(systems), systems)
+        t0 = _time.monotonic()
 
         async def _gen(system: str) -> tuple[str, NarrativeResult]:
             system_data = engine_data.get(system, engine_data)
             return system, await self.generate(system, system_data)
 
         pairs = await asyncio.gather(*[_gen(s) for s in systems])
+        elapsed = _time.monotonic() - t0
+        logger.info("[narrative] All %d narratives complete in %.1fs", len(systems), elapsed)
         return dict(pairs)

--- a/alchymine/workers/tasks.py
+++ b/alchymine/workers/tasks.py
@@ -391,6 +391,10 @@ def generate_report(
 
     try:
         # ── Run the async orchestrator ────────────────────────────────
+        import time as _time
+
+        logger.info("[task] Report %s: starting orchestrator (deterministic engines)", report_id)
+        t0 = _time.monotonic()
         orchestrator = MasterOrchestrator()
         result = _run_async(
             orchestrator.process_request(
@@ -400,6 +404,7 @@ def generate_report(
                 intentions=_resolved_intentions,
             )
         )
+        logger.info("[task] Report %s: orchestrator complete in %.1fs", report_id, _time.monotonic() - t0)
 
         serialised = _serialise_orchestrator_result(result)
 
@@ -427,7 +432,16 @@ def generate_report(
                     engine_data[cr.system] = cr.data
 
             if systems:
+                logger.info(
+                    "[task] Report %s: starting LLM narrative generation for %d systems: %s",
+                    report_id, len(systems), systems,
+                )
+                t_narr = _time.monotonic()
                 narratives = _run_async(generator.generate_all(systems, engine_data))
+                logger.info(
+                    "[task] Report %s: narrative generation complete in %.1fs",
+                    report_id, _time.monotonic() - t_narr,
+                )
                 serialised["narratives"] = {
                     system: {
                         "text": nr.narrative,
@@ -437,8 +451,16 @@ def generate_report(
                     for system, nr in narratives.items()
                     if nr.narrative
                 }
+                logger.info(
+                    "[task] Report %s: %d narratives stored (backends: %s)",
+                    report_id,
+                    len(serialised["narratives"]),
+                    {s: nr.llm_response.model if nr.llm_response else "none" for s, nr in narratives.items()},
+                )
+            else:
+                logger.warning("[task] Report %s: no systems available for narrative generation", report_id)
         except Exception as exc:
-            logger.warning("Narrative generation failed (non-fatal): %s", exc)
+            logger.warning("[task] Report %s: narrative generation failed (non-fatal): %s", report_id, exc)
 
         # ── Safety content filter on LLM-generated narratives ─────────
         # Resolve user_id early for audit logging


### PR DESCRIPTION
## Summary

- Adds `[task]`, `[narrative]`, and `[LLM]` prefixed log messages across the full report generation pipeline
- Logs orchestrator timing, narrative generation per-system, Claude model attempts/fallbacks, and token counts
- Enables end-to-end visibility into why reports succeed, fail, or hang

## Test plan

- [x] All 1944 tests pass
- [x] Ruff lint passes
- [ ] Deploy and verify logs appear in worker output during report generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)