### PR TITLE
Add GoatCounter analytics tracking

### DIFF
--- a/alchymine/web/src/app/layout.tsx
+++ b/alchymine/web/src/app/layout.tsx
@@ -84,6 +84,11 @@ export default function RootLayout({
           <ContentWrapper>{children}</ContentWrapper>
           <FeedbackButton />
         </Providers>
+        <script
+          data-goatcounter="https://alchymine.goatcounter.com/count"
+          async
+          src="//gc.zgo.at/count.js"
+        />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- Add GoatCounter analytics script to root layout for privacy-respecting visitor tracking
- Uses `alchymine.goatcounter.com` counter code
- Cookie-free, GDPR compliant, ~3.5 KB async script

## Test plan
- [ ] Verify site loads without errors
- [ ] Check GoatCounter dashboard receives pageviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)