### PR TITLE
fix(config): tolerate extra vars in .env files

### DIFF
--- a/alchymine/config.py
+++ b/alchymine/config.py
@@ -30,6 +30,12 @@ class Settings(BaseSettings):
         env_file=".env",
         env_file_encoding="utf-8",
         case_sensitive=False,
+        # Tolerate extra vars in .env files (e.g. production envs that include
+        # docker-compose service names, deployment secrets, or other tooling
+        # vars that Settings doesn't declare). Without this, a local dev
+        # running tests with a production-style .env hits extra_forbidden
+        # errors on every Settings() instantiation.
+        extra="ignore",
     )
 
     # ── App ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

One-line fix to `alchymine/config.py` adding `extra="ignore"` to `Settings.model_config` so pydantic-settings tolerates extra keys in `.env` files.

## Why

All three parallel Sprint 1-2 agents (Track 1 healing skills, Track 2 chat backend, Track 3 Gemini art) hit the same local test-env issue: running pytest in a worktree with a production-style `.env` blew up on every `Settings()` instantiation because the file contains vars the `Settings` class doesn't declare (`POSTGRES_HOST`, `POSTGRES_PORT`, `DOMAIN`, `SSL_EMAIL`, `PDF_SERVICE_TOKEN`, `REDIS_PASSWORD`, etc.). Each agent worked around it by moving `.env` aside during test runs — fragile and bad DX.

`extra="ignore"` keeps the existing strict behavior for unknown fields that actually belong to `Settings` (the `field_validator` on `jwt_secret_key` etc. still runs) while tolerating adjacent env vars that belong to docker-compose / deployment / other tooling. CI is unaffected because CI does not provide a `.env` file.

## Test plan
- [x] `ruff check alchymine/config.py` clean
- [x] `ruff format --check alchymine/config.py` clean
- [x] `mypy alchymine/config.py` clean
- [x] `pytest tests/test_config.py` — 28/28 passing
- [x] `pytest tests/api/test_feedback.py tests/api/test_healing_router.py` — 30/30 passing (these were failing locally before due to the exact `extra_forbidden` error this PR fixes)
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)