### PR TITLE
style: fix ruff format violations in LLM pipeline logging

### DIFF
--- a/alchymine/llm/client.py
+++ b/alchymine/llm/client.py
@@ -357,7 +357,11 @@ class LLMClient:
         # Try Claude first
         if self._forced_backend in (None, LLMBackend.CLAUDE) and self._anthropic_key:
             try:
-                logger.info("[LLM] Sending request to Claude (max_tokens=%d, temp=%.1f)", max_tokens, temperature)
+                logger.info(
+                    "[LLM] Sending request to Claude (max_tokens=%d, temp=%.1f)",
+                    max_tokens,
+                    temperature,
+                )
                 t0 = _time.monotonic()
                 result = await self._generate_claude(
                     system_prompt, user_prompt, max_tokens, temperature
@@ -366,7 +370,10 @@ class LLMClient:
                 self._last_backend = LLMBackend.CLAUDE.value
                 logger.info(
                     "[LLM] Claude response received in %.1fs — model=%s, in=%d tok, out=%d tok",
-                    elapsed, result.model, result.input_tokens, result.output_tokens,
+                    elapsed,
+                    result.model,
+                    result.input_tokens,
+                    result.output_tokens,
                 )
                 return result
             except Exception as exc:
@@ -546,7 +553,9 @@ class LLMClient:
 
                 logger.info(
                     "[LLM] Claude model %s succeeded — %d input tokens, %d output tokens",
-                    model, response.usage.input_tokens, response.usage.output_tokens,
+                    model,
+                    response.usage.input_tokens,
+                    response.usage.output_tokens,
                 )
                 return LLMResponse(
                     text=text,

--- a/alchymine/llm/narrative.py
+++ b/alchymine/llm/narrative.py
@@ -194,7 +194,10 @@ class NarrativeGenerator:
         )
         logger.info(
             "[narrative] Received narrative for system=%s — backend=%s, model=%s, %d chars",
-            system, llm_response.backend, llm_response.model, len(llm_response.text),
+            system,
+            llm_response.backend,
+            llm_response.model,
+            len(llm_response.text),
         )
 
         # Validate ethics

--- a/alchymine/workers/tasks.py
+++ b/alchymine/workers/tasks.py
@@ -404,7 +404,9 @@ def generate_report(
                 intentions=_resolved_intentions,
             )
         )
-        logger.info("[task] Report %s: orchestrator complete in %.1fs", report_id, _time.monotonic() - t0)
+        logger.info(
+            "[task] Report %s: orchestrator complete in %.1fs", report_id, _time.monotonic() - t0
+        )
 
         serialised = _serialise_orchestrator_result(result)
 
@@ -434,13 +436,16 @@ def generate_report(
             if systems:
                 logger.info(
                     "[task] Report %s: starting LLM narrative generation for %d systems: %s",
-                    report_id, len(systems), systems,
+                    report_id,
+                    len(systems),
+                    systems,
                 )
                 t_narr = _time.monotonic()
                 narratives = _run_async(generator.generate_all(systems, engine_data))
                 logger.info(
                     "[task] Report %s: narrative generation complete in %.1fs",
-                    report_id, _time.monotonic() - t_narr,
+                    report_id,
+                    _time.monotonic() - t_narr,
                 )
                 serialised["narratives"] = {
                     system: {
@@ -455,12 +460,19 @@ def generate_report(
                     "[task] Report %s: %d narratives stored (backends: %s)",
                     report_id,
                     len(serialised["narratives"]),
-                    {s: nr.llm_response.model if nr.llm_response else "none" for s, nr in narratives.items()},
+                    {
+                        s: nr.llm_response.model if nr.llm_response else "none"
+                        for s, nr in narratives.items()
+                    },
                 )
             else:
-                logger.warning("[task] Report %s: no systems available for narrative generation", report_id)
+                logger.warning(
+                    "[task] Report %s: no systems available for narrative generation", report_id
+                )
         except Exception as exc:
-            logger.warning("[task] Report %s: narrative generation failed (non-fatal): %s", report_id, exc)
+            logger.warning(
+                "[task] Report %s: narrative generation failed (non-fatal): %s", report_id, exc
+            )
 
         # ── Safety content filter on LLM-generated narratives ─────────
         # Resolve user_id early for audit logging


### PR DESCRIPTION
## Summary

- Fixes `ruff format --check` failures from PR #141
- No logic changes — formatting only

## Root cause

Our local pre-commit ran `ruff check` (lint rules) but not `ruff format --check` (formatting). CI runs both. We should add `ruff format --check` to local validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)