### PR TITLE
fix: polling timeout, narrative display, coordinator timeouts, deploy rollback

### DIFF
--- a/alchymine/agents/orchestrator/orchestrator.py
+++ b/alchymine/agents/orchestrator/orchestrator.py
@@ -8,6 +8,7 @@ requests and graceful degradation.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import uuid
 from dataclasses import dataclass, field
@@ -156,7 +157,24 @@ class MasterOrchestrator:
             if coordinator is None:
                 logger.warning("No coordinator for system: %s", system)
                 continue
-            result = await coordinator.process(user_id, request_data)
+            try:
+                result = await asyncio.wait_for(
+                    coordinator.process(user_id, request_data),
+                    timeout=120,
+                )
+            except TimeoutError:
+                logger.warning(
+                    "Coordinator %s timed out after 120s for user %s",
+                    system.value,
+                    user_id,
+                )
+                result = CoordinatorResult(
+                    status=CoordinatorStatus.ERROR.value,
+                    system=system.value,
+                    data={},
+                    errors=[f"{system.value} coordinator timed out after 120s"],
+                    quality_passed=False,
+                )
             coordinator_results.append(result)
 
             # After Intelligence completes, enrich request_data with

--- a/alchymine/web/src/app/discover/generating/[id]/page.tsx
+++ b/alchymine/web/src/app/discover/generating/[id]/page.tsx
@@ -78,8 +78,11 @@ export default function GeneratingPage() {
   const [currentStep, setCurrentStep] = useState(0);
   const [overallProgress, setOverallProgress] = useState(0);
   const [error, setError] = useState<string | null>(null);
+  const [networkWarning, setNetworkWarning] = useState<string | null>(null);
   const pollRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const animationRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollStartRef = useRef<number | null>(null);
+  const networkFailuresRef = useRef(0);
 
   // Animate through the visual steps
   useEffect(() => {
@@ -121,11 +124,27 @@ export default function GeneratingPage() {
   useEffect(() => {
     if (!reportId) return;
 
+    const POLL_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+    const MAX_NETWORK_FAILURES = 10;
+    const NETWORK_WARNING_THRESHOLD = 3;
+
     let delay = 4000; // Start at 4s, back off on 429
     let stopped = false;
+    pollStartRef.current = Date.now();
+    networkFailuresRef.current = 0;
 
     const poll = async () => {
       if (stopped) return;
+
+      // Check poll timeout
+      if (Date.now() - (pollStartRef.current ?? 0) >= POLL_TIMEOUT_MS) {
+        console.error("[generating] poll timeout reached");
+        setError("Report generation timed out. Please try again.");
+        stopped = true;
+        if (animationRef.current) clearInterval(animationRef.current);
+        return;
+      }
+
       try {
         console.log("[generating] polling report", reportId, "delay:", delay);
         const report = await getReport(reportId);
@@ -140,24 +159,52 @@ export default function GeneratingPage() {
           }, 800);
           return;
         } else if (report.status === "failed") {
-          const errorMsg = report.error || "Report generation failed. Please try again.";
+          const errorMsg =
+            report.error || "Report generation failed. Please try again.";
           console.error("[generating] report failed:", errorMsg);
           setError(errorMsg);
           stopped = true;
           if (animationRef.current) clearInterval(animationRef.current);
           return;
         }
-        // Reset delay on success
+        // Reset delay and network failure count on success
         delay = 4000;
+        networkFailuresRef.current = 0;
+        setNetworkWarning(null);
       } catch (err) {
         if (err instanceof ApiError && err.status === 202) {
           console.log("[generating] still generating (202)");
+          networkFailuresRef.current = 0;
+          setNetworkWarning(null);
         } else if (err instanceof ApiError && err.status === 429) {
           // Rate limited — back off
           delay = Math.min(delay * 2, 30000);
-          console.warn("[generating] rate limited (429), backing off to", delay);
+          console.warn(
+            "[generating] rate limited (429), backing off to",
+            delay,
+          );
+          networkFailuresRef.current = 0;
+          setNetworkWarning(null);
         } else {
-          console.error("[generating] polling error:", err);
+          // Network or unknown error
+          networkFailuresRef.current += 1;
+          const failures = networkFailuresRef.current;
+          console.error(
+            "[generating] polling error (failure #" + failures + "):",
+            err,
+          );
+          if (failures >= MAX_NETWORK_FAILURES) {
+            setError(
+              "Unable to reach the server. Please check your connection and try again.",
+            );
+            stopped = true;
+            if (animationRef.current) clearInterval(animationRef.current);
+            return;
+          } else if (failures >= NETWORK_WARNING_THRESHOLD) {
+            setNetworkWarning(
+              "Having trouble reaching the server. Still trying...",
+            );
+          }
         }
       }
       if (!stopped) {
@@ -271,6 +318,15 @@ export default function GeneratingPage() {
             </div>
           ))}
         </div>
+
+        {/* Network warning */}
+        {networkWarning && !error && (
+          <MotionReveal y={8}>
+            <div className="mt-8 p-4 rounded-xl card-surface text-sm font-body text-text/60">
+              <p>{networkWarning}</p>
+            </div>
+          </MotionReveal>
+        )}
 
         {/* Error state */}
         {error && (

--- a/alchymine/web/src/app/discover/report/[id]/page.tsx
+++ b/alchymine/web/src/app/discover/report/[id]/page.tsx
@@ -211,6 +211,25 @@ export default function ReportPage() {
       }
     | undefined;
 
+  const narratives = report?.result?.narratives as
+    | Record<
+        string,
+        { text: string; disclaimers?: string[]; ethics_passed?: boolean }
+      >
+    | undefined;
+
+  const NARRATIVE_SYSTEMS = [
+    "intelligence",
+    "healing",
+    "wealth",
+    "creative",
+    "perspective",
+  ] as const;
+
+  const activeNarratives = NARRATIVE_SYSTEMS.filter(
+    (key) => narratives?.[key]?.text,
+  );
+
   return (
     <div className="flex-1 px-4 sm:px-6 py-12">
       <div className="max-w-4xl mx-auto">
@@ -766,6 +785,45 @@ export default function ReportPage() {
                 </MotionStagger>
               </div>
             </MotionReveal>
+
+            {/* ── Personalized Insights ──────────────────────────────── */}
+            {activeNarratives.length > 0 && (
+              <MotionReveal delay={0.4}>
+                <div className="pt-4">
+                  <h2 className="section-heading-sm text-text/30 mb-6">
+                    Personalized Insights
+                  </h2>
+                  <div className="space-y-4">
+                    {activeNarratives.map((key) => {
+                      const narrative = narratives![key];
+                      return (
+                        <div key={key} className="card-surface p-6">
+                          <h3 className="font-display text-lg font-light text-text/80 mb-3 capitalize">
+                            {key}
+                          </h3>
+                          <p className="text-sm font-body text-text/60 leading-relaxed">
+                            {narrative.text}
+                          </p>
+                          {narrative.disclaimers &&
+                            narrative.disclaimers.length > 0 && (
+                              <div className="mt-4 pt-3 border-t border-white/[0.04]">
+                                {narrative.disclaimers.map((d, i) => (
+                                  <p
+                                    key={i}
+                                    className="text-[0.65rem] font-body text-text/25 leading-relaxed italic"
+                                  >
+                                    {d}
+                                  </p>
+                                ))}
+                              </div>
+                            )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              </MotionReveal>
+            )}
           </div>
         ) : (
           <MotionReveal>
@@ -803,7 +861,7 @@ export default function ReportPage() {
         )}
 
         {/* Actions */}
-        <MotionReveal delay={0.4}>
+        <MotionReveal delay={0.5}>
           <div className="mt-12 flex flex-col sm:flex-row items-center justify-center gap-4">
             <Button
               variant="ghost"

--- a/infrastructure/scripts/deploy-zero-downtime.sh
+++ b/infrastructure/scripts/deploy-zero-downtime.sh
@@ -66,15 +66,26 @@ rollback() {
     exit "$exit_code"
   fi
 
-  # Restore nginx config if we swapped it (safe: old compose containers still exist)
-  if $NGINX_SWAPPED && [ -f "$NGINX_CONF_BAK" ]; then
-    log "Restoring original nginx config..."
-    cp "$NGINX_CONF_BAK" "$NGINX_CONF"
-    docker exec alchymine-nginx nginx -s reload 2>/dev/null || true
-    log "Nginx restored to original config"
+  # Check if compose services are still functional before deciding rollback strategy
+  if $NGINX_SWAPPED; then
+    API_HEALTH=$(docker inspect --format='{{.State.Health.Status}}' alchymine-api 2>/dev/null || echo "missing")
+    if [ "$API_HEALTH" != "healthy" ] && $TEMPS_RUNNING; then
+      # Compose API is down/unhealthy but temps are still running — keep temps alive
+      err "Compose API is $API_HEALTH — keeping temp containers as fallback"
+      err "Temp containers are serving traffic via nginx. DO NOT remove them."
+      err "To recover: 'export DEPLOY_VERSION=${VERSION} && docker compose ... up -d'"
+      exit "$exit_code"
+    fi
+    # Compose API is healthy or no temps to fall back to — restore nginx
+    if [ -f "$NGINX_CONF_BAK" ]; then
+      log "Restoring original nginx config..."
+      cp "$NGINX_CONF_BAK" "$NGINX_CONF"
+      docker exec alchymine-nginx nginx -s reload 2>/dev/null || true
+      log "Nginx restored to original config"
+    fi
   fi
 
-  # Remove temp containers (old compose containers are still serving)
+  # Remove temp containers only if compose services are healthy
   if $TEMPS_RUNNING; then
     log "Removing temp containers..."
     docker rm -f alchymine-api-tmp alchymine-web-tmp 2>/dev/null || true
@@ -270,8 +281,8 @@ PHASE="compose-recreate"
 log "Step 5/8: Recreating compose services with new images..."
 
 export DEPLOY_VERSION="${VERSION}"
+COMPOSE_RECREATED=true  # Set BEFORE up -d: old containers are gone once --force-recreate starts
 $DC up -d --no-deps --no-build --force-recreate api web worker pdf-service
-COMPOSE_RECREATED=true
 
 # Wait for compose containers to become healthy (max 90s)
 log "Waiting for compose containers to become healthy..."


### PR DESCRIPTION
## Summary

Four fixes from the post-deploy audit:

1. **Polling timeout + network error feedback** (`generating/[id]/page.tsx`)
   - 10-minute max poll duration — shows "timed out" error instead of spinning forever
   - Warning after 3 consecutive network failures; stops after 10

2. **Narrative display** (`report/[id]/page.tsx`)
   - LLM-generated narratives were stored but never shown
   - New "Personalized Insights" section renders narrative text per system with disclaimers

3. **Coordinator timeouts** (`orchestrator.py`)
   - Each coordinator now has a 120s timeout via `asyncio.wait_for()`
   - On timeout, records error result so other coordinators can still proceed

4. **Deploy rollback robustness** (`deploy-zero-downtime.sh`)
   - Root cause of site going down during v0.17.3 deploy: rollback removed healthy temp containers while compose API was unhealthy
   - Now checks compose API health before removing temps — keeps temps alive as fallback if compose is down
   - Sets `COMPOSE_RECREATED=true` before `$DC up -d` since old containers are gone the moment `--force-recreate` starts

## Test plan

- [x] 1944 Python tests passing
- [x] TypeScript — no errors
- [x] ESLint — no warnings
- [x] Bash syntax validation — OK
- [ ] CI green
- [ ] Verify narrative section renders on completed reports
- [ ] Verify generating page shows timeout after 10 min (dev test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)