### PR TITLE
fix: worker not listening on reports queue — root cause of 90% hang

### DIFF
--- a/infrastructure/docker-compose.prod.yml
+++ b/infrastructure/docker-compose.prod.yml
@@ -131,15 +131,16 @@ services:
         required: true
     command: >
       celery -A alchymine.workers.celery_app worker
-      --loglevel=warning
+      --loglevel=${LOG_LEVEL:-info}
       --concurrency=${CELERY_WORKER_CONCURRENCY:-4}
       --max-tasks-per-child=1000
+      --queues=celery,reports
       --without-heartbeat
       --without-gossip
       --without-mingle
     environment:
       - ENVIRONMENT=production
-      - LOG_LEVEL=WARNING
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## Summary

**This is the root cause of reports hanging at 90%.**

The production compose override (`docker-compose.prod.yml`) replaces the base worker `command:` but omitted `--queues=celery,reports`. Without that flag, Celery defaults to only the `celery` queue.

Meanwhile, `celery_app.py` routes `generate_report` to the `reports` queue:
```python
task_routes={
    "alchymine.workers.tasks.generate_report": {"queue": "reports"},
    "alchymine.workers.tasks.generate_pdf_report": {"queue": "reports"},
}
```

**Result:** Tasks go into `reports` queue → worker only listens on `celery` → tasks sit in Redis forever → report stays "pending"/"generating" → frontend polls indefinitely → progress bar stuck at 90%.

**Evidence:** Worker startup logs show only `celery` queue:
```
[queues]
.> celery           exchange=celery(direct) key=celery
```

No task execution logs exist at all — the worker has NEVER processed a report task.

## Changes

- Add `--queues=celery,reports` to production worker command
- Bump worker log level from `WARNING` to `INFO` so `[task]`/`[LLM]`/`[narrative]` pipeline logs are visible

## Test plan

- [ ] CI green
- [ ] After deploy, worker startup shows BOTH queues:
  ```
  [queues]
  .> celery           exchange=celery(direct) key=celery
  .> reports          exchange=reports(direct) key=reports
  ```
- [ ] Submit a report and verify it completes (status goes to "complete")
- [ ] Worker logs show `[task]`, `[LLM]`, `[narrative]` progression

🤖 Generated with [Claude Code](https://claude.com/claude-code)