### PR TITLE
feat(healing): skills YAML loader, cross-system bridges, API endpoints

### DIFF
--- a/alchymine/api/main.py
+++ b/alchymine/api/main.py
@@ -29,6 +29,7 @@ from alchymine.api.routers import (
     creative,
     feedback,
     healing,
+    healing_skills,
     health,
     integration,
     journal,
@@ -120,6 +121,7 @@ app.include_router(wealth.router, prefix="/api/v1", tags=["wealth"])
 app.include_router(compatibility.router, prefix="/api/v1", tags=["compatibility"])
 app.include_router(biorhythm.router, prefix="/api/v1", tags=["biorhythm"])
 app.include_router(healing.router, prefix="/api/v1", tags=["healing"])
+app.include_router(healing_skills.router, prefix="/api/v1", tags=["healing-skills"])
 app.include_router(creative.router, prefix="/api/v1", tags=["creative"])
 app.include_router(perspective.router, prefix="/api/v1", tags=["perspective"])
 app.include_router(personality.router, prefix="/api/v1", tags=["personality"])

--- a/alchymine/api/main.py
+++ b/alchymine/api/main.py
@@ -25,6 +25,7 @@ from alchymine.api.routers import (
     astrology,
     auth,
     biorhythm,
+    bridges,
     compatibility,
     creative,
     feedback,
@@ -122,6 +123,7 @@ app.include_router(compatibility.router, prefix="/api/v1", tags=["compatibility"
 app.include_router(biorhythm.router, prefix="/api/v1", tags=["biorhythm"])
 app.include_router(healing.router, prefix="/api/v1", tags=["healing"])
 app.include_router(healing_skills.router, prefix="/api/v1", tags=["healing-skills"])
+app.include_router(bridges.router, prefix="/api/v1", tags=["bridges"])
 app.include_router(creative.router, prefix="/api/v1", tags=["creative"])
 app.include_router(perspective.router, prefix="/api/v1", tags=["perspective"])
 app.include_router(personality.router, prefix="/api/v1", tags=["personality"])

--- a/alchymine/api/routers/bridges.py
+++ b/alchymine/api/routers/bridges.py
@@ -1,0 +1,106 @@
+"""Cross-system bridges API endpoints — public reference data, no auth required.
+
+Exposes the seven cross-system bridges (XS-01..XS-07) declared in
+:mod:`alchymine.engine.bridges.registry`.  Bridges are static reference
+data, so the registry is injected via a FastAPI dependency to make the
+endpoints trivially testable.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, ConfigDict, Field
+
+from alchymine.engine.bridges import (
+    BRIDGE_REGISTRY,
+    Bridge,
+    BridgeId,
+)
+
+router = APIRouter()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Response model
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class BridgeResponse(BaseModel):
+    """Wire-format representation of a :class:`Bridge`.
+
+    FastAPI cannot serialize frozen dataclasses without help, so we mirror
+    the dataclass fields here and convert via :meth:`from_bridge`.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str = Field(..., description="Stable bridge identifier, e.g. 'XS-01'")
+    name: str = Field(..., description="Short human-readable title")
+    source_system: str = Field(..., description="Producing pillar")
+    target_system: str = Field(..., description="Consuming pillar")
+    description: str = Field(..., description="What insight flows from source to target")
+    insight_keys: list[str] = Field(
+        ..., description="Source-system field names surfaced in the target"
+    )
+
+    @classmethod
+    def from_bridge(cls, bridge: Bridge) -> BridgeResponse:
+        return cls(
+            id=bridge.id,
+            name=bridge.name,
+            source_system=bridge.source_system,
+            target_system=bridge.target_system,
+            description=bridge.description,
+            insight_keys=list(bridge.insight_keys),
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Dependency
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def get_bridge_registry() -> dict[BridgeId, Bridge]:
+    """FastAPI dependency that returns the in-memory bridge registry.
+
+    Kept as a thin wrapper so tests can override it via
+    ``app.dependency_overrides`` if needed.
+    """
+    return BRIDGE_REGISTRY
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Endpoints
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@router.get("/bridges")
+async def list_bridges_endpoint(
+    source: str | None = Query(None, description="Filter by source_system"),
+    target: str | None = Query(None, description="Filter by target_system"),
+    registry: dict[BridgeId, Bridge] = Depends(get_bridge_registry),
+) -> list[BridgeResponse]:
+    """List all cross-system bridges, optionally filtered by source/target.
+
+    Filters are independent and may be combined.  An unknown system value
+    simply yields an empty list (not a 400).  Results are returned in
+    stable id order (XS-01 first).
+    """
+    bridges: list[Bridge] = [registry[bid] for bid in sorted(registry.keys())]
+    if source is not None:
+        bridges = [b for b in bridges if b.source_system == source]
+    if target is not None:
+        bridges = [b for b in bridges if b.target_system == target]
+    return [BridgeResponse.from_bridge(b) for b in bridges]
+
+
+@router.get("/bridges/{bridge_id}")
+async def get_bridge_endpoint(
+    bridge_id: str,
+    registry: dict[BridgeId, Bridge] = Depends(get_bridge_registry),
+) -> BridgeResponse:
+    """Return a single bridge by id, or 404 if not found."""
+    bridge = registry.get(bridge_id)  # type: ignore[call-overload]
+    if bridge is None:
+        raise HTTPException(status_code=404, detail=f"Bridge not found: {bridge_id}")
+    return BridgeResponse.from_bridge(bridge)

--- a/alchymine/api/routers/healing_skills.py
+++ b/alchymine/api/routers/healing_skills.py
@@ -1,0 +1,50 @@
+"""Healing skills API endpoints — public reference data, no auth required."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from alchymine.engine.healing.skills import (
+    SkillDefinition,
+    SkillNotFoundError,
+    SkillRegistry,
+    get_default_yaml_dir,
+)
+
+router = APIRouter()
+
+# Module-level registry, loaded on first request and reused thereafter.
+_registry: SkillRegistry | None = None
+
+
+def get_skill_registry() -> SkillRegistry:
+    """FastAPI dependency that returns the lazy-loaded SkillRegistry."""
+    global _registry
+    if _registry is None:
+        reg = SkillRegistry()
+        reg.load_directory(get_default_yaml_dir())
+        _registry = reg
+    return _registry
+
+
+@router.get("/healing/skills")
+async def list_healing_skills(
+    modality: str | None = Query(None, description="Optional modality filter"),
+    registry: SkillRegistry = Depends(get_skill_registry),
+) -> list[SkillDefinition]:
+    """List all healing skills, optionally filtered by modality."""
+    if modality is not None:
+        return registry.list_by_modality(modality)
+    return registry.list_all()
+
+
+@router.get("/healing/skills/{name}")
+async def get_healing_skill(
+    name: str,
+    registry: SkillRegistry = Depends(get_skill_registry),
+) -> SkillDefinition:
+    """Return a single healing skill by name."""
+    try:
+        return registry.get(name)
+    except SkillNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=f"Skill not found: {name}") from exc

--- a/alchymine/config.py
+++ b/alchymine/config.py
@@ -30,6 +30,12 @@ class Settings(BaseSettings):
         env_file=".env",
         env_file_encoding="utf-8",
         case_sensitive=False,
+        # Tolerate extra vars in .env files (e.g. production envs that include
+        # docker-compose service names, deployment secrets, or other tooling
+        # vars that Settings doesn't declare). Without this, a local dev
+        # running tests with a production-style .env hits extra_forbidden
+        # errors on every Settings() instantiation.
+        extra="ignore",
     )
 
     # ── App ──────────────────────────────────────────────────────────────

--- a/alchymine/engine/bridges/__init__.py
+++ b/alchymine/engine/bridges/__init__.py
@@ -1,0 +1,31 @@
+"""Cross-system bridges sub-package.
+
+Defines the 7 cross-system insight bridges (XS-01..XS-07) that describe
+how data and insights flow between Alchymine's five pillars
+(intelligence, healing, wealth, creative, perspective).
+
+Bridges are pure in-code reference data — frozen dataclasses kept in a
+module-level registry. There is no DB persistence and no I/O involved.
+"""
+
+from .registry import (
+    BRIDGE_REGISTRY,
+    Bridge,
+    BridgeId,
+    BridgeNotFoundError,
+    get_bridge,
+    list_bridges,
+    list_bridges_from,
+    list_bridges_to,
+)
+
+__all__ = [
+    "BRIDGE_REGISTRY",
+    "Bridge",
+    "BridgeId",
+    "BridgeNotFoundError",
+    "get_bridge",
+    "list_bridges",
+    "list_bridges_from",
+    "list_bridges_to",
+]

--- a/alchymine/engine/bridges/registry.py
+++ b/alchymine/engine/bridges/registry.py
@@ -1,0 +1,209 @@
+"""Cross-system bridge definitions (XS-01..XS-07).
+
+Each :class:`Bridge` describes how an insight produced by one of the five
+Alchymine pillars (intelligence, healing, wealth, creative, perspective)
+informs a downstream pillar.  The seven bridges are static reference
+data, declared as frozen dataclasses and exposed through a registry
+mapping plus convenience filters.
+
+System enum values must match the directory names under
+``alchymine/engine/`` and the names used elsewhere in the codebase
+(e.g. routers, frontend ``currentSystem`` props).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final, Literal, TypeAlias
+
+# ─────────────────────────────────────────────────────────────────────────
+# System enum
+# ─────────────────────────────────────────────────────────────────────────
+
+#: Canonical names of the five Alchymine systems.  Bridges may only
+#: reference these as ``source_system`` or ``target_system``.
+VALID_SYSTEMS: Final[frozenset[str]] = frozenset(
+    {"intelligence", "healing", "wealth", "creative", "perspective"}
+)
+
+BridgeId: TypeAlias = Literal[
+    "XS-01",
+    "XS-02",
+    "XS-03",
+    "XS-04",
+    "XS-05",
+    "XS-06",
+    "XS-07",
+]
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Errors
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class BridgeNotFoundError(Exception):
+    """Raised when a bridge id is not present in :data:`BRIDGE_REGISTRY`."""
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Dataclass
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Bridge:
+    """A single cross-system bridge.
+
+    Attributes:
+        id: Stable identifier in the form ``XS-NN``.
+        name: Short human-readable title shown in UI cards.
+        source_system: The pillar that produces the insight.
+        target_system: The pillar that consumes / surfaces the insight.
+        description: Long-form sentence describing what insight flows
+            from ``source_system`` to ``target_system``.
+        insight_keys: Tuple of field names on the source system's output
+            that get surfaced in the target system.  These are stable
+            keys that downstream consumers (other engines, the chat
+            agent, the frontend bridge panel) can rely on.
+    """
+
+    id: str
+    name: str
+    source_system: str
+    target_system: str
+    description: str
+    insight_keys: tuple[str, ...]
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Registry
+# ─────────────────────────────────────────────────────────────────────────
+
+# Bridge content is sourced from
+# ``docs/superpowers/plans/2026-03-10-track-1-healing-skills-cross-system-ux.md``
+# (Sprint 3, Task 3.1).  ``insight_keys`` are derived from each bridge's
+# stated mechanism — they name the source-system fields that the target
+# system pulls in to personalize its output.
+BRIDGE_REGISTRY: Final[dict[BridgeId, Bridge]] = {
+    "XS-01": Bridge(
+        id="XS-01",
+        name="Healing Primes Perspective",
+        source_system="healing",
+        target_system="perspective",
+        description=(
+            "Breathwork and somatic work soften rigid thinking patterns, "
+            "making Kegan stage transitions more accessible."
+        ),
+        insight_keys=("regulation_state", "somatic_readiness"),
+    ),
+    "XS-02": Bridge(
+        id="XS-02",
+        name="Numerology Selects Modality",
+        source_system="intelligence",
+        target_system="healing",
+        description=(
+            "Your Life Path number has strong affinity with specific "
+            "healing traditions. The engine pre-selects modalities "
+            "aligned to your number."
+        ),
+        insight_keys=("life_path_number", "archetype_affinity"),
+    ),
+    "XS-03": Bridge(
+        id="XS-03",
+        name="Financial Stress Routes to Somatic Release",
+        source_system="wealth",
+        target_system="healing",
+        description=(
+            "Money anxiety activates the same stress circuits as physical "
+            "threat. Somatic and breathwork practices directly address "
+            "wealth-related cortisol."
+        ),
+        insight_keys=("financial_stress_score", "anxiety_indicators"),
+    ),
+    "XS-04": Bridge(
+        id="XS-04",
+        name="Creative Expression Heals",
+        source_system="creative",
+        target_system="healing",
+        description=(
+            "Expressive healing modalities use art, movement, and writing "
+            "to access pre-verbal experience — the same materials your "
+            "Creative system works with."
+        ),
+        insight_keys=("expression_modes", "creative_themes"),
+    ),
+    "XS-05": Bridge(
+        id="XS-05",
+        name="Kegan Stage Unlocks Money Mindset",
+        source_system="perspective",
+        target_system="wealth",
+        description=(
+            "Stage 4 development (self-authoring) is the psychological "
+            "prerequisite for the generative wealth mindset. Perspective "
+            "work directly enables wealth expansion."
+        ),
+        insight_keys=("kegan_stage", "self_authoring_score"),
+    ),
+    "XS-06": Bridge(
+        id="XS-06",
+        name="Healed Expression Flows",
+        source_system="healing",
+        target_system="creative",
+        description=(
+            "Clearing somatic blocks through healing practices removes "
+            "the psychological censorship that suppresses creative output."
+        ),
+        insight_keys=("regulation_state", "inhibition_level"),
+    ),
+    "XS-07": Bridge(
+        id="XS-07",
+        name="Archetype Shapes Stage Pathway",
+        source_system="intelligence",
+        target_system="perspective",
+        description=(
+            "Your Jungian archetype has natural affinity with specific "
+            "Kegan developmental stages. Intelligence data fast-tracks "
+            "your perspective growth path."
+        ),
+        insight_keys=("archetype", "life_path_number"),
+    ),
+}
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Module-level helpers
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def get_bridge(bridge_id: str) -> Bridge:
+    """Return the bridge with the given id.
+
+    Args:
+        bridge_id: Bridge identifier (e.g. ``"XS-01"``).
+
+    Returns:
+        The matching :class:`Bridge`.
+
+    Raises:
+        BridgeNotFoundError: if ``bridge_id`` is not in the registry.
+    """
+    try:
+        return BRIDGE_REGISTRY[bridge_id]  # type: ignore[index]
+    except KeyError as exc:
+        raise BridgeNotFoundError(f"Unknown bridge id: {bridge_id}") from exc
+
+
+def list_bridges() -> tuple[Bridge, ...]:
+    """Return all bridges in stable id order (XS-01 first, XS-07 last)."""
+    return tuple(BRIDGE_REGISTRY[bid] for bid in sorted(BRIDGE_REGISTRY.keys()))
+
+
+def list_bridges_from(source_system: str) -> tuple[Bridge, ...]:
+    """Return all bridges whose ``source_system`` matches, in id order."""
+    return tuple(b for b in list_bridges() if b.source_system == source_system)
+
+
+def list_bridges_to(target_system: str) -> tuple[Bridge, ...]:
+    """Return all bridges whose ``target_system`` matches, in id order."""
+    return tuple(b for b in list_bridges() if b.target_system == target_system)

--- a/alchymine/engine/healing/skills/__init__.py
+++ b/alchymine/engine/healing/skills/__init__.py
@@ -1,0 +1,22 @@
+"""Healing skills sub-package.
+
+YAML-defined practice cards (one per healing modality) loaded by a
+`SkillRegistry`. Each skill is a structured, evidence-rated practice
+that the API and chat agents can surface to users.
+"""
+
+from .loader import (
+    SkillNotFoundError,
+    SkillRegistry,
+    SkillValidationError,
+    get_default_yaml_dir,
+)
+from .schema import SkillDefinition
+
+__all__ = [
+    "SkillDefinition",
+    "SkillNotFoundError",
+    "SkillRegistry",
+    "SkillValidationError",
+    "get_default_yaml_dir",
+]

--- a/alchymine/engine/healing/skills/loader.py
+++ b/alchymine/engine/healing/skills/loader.py
@@ -1,0 +1,85 @@
+"""Loader and registry for healing skill YAML files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from pydantic import ValidationError
+
+from .schema import SkillDefinition
+
+
+class SkillNotFoundError(KeyError):
+    """Raised when a skill name is not present in the registry."""
+
+
+class SkillValidationError(ValueError):
+    """Raised when a YAML file fails schema validation."""
+
+
+def get_default_yaml_dir() -> Path:
+    """Return the package-relative directory of seed skill YAML files."""
+    return Path(__file__).parent / "yaml"
+
+
+class SkillRegistry:
+    """In-memory registry of healing skills loaded from YAML files."""
+
+    def __init__(self) -> None:
+        self._skills: dict[str, SkillDefinition] = {}
+
+    def load_directory(self, path: Path) -> None:
+        """Replace the registry contents with all *.yaml files under `path`.
+
+        Raises:
+            FileNotFoundError: if `path` does not exist.
+            SkillValidationError: if any file fails schema validation or
+                contains a duplicate skill name.
+        """
+        if not path.exists() or not path.is_dir():
+            raise FileNotFoundError(f"Skill YAML directory not found: {path}")
+
+        loaded: dict[str, SkillDefinition] = {}
+        for yaml_path in sorted(path.glob("*.yaml")):
+            skill = _load_one(yaml_path)
+            if skill.name in loaded:
+                raise SkillValidationError(
+                    f"Duplicate skill name '{skill.name}' in {yaml_path.name}"
+                )
+            loaded[skill.name] = skill
+
+        self._skills = loaded
+
+    def get(self, name: str) -> SkillDefinition:
+        try:
+            return self._skills[name]
+        except KeyError as exc:
+            raise SkillNotFoundError(name) from exc
+
+    def list_by_modality(self, modality: str) -> list[SkillDefinition]:
+        return [s for s in self._skills.values() if s.modality == modality]
+
+    def list_all(self) -> list[SkillDefinition]:
+        return list(self._skills.values())
+
+    def __len__(self) -> int:
+        return len(self._skills)
+
+
+def _load_one(yaml_path: Path) -> SkillDefinition:
+    try:
+        with open(yaml_path, encoding="utf-8") as f:
+            raw = yaml.safe_load(f)
+    except yaml.YAMLError as exc:
+        raise SkillValidationError(f"{yaml_path.name}: invalid YAML: {exc}") from exc
+
+    if not isinstance(raw, dict):
+        raise SkillValidationError(
+            f"{yaml_path.name}: top-level YAML must be a mapping, got {type(raw).__name__}"
+        )
+
+    try:
+        return SkillDefinition.model_validate(raw)
+    except ValidationError as exc:
+        raise SkillValidationError(f"{yaml_path.name}: {exc}") from exc

--- a/alchymine/engine/healing/skills/schema.py
+++ b/alchymine/engine/healing/skills/schema.py
@@ -1,0 +1,63 @@
+"""Pydantic schema for healing skill YAML definitions."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from alchymine.engine.healing.modalities import MODALITY_REGISTRY
+
+# Source of truth: the 15 modality keys from the existing healing engine.
+ALLOWED_MODALITIES: frozenset[str] = frozenset(MODALITY_REGISTRY.keys())
+
+EvidenceRating = Literal["A", "B", "C", "D"]
+
+
+class SkillDefinition(BaseModel):
+    """A single healing skill loaded from YAML.
+
+    Evidence rating scale:
+        A — Strong RCT / meta-analytic support
+        B — Multiple controlled studies, moderate effect sizes
+        C — Limited / observational evidence, plausible mechanism
+        D — Traditional, anecdotal, or contemplative practice (not RCT-tested)
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    name: str = Field(..., min_length=1, description="Unique slug, lowercase-with-dashes")
+    modality: str = Field(..., description="One of the 15 healing modality keys")
+    title: str = Field(..., min_length=1, description="Display name")
+    description: str = Field(..., min_length=1)
+    steps: list[str] = Field(..., min_length=1)
+    evidence_rating: EvidenceRating
+    contraindications: list[str] = Field(default_factory=list)
+    duration_minutes: int = Field(..., gt=0)
+
+    @field_validator("name")
+    @classmethod
+    def _validate_name_slug(cls, v: str) -> str:
+        if v != v.lower():
+            raise ValueError("name must be lowercase")
+        if " " in v or "_" in v:
+            raise ValueError("name must use dashes (not spaces or underscores)")
+        if not all(c.isalnum() or c == "-" for c in v):
+            raise ValueError("name must contain only [a-z0-9-]")
+        return v
+
+    @field_validator("modality")
+    @classmethod
+    def _validate_modality(cls, v: str) -> str:
+        if v not in ALLOWED_MODALITIES:
+            raise ValueError(
+                f"unknown modality '{v}'. Must be one of: {sorted(ALLOWED_MODALITIES)}"
+            )
+        return v
+
+    @field_validator("steps")
+    @classmethod
+    def _validate_steps_nonempty(cls, v: list[str]) -> list[str]:
+        if any(not s.strip() for s in v):
+            raise ValueError("steps must not contain empty strings")
+        return v

--- a/alchymine/engine/healing/skills/yaml/breathwork-box-breathing.yaml
+++ b/alchymine/engine/healing/skills/yaml/breathwork-box-breathing.yaml
@@ -1,0 +1,23 @@
+name: breathwork-box-breathing
+modality: breathwork
+title: Box Breathing (4-4-4-4)
+description: >-
+  A simple, evidence-based breathing pattern used by Navy SEALs and clinicians
+  to down-regulate the sympathetic nervous system. Each phase is held for an
+  equal count of four, producing a steady "box" rhythm that improves heart-rate
+  variability and focus.
+steps:
+  - Sit upright with both feet on the floor and hands resting on your thighs.
+  - Exhale fully through pursed lips to empty the lungs.
+  - Inhale slowly through the nose for a count of 4.
+  - Hold the breath gently for a count of 4 (do not strain).
+  - Exhale through the mouth for a count of 4.
+  - Hold empty for a count of 4 before the next inhale.
+  - Repeat for 8 cycles, then breathe normally and notice any shift.
+evidence_rating: B
+contraindications:
+  - severe asthma during an active flare
+  - panic disorder triggered by breath retention
+  - uncontrolled epilepsy
+  - late-stage pregnancy (consult clinician before breath holds)
+duration_minutes: 6

--- a/alchymine/engine/healing/skills/yaml/coherence-heart-focused-breathing.yaml
+++ b/alchymine/engine/healing/skills/yaml/coherence-heart-focused-breathing.yaml
@@ -1,0 +1,20 @@
+name: coherence-heart-focused-breathing
+modality: coherence_meditation
+title: Heart-Focused Breathing for Coherence
+description: >-
+  A HeartMath-derived practice that combines slow rhythmic breathing with a
+  focus on the heart area and a sustained positive feeling. Multiple controlled
+  studies show it improves heart-rate variability coherence and self-reported
+  emotional regulation within minutes.
+steps:
+  - Find a quiet seat and bring your attention to the centre of the chest.
+  - Imagine the breath flowing in and out through the heart area.
+  - Inhale for 5 seconds, exhale for 5 seconds, in a smooth even rhythm.
+  - After 1-2 minutes of steady breathing, recall a feeling of appreciation, care, or gratitude — for a person, place, or moment.
+  - Hold that feeling alongside the rhythmic breathing for 3-5 minutes.
+  - Notice the texture of any shift before opening your eyes.
+evidence_rating: B
+contraindications:
+  - acute psychosis
+  - severe dissociative disorder
+duration_minutes: 7

--- a/alchymine/engine/healing/skills/yaml/community-deep-listening-pair.yaml
+++ b/alchymine/engine/healing/skills/yaml/community-deep-listening-pair.yaml
@@ -1,0 +1,22 @@
+name: community-deep-listening-pair
+modality: community_healing
+title: Deep Listening Pair Practice
+description: >-
+  A structured 20-minute pair practice in which two people take turns speaking
+  and listening without interruption, advice, or response. Drawn from talking-circle
+  traditions and group-therapy research, it builds relational repair, empathy,
+  and the experience of being heard without being fixed.
+steps:
+  - Find a willing partner — friend, family member, or peer support contact.
+  - Sit facing each other in a quiet space and put phones away.
+  - Decide who speaks first. Set a 6-minute timer.
+  - The speaker shares whatever is alive for them. The listener says nothing — only listens with soft eyes and an open posture.
+  - When the timer ends, the listener simply says, "Thank you for sharing." No advice, no questions, no rebuttal.
+  - Reset the timer and switch roles.
+  - After both rounds, take 1 minute of silence together before resuming normal conversation.
+evidence_rating: C
+contraindications:
+  - severe social anxiety disorder (try with a clinician first)
+  - active paranoid ideation
+  - relationships with active intimate-partner abuse (do not use within those relationships)
+duration_minutes: 20

--- a/alchymine/engine/healing/skills/yaml/consciousness-yoga-nidra.yaml
+++ b/alchymine/engine/healing/skills/yaml/consciousness-yoga-nidra.yaml
@@ -1,0 +1,22 @@
+name: consciousness-yoga-nidra
+modality: consciousness_journey
+title: Yoga Nidra Body Scan and Sankalpa
+description: >-
+  A traditional Yogic practice of "yogic sleep" — a guided body-scan that
+  brings the practitioner to the threshold between waking and sleep while
+  remaining aware. Modern research shows benefits for sleep quality, anxiety,
+  and parasympathetic tone.
+steps:
+  - Lie flat on your back with a small pillow under your head and a blanket nearby.
+  - Set a single short intention (sankalpa) in present tense — for example, "I am at ease".
+  - Beginning with the right thumb, move your attention slowly through every part of the body, naming each silently.
+  - Continue through fingers, hand, arm, shoulder, then repeat on the left side.
+  - Move through the back, front of the torso, legs, and feet at an unhurried pace.
+  - Rest in whole-body awareness for 2 minutes, then silently repeat your sankalpa three times.
+  - Bring small movements back to fingers and toes before opening the eyes.
+evidence_rating: B
+contraindications:
+  - schizophrenia or active psychotic episode
+  - unmedicated bipolar disorder
+  - severe dissociative disorder
+duration_minutes: 30

--- a/alchymine/engine/healing/skills/yaml/expressive-morning-pages.yaml
+++ b/alchymine/engine/healing/skills/yaml/expressive-morning-pages.yaml
@@ -1,0 +1,22 @@
+name: expressive-morning-pages
+modality: expressive_healing
+title: Morning Pages — Three Pages of Stream Writing
+description: >-
+  A daily expressive writing practice popularised by Julia Cameron — three pages
+  of unedited longhand writing first thing in the morning. Expressive writing
+  has solid evidence for reducing rumination, improving mood, and clarifying
+  decisions when practiced consistently.
+steps:
+  - Place a notebook and pen at your bedside the night before.
+  - On waking, sit up and start writing without checking your phone first.
+  - Write three full pages in longhand — whatever comes, exactly as it comes.
+  - Do not stop, edit, censor, or judge what appears on the page.
+  - If you have nothing to say, write "I have nothing to say" until something else surfaces.
+  - When the third page is complete, close the notebook and continue your morning.
+  - Do not re-read the pages for at least one week.
+evidence_rating: B
+contraindications:
+  - acute psychosis with disorganised thought
+  - severe perfectionism that turns the practice into self-criticism (try with a clinician)
+  - early-recovery from disordered eating where journaling triggers obsessive self-monitoring
+duration_minutes: 25

--- a/alchymine/engine/healing/skills/yaml/grief-letter-to-loss.yaml
+++ b/alchymine/engine/healing/skills/yaml/grief-letter-to-loss.yaml
@@ -1,0 +1,22 @@
+name: grief-letter-to-loss
+modality: grief_healing
+title: A Letter to What Has Been Lost
+description: >-
+  An expressive writing practice from grief therapy in which the bereaved
+  writes an unsent letter to the person, relationship, role, or place they
+  have lost. Expressive writing for grief has moderate research support for
+  reducing intrusive thoughts and improving meaning-making over weeks of practice.
+steps:
+  - Choose 30 quiet, uninterrupted minutes in a private space.
+  - Have tissues, water, and something to ground you nearby (a photo, an object).
+  - At the top of a page, write "Dear ____," addressing what or who you have lost.
+  - Write continuously for 15 minutes — what you miss, what you wish you had said, what you carry forward, what you release.
+  - Do not edit; spelling and grammar do not matter here.
+  - When you finish, sit quietly. You may keep, burn, or bury the letter as feels right.
+  - Take a slow walk or call a trusted person before returning to ordinary tasks.
+evidence_rating: B
+contraindications:
+  - bereavement within the last 48 hours (use crisis support instead)
+  - complicated grief with active suicidal ideation
+  - history of self-harm triggered by writing about loss (do with a clinician)
+duration_minutes: 35

--- a/alchymine/engine/healing/skills/yaml/inquiry-self-inquiry-who-am-i.yaml
+++ b/alchymine/engine/healing/skills/yaml/inquiry-self-inquiry-who-am-i.yaml
@@ -1,0 +1,24 @@
+name: inquiry-self-inquiry-who-am-i
+modality: contemplative_inquiry
+title: Atma Vichara — "Who Am I?" Self-Inquiry
+description: >-
+  A traditional Advaita Vedanta contemplative practice taught by Ramana
+  Maharshi. The practitioner repeatedly asks the question "Who am I?" and
+  rests in the silence the question opens, rather than seeking a verbal answer.
+  This is an advanced contemplative tradition with no RCT evidence base, but
+  centuries of contemplative use across Indian wisdom traditions.
+steps:
+  - Sit quietly with eyes closed or softly open in a comfortable upright posture.
+  - Take three slow breaths to settle attention in the body.
+  - Inwardly ask, "Who am I?" Do not try to answer with words.
+  - Whenever a thought, image, or self-concept arises, gently ask, "To whom does this arise?"
+  - Let attention rest on the source of the questioning, not on any answer.
+  - When attention drifts, return to the question without self-criticism.
+  - End by sitting in silence for 1 minute, then take three breaths and gently re-engage the room.
+evidence_rating: D
+contraindications:
+  - active depersonalisation or derealisation disorder
+  - acute existential crisis or suicidal ideation
+  - first weeks of grief (use grief-specific practices instead)
+  - history of dissociative episodes triggered by silent meditation
+duration_minutes: 20

--- a/alchymine/engine/healing/skills/yaml/language-cognitive-reframe.yaml
+++ b/alchymine/engine/healing/skills/yaml/language-cognitive-reframe.yaml
@@ -1,0 +1,20 @@
+name: language-cognitive-reframe
+modality: language_awareness
+title: Cognitive Reframe of an Automatic Thought
+description: >-
+  A short journaling practice from cognitive behavioural therapy that surfaces
+  habitual self-talk and rewrites it in language that is more accurate and less
+  catastrophising. The technique is well-supported by RCTs for mild-to-moderate
+  anxiety and low mood.
+steps:
+  - Notice a recent moment when you felt strong unpleasant emotion.
+  - Write down the automatic thought that ran through your mind in that moment, word-for-word.
+  - Underline any absolutist words ("always", "never", "must", "everyone", "nothing").
+  - Ask three questions in writing — What is the evidence for this? What is the evidence against? What would I tell a friend with this thought?
+  - Rewrite the thought in language that is true, fair, and uses concrete specifics instead of absolutes.
+  - Read the new sentence aloud once and notice how the body responds.
+evidence_rating: A
+contraindications:
+  - active speech therapy for trauma-related mutism
+  - acute trauma flashbacks (use grounding first)
+duration_minutes: 12

--- a/alchymine/engine/healing/skills/yaml/nature-shinrin-yoku-walk.yaml
+++ b/alchymine/engine/healing/skills/yaml/nature-shinrin-yoku-walk.yaml
@@ -1,0 +1,21 @@
+name: nature-shinrin-yoku-walk
+modality: nature_healing
+title: Shinrin-yoku Forest Bathing Walk
+description: >-
+  A slow, sensory-led walk in a forested or wooded area, drawn from the
+  Japanese practice of shinrin-yoku ("forest bathing"). RCTs show measurable
+  reductions in cortisol, blood pressure, and self-reported stress after a
+  single session of 1-2 hours in a wooded environment.
+steps:
+  - Find a wooded park, forest, or tree-lined trail and put your phone on silent.
+  - Walk much more slowly than usual — about half your normal pace.
+  - For the first 5 minutes, simply notice 3 sights, 3 sounds, and 3 smells.
+  - Pause beside a tree and place a hand on the bark. Stay for 1 minute.
+  - Continue walking, letting attention rest on textures, light through leaves, and the sensation of air on the skin.
+  - Sit somewhere quiet for the final 5 minutes and breathe normally before returning.
+evidence_rating: A
+contraindications:
+  - severe agoraphobia
+  - anaphylactic environmental allergies (insect stings, pollen) without medication on hand
+  - mobility impairment incompatible with uneven terrain
+duration_minutes: 60

--- a/alchymine/engine/healing/skills/yaml/pni-stress-recovery-mapping.yaml
+++ b/alchymine/engine/healing/skills/yaml/pni-stress-recovery-mapping.yaml
@@ -1,0 +1,20 @@
+name: pni-stress-recovery-mapping
+modality: pni_mapping
+title: Stress and Recovery Mapping (PNI Journal)
+description: >-
+  A weekly journaling exercise informed by psychoneuroimmunology research.
+  By tracking stress, sleep, immune symptoms, and mood together, the practitioner
+  surfaces patterns linking mental states to physical wellbeing — useful as
+  data for self-understanding, not as a diagnostic tool.
+steps:
+  - At the end of each day, rate today's stress (1-10), sleep quality last night (1-10), and mood (1-10) in a notebook or app.
+  - Write one sentence describing the most stressful event and one describing the most restorative moment.
+  - Note any physical symptoms (headache, digestive change, muscle tension, illness).
+  - At the end of the week, look back at all 7 entries and circle patterns that repeat.
+  - Choose ONE small experiment for the coming week (earlier sleep, mid-day walk, evening stretch) and commit in writing.
+  - Notice without judgement; this is observation, not self-improvement pressure.
+evidence_rating: C
+contraindications:
+  - active autoimmune flare without medical supervision
+  - history of using journaling to ruminate or self-monitor obsessively
+duration_minutes: 10

--- a/alchymine/engine/healing/skills/yaml/resilience-cold-exposure-protocol.yaml
+++ b/alchymine/engine/healing/skills/yaml/resilience-cold-exposure-protocol.yaml
@@ -1,0 +1,23 @@
+name: resilience-cold-exposure-protocol
+modality: resilience_training
+title: Graded Cold Exposure for Stress Inoculation
+description: >-
+  A graded shower protocol that uses brief, voluntary cold exposure to train
+  parasympathetic recovery and tolerance for discomfort. Multiple controlled
+  trials suggest modest but real benefits for mood, sick-day frequency, and
+  perceived resilience when practiced consistently.
+steps:
+  - Take your normal warm shower first, washing as usual.
+  - At the end, lower the temperature gradually until the water is cold but tolerable.
+  - Stand under the cold stream for 30 seconds, breathing slowly and deeply through the nose.
+  - Notice the urge to brace or gasp — instead, soften the jaw and shoulders.
+  - Step out and dry off vigorously to rewarm.
+  - Each subsequent day, add 15 seconds until you reach 2-3 minutes total.
+evidence_rating: B
+contraindications:
+  - cardiovascular disease (uncleared)
+  - Raynaud's phenomenon
+  - pregnancy without obstetric clearance
+  - cold urticaria
+  - acute PTSD without clinical supervision
+duration_minutes: 5

--- a/alchymine/engine/healing/skills/yaml/sleep-cbt-i-wind-down.yaml
+++ b/alchymine/engine/healing/skills/yaml/sleep-cbt-i-wind-down.yaml
@@ -1,0 +1,20 @@
+name: sleep-cbt-i-wind-down
+modality: sleep_healing
+title: CBT-I Wind-Down Routine
+description: >-
+  A 30-minute pre-sleep routine drawn from cognitive behavioural therapy for
+  insomnia (CBT-I), the first-line non-pharmacological treatment for chronic
+  insomnia. The protocol cues the nervous system that sleep is imminent through
+  light, temperature, and stimulus control.
+steps:
+  - 30 minutes before intended sleep, dim all bright lights and put screens away (or use a strict night filter).
+  - Lower the room temperature toward 18-19 C and ventilate if possible.
+  - Spend 10 minutes on a quiet, non-stimulating activity (reading paper, light stretching, journaling).
+  - Write a 3-line "tomorrow list" so the mind has nowhere new to wander.
+  - Get into bed only when sleepy. If awake after 20 minutes, get up, sit somewhere dim, and return when sleepy again.
+  - Keep a consistent wake time the next morning regardless of how the night went.
+evidence_rating: A
+contraindications:
+  - untreated sleep apnoea requiring CPAP titration
+  - severe restless leg syndrome (consult clinician)
+duration_minutes: 30

--- a/alchymine/engine/healing/skills/yaml/somatic-grounding-5-4-3-2-1.yaml
+++ b/alchymine/engine/healing/skills/yaml/somatic-grounding-5-4-3-2-1.yaml
@@ -1,0 +1,20 @@
+name: somatic-grounding-5-4-3-2-1
+modality: somatic_practice
+title: 5-4-3-2-1 Sensory Grounding
+description: >-
+  A trauma-informed grounding technique that interrupts dissociation, anxious
+  spirals, and panic by anchoring attention to the immediate sensory environment.
+  Widely used in clinical settings for its simplicity and quick effect.
+steps:
+  - Plant both feet on the floor and feel the contact between feet and ground.
+  - Name 5 things you can see in the room — describe each in one short phrase.
+  - Name 4 things you can physically feel (clothing, chair, air on skin, weight of hands).
+  - Name 3 things you can hear right now, near or far.
+  - Name 2 things you can smell, or two smells you can recall vividly.
+  - Name 1 thing you can taste, or take a sip of water and name what you taste.
+  - Take one slow breath and notice the difference from when you started.
+evidence_rating: B
+contraindications:
+  - recent major surgery preventing seated posture
+  - acute physical injury at the practice site
+duration_minutes: 5

--- a/alchymine/engine/healing/skills/yaml/sound-humming-vagal-toning.yaml
+++ b/alchymine/engine/healing/skills/yaml/sound-humming-vagal-toning.yaml
@@ -1,0 +1,21 @@
+name: sound-humming-vagal-toning
+modality: sound_healing
+title: Humming Bee Breath (Bhramari) for Vagal Toning
+description: >-
+  An ancient Yogic practice that uses extended humming on the exhale to
+  stimulate the vagus nerve and produce a soothing buzz felt in the head and
+  chest. Small studies show acute reductions in heart rate, blood pressure, and
+  self-reported anxiety.
+steps:
+  - Sit upright in a comfortable cross-legged or chair position.
+  - Place your index fingers gently on the cartilage flaps in front of the ears (do not press hard).
+  - Inhale slowly through the nose for a count of 4.
+  - On the exhale, keep the lips closed and produce a steady, low-pitched "mmm" hum until the breath is fully out.
+  - Notice the vibration in the lips, palate, and skull.
+  - Repeat for 7 cycles, then sit silently for 1 minute.
+evidence_rating: C
+contraindications:
+  - sound-triggered epilepsy
+  - severe hyperacusis
+  - acute middle-ear infection
+duration_minutes: 8

--- a/alchymine/engine/healing/skills/yaml/water-warm-bath-immersion.yaml
+++ b/alchymine/engine/healing/skills/yaml/water-warm-bath-immersion.yaml
@@ -1,0 +1,23 @@
+name: water-warm-bath-immersion
+modality: water_healing
+title: Mindful Warm Bath Immersion
+description: >-
+  A simple hydrotherapy practice — a 20-minute warm bath taken with full
+  sensory attention. Studies suggest evening warm immersion can shorten sleep
+  onset and lower core temperature on exit, supporting deeper sleep.
+steps:
+  - Run a warm (not hot) bath, around 38-40 C, with the bathroom dimly lit.
+  - Optional — add a handful of unscented epsom salts and stir to dissolve.
+  - Step in slowly and let the body acclimate before fully reclining.
+  - For the first 5 minutes, simply notice the sensation of warmth, weight, and buoyancy.
+  - For the next 10 minutes, breathe long and slow, letting attention rest on the sound of water.
+  - Stay no longer than 20 minutes total to avoid overheating.
+  - On exit, dry off in a warm towel and notice the contrast as the body cools.
+evidence_rating: B
+contraindications:
+  - severe aquaphobia
+  - open wounds or active skin infections
+  - cardiovascular conditions where heat is contraindicated
+  - first-trimester pregnancy without obstetric clearance for warm immersion
+  - uncontrolled epilepsy
+duration_minutes: 25

--- a/tests/api/test_bridges.py
+++ b/tests/api/test_bridges.py
@@ -1,0 +1,165 @@
+"""Tests for the public cross-system bridges API endpoints."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from alchymine.api.main import app
+
+EXPECTED_IDS = {"XS-01", "XS-02", "XS-03", "XS-04", "XS-05", "XS-06", "XS-07"}
+REQUIRED_FIELDS = (
+    "id",
+    "name",
+    "source_system",
+    "target_system",
+    "description",
+    "insight_keys",
+)
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# GET /api/v1/bridges
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestListBridges:
+    def test_list_all_bridges(self, client: TestClient) -> None:
+        response = client.get("/api/v1/bridges")
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) == 7
+
+    def test_list_bridges_structure(self, client: TestClient) -> None:
+        response = client.get("/api/v1/bridges")
+        assert response.status_code == 200
+        for bridge in response.json():
+            for field in REQUIRED_FIELDS:
+                assert field in bridge, f"missing {field} in {bridge}"
+            assert isinstance(bridge["insight_keys"], list)
+            assert len(bridge["insight_keys"]) >= 1
+
+    def test_all_bridge_ids_present(self, client: TestClient) -> None:
+        response = client.get("/api/v1/bridges")
+        ids = {b["id"] for b in response.json()}
+        assert ids == EXPECTED_IDS
+
+    def test_list_returns_stable_order(self, client: TestClient) -> None:
+        response = client.get("/api/v1/bridges")
+        ids = [b["id"] for b in response.json()]
+        assert ids == sorted(ids)
+        assert ids[0] == "XS-01"
+        assert ids[-1] == "XS-07"
+
+    def test_filter_by_source_system(self, client: TestClient) -> None:
+        response = client.get("/api/v1/bridges", params={"source": "healing"})
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) >= 1
+        for b in data:
+            assert b["source_system"] == "healing"
+        # XS-01 (healing→perspective) and XS-06 (healing→creative)
+        assert {b["id"] for b in data} == {"XS-01", "XS-06"}
+
+    def test_filter_by_target_system(self, client: TestClient) -> None:
+        response = client.get("/api/v1/bridges", params={"target": "wealth"})
+        assert response.status_code == 200
+        data = response.json()
+        for b in data:
+            assert b["target_system"] == "wealth"
+        # XS-05 (perspective→wealth)
+        assert {b["id"] for b in data} == {"XS-05"}
+
+    def test_filter_by_both(self, client: TestClient) -> None:
+        response = client.get(
+            "/api/v1/bridges",
+            params={"source": "intelligence", "target": "perspective"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        # XS-07 (intelligence→perspective)
+        assert len(data) == 1
+        assert data[0]["id"] == "XS-07"
+
+    def test_filter_unknown_source_returns_empty(self, client: TestClient) -> None:
+        response = client.get("/api/v1/bridges", params={"source": "definitely-not-real"})
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_filter_unknown_target_returns_empty(self, client: TestClient) -> None:
+        response = client.get("/api/v1/bridges", params={"target": "definitely-not-real"})
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_filter_combo_with_no_matches_returns_empty(self, client: TestClient) -> None:
+        # healing→healing doesn't exist
+        response = client.get(
+            "/api/v1/bridges",
+            params={"source": "healing", "target": "healing"},
+        )
+        assert response.status_code == 200
+        assert response.json() == []
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# GET /api/v1/bridges/{bridge_id}
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestGetSingleBridge:
+    def test_get_single_bridge(self, client: TestClient) -> None:
+        response = client.get("/api/v1/bridges/XS-01")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == "XS-01"
+        assert data["source_system"] == "healing"
+        assert data["target_system"] == "perspective"
+        for field in REQUIRED_FIELDS:
+            assert field in data
+
+    def test_get_unknown_bridge(self, client: TestClient) -> None:
+        response = client.get("/api/v1/bridges/XS-99")
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+
+    def test_get_bridge_with_garbage_id(self, client: TestClient) -> None:
+        response = client.get("/api/v1/bridges/not-a-bridge")
+        assert response.status_code == 404
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Auth: endpoints are public reference data
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_list_endpoint_is_public() -> None:
+    """Bridges are open reference data — must work even when the auth
+    override fixture is bypassed by clearing dependency overrides.
+    """
+    app.dependency_overrides.clear()
+    try:
+        with TestClient(app) as client:
+            response = client.get("/api/v1/bridges")
+            assert response.status_code == 200
+            assert isinstance(response.json(), list)
+            assert len(response.json()) == 7
+    finally:
+        # conftest's autouse fixtures will re-install overrides next test.
+        pass
+
+
+def test_get_endpoint_is_public() -> None:
+    app.dependency_overrides.clear()
+    try:
+        with TestClient(app) as client:
+            response = client.get("/api/v1/bridges/XS-02")
+            assert response.status_code == 200
+            assert response.json()["id"] == "XS-02"
+    finally:
+        pass

--- a/tests/api/test_healing_skills.py
+++ b/tests/api/test_healing_skills.py
@@ -1,0 +1,101 @@
+"""Tests for the public healing skills API endpoints."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from alchymine.api.main import app
+from alchymine.engine.healing.modalities import MODALITY_REGISTRY
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+# ── GET /api/v1/healing/skills ─────────────────────────────────────────
+
+
+class TestListHealingSkills:
+    def test_returns_200_and_15_skills(self, client: TestClient) -> None:
+        response = client.get("/api/v1/healing/skills")
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) == 15
+
+    def test_skill_payload_has_required_fields(self, client: TestClient) -> None:
+        response = client.get("/api/v1/healing/skills")
+        assert response.status_code == 200
+        skill = response.json()[0]
+        for field in (
+            "name",
+            "modality",
+            "title",
+            "description",
+            "steps",
+            "evidence_rating",
+            "contraindications",
+            "duration_minutes",
+        ):
+            assert field in skill, f"missing {field}"
+        assert isinstance(skill["steps"], list)
+        assert len(skill["steps"]) >= 1
+
+    def test_filter_by_modality(self, client: TestClient) -> None:
+        response = client.get("/api/v1/healing/skills", params={"modality": "breathwork"})
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) >= 1
+        for skill in data:
+            assert skill["modality"] == "breathwork"
+
+    def test_unknown_modality_returns_empty_list(self, client: TestClient) -> None:
+        response = client.get(
+            "/api/v1/healing/skills",
+            params={"modality": "definitely-not-a-modality"},
+        )
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_every_modality_represented(self, client: TestClient) -> None:
+        response = client.get("/api/v1/healing/skills")
+        modalities = {s["modality"] for s in response.json()}
+        assert modalities == set(MODALITY_REGISTRY.keys())
+
+
+# ── GET /api/v1/healing/skills/{name} ──────────────────────────────────
+
+
+class TestGetHealingSkill:
+    def test_returns_skill_when_found(self, client: TestClient) -> None:
+        response = client.get("/api/v1/healing/skills/breathwork-box-breathing")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "breathwork-box-breathing"
+        assert data["modality"] == "breathwork"
+        assert data["evidence_rating"] in {"A", "B", "C", "D"}
+
+    def test_returns_404_when_not_found(self, client: TestClient) -> None:
+        response = client.get("/api/v1/healing/skills/no-such-skill")
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+
+
+# ── Auth: endpoints are public reference data ─────────────────────────
+
+
+def test_list_endpoint_does_not_require_auth() -> None:
+    """Skills are open reference data — must work even when the auth
+    override fixture is bypassed by clearing dependency overrides.
+    """
+    app.dependency_overrides.clear()
+    try:
+        with TestClient(app) as client:
+            response = client.get("/api/v1/healing/skills")
+            assert response.status_code == 200
+            assert isinstance(response.json(), list)
+    finally:
+        # conftest's autouse fixtures will re-install overrides next test.
+        pass

--- a/tests/engine/healing/test_seed_skills.py
+++ b/tests/engine/healing/test_seed_skills.py
@@ -1,0 +1,44 @@
+"""Smoke tests for the bundled healing skill YAML files.
+
+These tests load the real directory at
+``alchymine/engine/healing/skills/yaml/`` and verify that all 15 seed
+skills parse cleanly and that each modality is represented exactly once.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+from alchymine.engine.healing.modalities import MODALITY_REGISTRY
+from alchymine.engine.healing.skills import SkillRegistry, get_default_yaml_dir
+
+
+def test_seed_directory_loads_all_files() -> None:
+    reg = SkillRegistry()
+    reg.load_directory(get_default_yaml_dir())
+    assert len(reg) == 15
+
+
+def test_each_modality_has_exactly_one_seed_skill() -> None:
+    reg = SkillRegistry()
+    reg.load_directory(get_default_yaml_dir())
+
+    counts = Counter(skill.modality for skill in reg.list_all())
+    expected = set(MODALITY_REGISTRY.keys())
+
+    assert set(counts.keys()) == expected, (
+        f"missing modalities: {expected - set(counts.keys())}; "
+        f"extra modalities: {set(counts.keys()) - expected}"
+    )
+    duplicates = {m: c for m, c in counts.items() if c != 1}
+    assert not duplicates, f"modalities with !=1 seed skill: {duplicates}"
+
+
+def test_seed_skills_have_meaningful_content() -> None:
+    reg = SkillRegistry()
+    reg.load_directory(get_default_yaml_dir())
+
+    for skill in reg.list_all():
+        assert skill.duration_minutes > 0
+        assert len(skill.steps) >= 3, f"{skill.name}: needs at least 3 steps"
+        assert len(skill.description) >= 40, f"{skill.name}: description too short"

--- a/tests/engine/healing/test_skill_loader.py
+++ b/tests/engine/healing/test_skill_loader.py
@@ -1,0 +1,316 @@
+"""Tests for the healing SkillRegistry loader and SkillDefinition schema."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+from pydantic import ValidationError
+
+from alchymine.engine.healing.skills import (
+    SkillDefinition,
+    SkillNotFoundError,
+    SkillRegistry,
+    SkillValidationError,
+)
+
+# ── Schema validation ──────────────────────────────────────────────────
+
+
+def _valid_payload(**overrides: object) -> dict:
+    base: dict = {
+        "name": "box-breath-foundation",
+        "modality": "breathwork",
+        "title": "Box Breathing Foundation",
+        "description": "A baseline 4-4-4-4 breathing protocol.",
+        "steps": [
+            "Sit comfortably and close your eyes.",
+            "Inhale through the nose for 4 counts.",
+            "Hold for 4 counts.",
+            "Exhale through the mouth for 4 counts.",
+        ],
+        "evidence_rating": "B",
+        "contraindications": ["severe asthma"],
+        "duration_minutes": 5,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_valid_skill_parses() -> None:
+    skill = SkillDefinition.model_validate(_valid_payload())
+    assert skill.name == "box-breath-foundation"
+    assert skill.modality == "breathwork"
+    assert skill.duration_minutes == 5
+
+
+def test_skill_is_frozen() -> None:
+    skill = SkillDefinition.model_validate(_valid_payload())
+    with pytest.raises(ValidationError):
+        skill.name = "different-name"  # type: ignore[misc]
+
+
+def test_extra_fields_forbidden() -> None:
+    with pytest.raises(ValidationError):
+        SkillDefinition.model_validate(_valid_payload(unexpected_field="oops"))
+
+
+@pytest.mark.parametrize(
+    "missing",
+    [
+        "name",
+        "modality",
+        "title",
+        "description",
+        "steps",
+        "evidence_rating",
+        "duration_minutes",
+    ],
+)
+def test_missing_required_field_raises(missing: str) -> None:
+    payload = _valid_payload()
+    payload.pop(missing)
+    with pytest.raises(ValidationError):
+        SkillDefinition.model_validate(payload)
+
+
+def test_unknown_modality_rejected() -> None:
+    with pytest.raises(ValidationError):
+        SkillDefinition.model_validate(_valid_payload(modality="not-a-real-modality"))
+
+
+def test_invalid_evidence_rating_rejected() -> None:
+    with pytest.raises(ValidationError):
+        SkillDefinition.model_validate(_valid_payload(evidence_rating="Z"))
+
+
+def test_zero_duration_rejected() -> None:
+    with pytest.raises(ValidationError):
+        SkillDefinition.model_validate(_valid_payload(duration_minutes=0))
+
+
+def test_empty_steps_rejected() -> None:
+    with pytest.raises(ValidationError):
+        SkillDefinition.model_validate(_valid_payload(steps=[]))
+
+
+def test_blank_step_rejected() -> None:
+    with pytest.raises(ValidationError):
+        SkillDefinition.model_validate(_valid_payload(steps=["good step", "   "]))
+
+
+def test_uppercase_name_rejected() -> None:
+    with pytest.raises(ValidationError):
+        SkillDefinition.model_validate(_valid_payload(name="BoxBreath"))
+
+
+def test_underscore_name_rejected() -> None:
+    with pytest.raises(ValidationError):
+        SkillDefinition.model_validate(_valid_payload(name="box_breath"))
+
+
+def test_steps_must_be_list_of_strings() -> None:
+    with pytest.raises(ValidationError):
+        SkillDefinition.model_validate(_valid_payload(steps="just one string"))
+
+
+# ── Registry / loader ──────────────────────────────────────────────────
+
+
+def _write_yaml(directory: Path, filename: str, content: str) -> Path:
+    file_path = directory / filename
+    file_path.write_text(dedent(content).strip() + "\n", encoding="utf-8")
+    return file_path
+
+
+@pytest.fixture
+def fake_skills_dir(tmp_path: Path) -> Path:
+    yaml_dir = tmp_path / "yaml"
+    yaml_dir.mkdir()
+    _write_yaml(
+        yaml_dir,
+        "alpha.yaml",
+        """
+        name: alpha-skill
+        modality: breathwork
+        title: Alpha Skill
+        description: First skill.
+        steps:
+          - Step one
+          - Step two
+        evidence_rating: A
+        contraindications: []
+        duration_minutes: 10
+        """,
+    )
+    _write_yaml(
+        yaml_dir,
+        "beta.yaml",
+        """
+        name: beta-skill
+        modality: somatic_practice
+        title: Beta Skill
+        description: Second skill.
+        steps:
+          - Move slowly
+        evidence_rating: B
+        contraindications:
+          - acute injury
+        duration_minutes: 15
+        """,
+    )
+    _write_yaml(
+        yaml_dir,
+        "gamma.yaml",
+        """
+        name: gamma-skill
+        modality: breathwork
+        title: Gamma Skill
+        description: Third skill.
+        steps:
+          - Inhale
+          - Exhale
+        evidence_rating: C
+        contraindications: []
+        duration_minutes: 7
+        """,
+    )
+    return yaml_dir
+
+
+def test_load_directory_loads_all_files(fake_skills_dir: Path) -> None:
+    reg = SkillRegistry()
+    reg.load_directory(fake_skills_dir)
+    assert len(reg) == 3
+
+
+def test_get_returns_skill(fake_skills_dir: Path) -> None:
+    reg = SkillRegistry()
+    reg.load_directory(fake_skills_dir)
+    skill = reg.get("alpha-skill")
+    assert skill.title == "Alpha Skill"
+
+
+def test_get_missing_raises_skill_not_found(fake_skills_dir: Path) -> None:
+    reg = SkillRegistry()
+    reg.load_directory(fake_skills_dir)
+    with pytest.raises(SkillNotFoundError):
+        reg.get("does-not-exist")
+
+
+def test_list_by_modality_filters_correctly(fake_skills_dir: Path) -> None:
+    reg = SkillRegistry()
+    reg.load_directory(fake_skills_dir)
+    breath = reg.list_by_modality("breathwork")
+    somatic = reg.list_by_modality("somatic_practice")
+    assert {s.name for s in breath} == {"alpha-skill", "gamma-skill"}
+    assert {s.name for s in somatic} == {"beta-skill"}
+
+
+def test_list_all_returns_every_skill(fake_skills_dir: Path) -> None:
+    reg = SkillRegistry()
+    reg.load_directory(fake_skills_dir)
+    assert len(reg.list_all()) == 3
+
+
+def test_load_twice_replaces_registry(tmp_path: Path, fake_skills_dir: Path) -> None:
+    reg = SkillRegistry()
+    reg.load_directory(fake_skills_dir)
+    assert len(reg) == 3
+
+    smaller = tmp_path / "smaller"
+    smaller.mkdir()
+    _write_yaml(
+        smaller,
+        "only.yaml",
+        """
+        name: only-skill
+        modality: nature_healing
+        title: Only Skill
+        description: Sole entry.
+        steps:
+          - Walk outside
+        evidence_rating: B
+        contraindications: []
+        duration_minutes: 20
+        """,
+    )
+    reg.load_directory(smaller)
+    assert len(reg) == 1
+    assert reg.get("only-skill").modality == "nature_healing"
+    with pytest.raises(SkillNotFoundError):
+        reg.get("alpha-skill")
+
+
+def test_invalid_yaml_raises_validation_error(tmp_path: Path) -> None:
+    yaml_dir = tmp_path / "bad"
+    yaml_dir.mkdir()
+    _write_yaml(
+        yaml_dir,
+        "broken.yaml",
+        """
+        name: broken
+        modality: not-a-real-modality
+        title: Broken
+        description: Bad modality.
+        steps:
+          - Step
+        evidence_rating: A
+        duration_minutes: 5
+        """,
+    )
+    reg = SkillRegistry()
+    with pytest.raises(SkillValidationError, match="broken.yaml"):
+        reg.load_directory(yaml_dir)
+
+
+def test_malformed_yaml_raises(tmp_path: Path) -> None:
+    yaml_dir = tmp_path / "malformed"
+    yaml_dir.mkdir()
+    (yaml_dir / "garbage.yaml").write_text("name: [unbalanced\n", encoding="utf-8")
+    reg = SkillRegistry()
+    with pytest.raises(SkillValidationError, match="garbage.yaml"):
+        reg.load_directory(yaml_dir)
+
+
+def test_duplicate_skill_names_rejected(tmp_path: Path) -> None:
+    yaml_dir = tmp_path / "dupes"
+    yaml_dir.mkdir()
+    _write_yaml(
+        yaml_dir,
+        "one.yaml",
+        """
+        name: same-name
+        modality: breathwork
+        title: One
+        description: First.
+        steps:
+          - A
+        evidence_rating: A
+        duration_minutes: 5
+        """,
+    )
+    _write_yaml(
+        yaml_dir,
+        "two.yaml",
+        """
+        name: same-name
+        modality: somatic_practice
+        title: Two
+        description: Second.
+        steps:
+          - B
+        evidence_rating: B
+        duration_minutes: 6
+        """,
+    )
+    reg = SkillRegistry()
+    with pytest.raises(SkillValidationError, match="Duplicate"):
+        reg.load_directory(yaml_dir)
+
+
+def test_missing_directory_raises(tmp_path: Path) -> None:
+    reg = SkillRegistry()
+    with pytest.raises(FileNotFoundError):
+        reg.load_directory(tmp_path / "nope")

--- a/tests/engine/test_bridges_registry.py
+++ b/tests/engine/test_bridges_registry.py
@@ -1,0 +1,166 @@
+"""Unit tests for the cross-system bridges registry."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from alchymine.engine.bridges import (
+    BRIDGE_REGISTRY,
+    Bridge,
+    BridgeNotFoundError,
+    get_bridge,
+    list_bridges,
+    list_bridges_from,
+    list_bridges_to,
+)
+from alchymine.engine.bridges.registry import VALID_SYSTEMS
+
+EXPECTED_IDS = ("XS-01", "XS-02", "XS-03", "XS-04", "XS-05", "XS-06", "XS-07")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Registry composition
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestRegistryComposition:
+    def test_registry_has_all_seven_bridges(self) -> None:
+        assert len(BRIDGE_REGISTRY) == 7
+        assert set(BRIDGE_REGISTRY.keys()) == set(EXPECTED_IDS)
+
+    def test_bridge_ids_are_unique(self) -> None:
+        ids = [b.id for b in BRIDGE_REGISTRY.values()]
+        assert len(ids) == len(set(ids))
+
+    def test_dict_key_matches_bridge_id_field(self) -> None:
+        for key, bridge in BRIDGE_REGISTRY.items():
+            assert key == bridge.id
+
+    def test_source_systems_are_valid(self) -> None:
+        for bridge in BRIDGE_REGISTRY.values():
+            assert bridge.source_system in VALID_SYSTEMS, (
+                f"{bridge.id} has invalid source_system={bridge.source_system!r}"
+            )
+
+    def test_target_systems_are_valid(self) -> None:
+        for bridge in BRIDGE_REGISTRY.values():
+            assert bridge.target_system in VALID_SYSTEMS, (
+                f"{bridge.id} has invalid target_system={bridge.target_system!r}"
+            )
+
+    def test_source_and_target_differ(self) -> None:
+        for bridge in BRIDGE_REGISTRY.values():
+            assert bridge.source_system != bridge.target_system, (
+                f"{bridge.id} has source==target ({bridge.source_system})"
+            )
+
+    def test_every_bridge_has_nonempty_metadata(self) -> None:
+        for bridge in BRIDGE_REGISTRY.values():
+            assert bridge.name.strip(), f"{bridge.id} has empty name"
+            assert bridge.description.strip(), f"{bridge.id} has empty description"
+            assert len(bridge.insight_keys) >= 1, f"{bridge.id} has no insight_keys"
+
+    def test_insight_keys_is_a_tuple(self) -> None:
+        # Frozen dataclass + tuple makes the entry effectively immutable.
+        for bridge in BRIDGE_REGISTRY.values():
+            assert isinstance(bridge.insight_keys, tuple)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# get_bridge
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestGetBridge:
+    def test_get_bridge_returns_known_id(self) -> None:
+        bridge = get_bridge("XS-01")
+        assert bridge.id == "XS-01"
+        assert bridge.source_system == "healing"
+        assert bridge.target_system == "perspective"
+
+    def test_get_bridge_raises_on_unknown_id(self) -> None:
+        with pytest.raises(BridgeNotFoundError):
+            get_bridge("XS-99")
+
+    def test_get_bridge_raises_on_empty_string(self) -> None:
+        with pytest.raises(BridgeNotFoundError):
+            get_bridge("")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# list_bridges* helpers
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestListBridges:
+    def test_list_bridges_returns_seven(self) -> None:
+        bridges = list_bridges()
+        assert len(bridges) == 7
+
+    def test_list_bridges_returns_stable_order(self) -> None:
+        bridges = list_bridges()
+        ids = tuple(b.id for b in bridges)
+        assert ids == EXPECTED_IDS
+
+    def test_list_bridges_returns_tuple(self) -> None:
+        bridges = list_bridges()
+        assert isinstance(bridges, tuple)
+
+    def test_list_bridges_from_filters_correctly(self) -> None:
+        healing_sources = list_bridges_from("healing")
+        # XS-01 (healing→perspective) and XS-06 (healing→creative)
+        assert {b.id for b in healing_sources} == {"XS-01", "XS-06"}
+        for b in healing_sources:
+            assert b.source_system == "healing"
+
+    def test_list_bridges_from_unknown_returns_empty(self) -> None:
+        assert list_bridges_from("not-a-system") == ()
+
+    def test_list_bridges_to_filters_correctly(self) -> None:
+        healing_targets = list_bridges_to("healing")
+        # XS-02 (intelligence→healing), XS-03 (wealth→healing),
+        # XS-04 (creative→healing)
+        assert {b.id for b in healing_targets} == {"XS-02", "XS-03", "XS-04"}
+        for b in healing_targets:
+            assert b.target_system == "healing"
+
+    def test_list_bridges_to_unknown_returns_empty(self) -> None:
+        assert list_bridges_to("not-a-system") == ()
+
+    def test_list_bridges_from_preserves_id_order(self) -> None:
+        bridges = list_bridges_from("intelligence")
+        ids = [b.id for b in bridges]
+        assert ids == sorted(ids)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Frozenness
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestBridgeIsFrozen:
+    def test_bridge_attributes_cannot_be_mutated(self) -> None:
+        bridge = get_bridge("XS-01")
+        with pytest.raises(FrozenInstanceError):
+            bridge.name = "Hacked"  # type: ignore[misc]
+
+    def test_cannot_add_new_attribute(self) -> None:
+        bridge = get_bridge("XS-01")
+        with pytest.raises(FrozenInstanceError):
+            bridge.foo = "bar"  # type: ignore[attr-defined]
+
+    def test_bridge_dataclass_is_frozen_class_level(self) -> None:
+        # Sanity: instantiating a fresh Bridge and trying to mutate it
+        # should also raise.
+        b = Bridge(
+            id="XS-XX",
+            name="Test",
+            source_system="healing",
+            target_system="creative",
+            description="d",
+            insight_keys=("k",),
+        )
+        with pytest.raises(FrozenInstanceError):
+            b.id = "XS-YY"  # type: ignore[misc]


### PR DESCRIPTION
## Summary
- **Issues:** #156 (healing skills), #158 (bridges)
- Skills YAML schema + `SkillRegistry` loader + 15 seed healing skill files
- Cross-system bridge registry (XS-01..XS-07) mapping insights between all 5 systems
- API: `GET /api/v1/healing/skills`, `GET /api/v1/healing/skills/{name}`, `GET /api/v1/bridges`, `GET /api/v1/bridges/{id}`
- 76 tests (39 skills + 37 bridges)

## Test plan
- [ ] `pytest tests/engine/healing/ -v` — skill loader + validation
- [ ] `pytest tests/api/test_healing_skills.py -v` — skills API
- [ ] `pytest tests/api/test_bridges.py -v` — bridges API
- [ ] `ruff check && ruff format --check` — lint clean

Closes #156, closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)