### PR TITLE
fix: JSON-serialize full result dict before DB save

### DIFF
--- a/alchymine/workers/tasks.py
+++ b/alchymine/workers/tasks.py
@@ -484,6 +484,10 @@ def generate_report(
             logger.warning("Content filter failed (non-fatal): %s", exc)
 
         # ── Store success ─────────────────────────────────────────────
+        # Re-serialize the full dict: profile_summary and narratives were
+        # added after _serialise_orchestrator_result, so they may contain
+        # date/datetime objects that PostgreSQL JSON columns can't handle.
+        serialised = json.loads(json.dumps(serialised, default=str))
         _run_async(_db_set_complete(report_id, serialised))
 
         # ── Populate profile layer tables from coordinator results ────


### PR DESCRIPTION
## Summary

Reports were generating successfully but crashing on save:
```
TypeError: Object of type date is not JSON serializable
[SQL: UPDATE reports SET result=$1::JSON ...]
```

**Root cause:** `profile_summary` and `narratives` are added to the result dict *after* `_serialise_orchestrator_result()` runs its `json.dumps(default=str)` round-trip. Date objects from engine calculations (astrology dates, etc.) in `transform_to_profile_summary()` bypass serialization.

**Fix:** Re-serialize the full dict with `json.loads(json.dumps(serialised, default=str))` right before the DB save.

## Test plan
- [x] 28 worker tests passing
- [ ] CI green
- [ ] Generate report end-to-end — status goes to "complete"

🤖 Generated with [Claude Code](https://claude.com/claude-code)