### PR TITLE
feat(art): Gemini generative art, creative studio UI, style presets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,15 @@ LLM_MODEL=claude-sonnet-4-20250514
 OLLAMA_BASE_URL=http://localhost:11434
 OLLAMA_MODEL=llama3.2
 
+# ─── Gemini (Generative Art — optional) ──────────────────────────────────
+# Optional. When unset, generative art endpoints return 204 and the
+# frontend renders an on-brand gradient placeholder. Install the optional
+# SDK with: pip install "alchymine[gemini]"
+GEMINI_API_KEY=
+GEMINI_MODEL=gemini-2.0-flash-preview-image-generation
+# Filesystem cache for generated image bytes (relative to project root)
+ART_CACHE_DIR=data/generated_images
+
 # ─── API (non-Settings — used by Docker / uvicorn) ───────────────────────
 API_HOST=0.0.0.0
 API_PORT=8000

--- a/alchymine/api/main.py
+++ b/alchymine/api/main.py
@@ -30,6 +30,7 @@ from alchymine.api.routers import (
     compatibility,
     creative,
     feedback,
+    generative_art,
     healing,
     healing_skills,
     health,
@@ -136,3 +137,4 @@ app.include_router(spiral.router, prefix="/api/v1", tags=["spiral"])
 app.include_router(integration.router, prefix="/api/v1", tags=["integration"])
 app.include_router(admin.router, prefix="/api/v1", tags=["admin"])
 app.include_router(feedback.router, prefix="/api/v1", tags=["feedback"])
+app.include_router(generative_art.router, prefix="/api/v1", tags=["art"])

--- a/alchymine/api/routers/generative_art.py
+++ b/alchymine/api/routers/generative_art.py
@@ -1,0 +1,229 @@
+"""Generative art API endpoints.
+
+Provides personalized image generation via Gemini. All endpoints degrade
+gracefully (``204 No Content``) when ``GEMINI_API_KEY`` is not
+configured, so the frontend can render an on-brand placeholder.
+
+Endpoints
+---------
+``POST /api/v1/art/generate``
+    Generate a single hero image for the authenticated user. Body
+    accepts an optional ``style_preset`` and an optional
+    ``user_prompt_extension``. The extension is sanitized through the
+    project content filter to block PII, harmful content, and ethics
+    violations.
+
+``GET /api/v1/art/{image_id}``
+    Stream the raw image bytes back to the owning user. Returns 404 to
+    requests from any other user (we deliberately do not leak existence
+    via 403/200 split).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import Response
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from alchymine.api.auth import get_current_user
+from alchymine.api.deps import get_db_session
+from alchymine.db import repository
+from alchymine.db.models import User
+from alchymine.llm.art_prompts import STYLE_PRESETS, build_studio_prompt
+from alchymine.llm.art_storage import read_image, write_image
+from alchymine.llm.gemini import GeminiClient, get_gemini_client
+from alchymine.safety.content_filter import FilterAction, filter_content
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/art", tags=["art"])
+
+
+# ── Request / response models ─────────────────────────────────────────
+
+
+class ArtGenerateRequest(BaseModel):
+    """Body for ``POST /art/generate``."""
+
+    style_preset: str | None = Field(
+        default=None,
+        description=f"One of: {', '.join(sorted(STYLE_PRESETS.keys()))}",
+    )
+    user_prompt_extension: str | None = Field(
+        default=None,
+        max_length=400,
+        description="Optional user-supplied theme to append to the base prompt",
+    )
+
+
+class ArtGenerateResponse(BaseModel):
+    """Body returned on successful generation."""
+
+    image_id: str
+    url: str
+    prompt: str
+
+
+# ── Dependency wrappers ───────────────────────────────────────────────
+
+
+def _gemini_dependency() -> GeminiClient:
+    return get_gemini_client()
+
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+async def _load_identity_dict(session: AsyncSession, user_id: str) -> dict[str, object]:
+    """Load the user's identity layer into a plain dict for the prompt builder.
+
+    Returns an empty dict for users without an identity profile so the
+    builder falls back to its default imagery rather than raising.
+    """
+    user: User | None = await repository.get_profile(session, user_id)
+    if user is None or user.identity is None:
+        return {}
+    identity = user.identity
+    return {
+        "archetype": identity.archetype or {},
+        "astrology": identity.astrology or {},
+        "numerology": identity.numerology or {},
+    }
+
+
+def _validate_style_preset(preset: str | None) -> None:
+    if preset is not None and preset not in STYLE_PRESETS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Invalid style_preset {preset!r}. Must be one of: {sorted(STYLE_PRESETS.keys())}"
+            ),
+        )
+
+
+def _sanitize_extension(extension: str | None) -> str | None:
+    """Run a user-supplied prompt extension through the content filter.
+
+    Returns the cleaned text on success, or raises 400 on a hard block.
+    """
+    if not extension or not extension.strip():
+        return None
+    result = filter_content(
+        extension,
+        context="creative",
+        redact_pii=True,
+        check_crisis=False,
+    )
+    if result.action == FilterAction.BLOCK:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Prompt extension blocked: {result.blocked_reason}",
+        )
+    return result.filtered_text
+
+
+# ── Routes ────────────────────────────────────────────────────────────
+
+
+@router.post(
+    "/generate",
+    response_model=ArtGenerateResponse,
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        201: {"description": "Image generated and stored"},
+        204: {"description": "Generative art is disabled or generation returned no image"},
+        400: {"description": "Invalid style preset or blocked user prompt"},
+        401: {"description": "Authentication required"},
+    },
+)
+async def generate_art(
+    request: ArtGenerateRequest,
+    current_user: dict = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db_session),
+    gemini: GeminiClient = Depends(_gemini_dependency),
+) -> Response | ArtGenerateResponse:
+    """Generate a single personalized hero image for the authenticated user."""
+    user_id = current_user.get("sub")
+    if not user_id:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="No user")
+
+    # Validate inputs early so 400s never reach the generator.
+    _validate_style_preset(request.style_preset)
+    cleaned_extension = _sanitize_extension(request.user_prompt_extension)
+
+    if not gemini.is_available:
+        # The frontend treats 204 as a signal to render its placeholder.
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    # Build the personalized prompt from the user's identity layer.
+    identity_dict = await _load_identity_dict(session, user_id)
+    prompt = build_studio_prompt(
+        identity_dict,
+        user_extension=cleaned_extension,
+        style_preset=request.style_preset,
+    )
+
+    result = await gemini.generate_image(prompt)
+    if result is None:
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    # Persist bytes to disk + metadata row to DB.
+    image_row = await repository.create_generated_image(
+        session,
+        user_id=user_id,
+        prompt=result.prompt,
+        file_path="",  # placeholder, set after we know the row id
+        mime_type=result.mime_type,
+        style_preset=request.style_preset,
+        model=result.model,
+    )
+    rel_path = write_image(
+        user_id=user_id,
+        image_id=image_row.id,
+        image_bytes=result.image_bytes,
+        mime_type=result.mime_type,
+    )
+    image_row.file_path = rel_path
+    await session.flush()
+
+    return ArtGenerateResponse(
+        image_id=image_row.id,
+        url=f"/api/v1/art/{image_row.id}",
+        prompt=result.prompt,
+    )
+
+
+@router.get(
+    "/{image_id}",
+    responses={
+        200: {"content": {"image/png": {}}, "description": "Raw image bytes"},
+        401: {"description": "Authentication required"},
+        404: {"description": "Image not found or not owned by the requesting user"},
+    },
+)
+async def get_image(
+    image_id: str,
+    current_user: dict = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db_session),
+) -> Response:
+    """Return the raw bytes of a previously generated image.
+
+    Returns 404 (not 403) when the requesting user does not own the
+    image, so we don't leak the existence of other users' images.
+    """
+    user_id = current_user.get("sub")
+    if not user_id:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="No user")
+
+    image = await repository.get_generated_image(session, image_id)
+    if image is None or image.user_id != user_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Image not found")
+
+    raw = read_image(image.file_path)
+    if raw is None:
+        # Row exists but the file is missing — treat as gone.
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Image not found")
+
+    return Response(content=raw, media_type=image.mime_type)

--- a/alchymine/api/routers/generative_art.py
+++ b/alchymine/api/routers/generative_art.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import Response
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -33,7 +33,7 @@ from alchymine.api.deps import get_db_session
 from alchymine.db import repository
 from alchymine.db.models import User
 from alchymine.llm.art_prompts import STYLE_PRESETS, build_studio_prompt
-from alchymine.llm.art_storage import read_image, write_image
+from alchymine.llm.art_storage import delete_image, read_image, write_image
 from alchymine.llm.gemini import GeminiClient, get_gemini_client
 from alchymine.safety.content_filter import FilterAction, filter_content
 
@@ -64,6 +64,52 @@ class ArtGenerateResponse(BaseModel):
     image_id: str
     url: str
     prompt: str
+
+
+class StylePresetOut(BaseModel):
+    """Public metadata for a single style preset.
+
+    The ``id`` corresponds to a key in
+    :data:`alchymine.llm.art_prompts.STYLE_PRESETS`; the canonical
+    suffix text lives only on the server. The ``name`` and
+    ``description`` are short human-facing labels safe to render in UI.
+    """
+
+    id: str
+    name: str
+    description: str
+
+
+# Short, human-readable metadata for each preset. The authoritative
+# style suffix text lives in ``alchymine.llm.art_prompts.STYLE_PRESETS``
+# — this dict is purely display copy for the frontend picker, keyed on
+# the same preset ids. If ``STYLE_PRESETS`` grows a new key, add a
+# matching entry here or the preset endpoint will 500.
+_PRESET_METADATA: dict[str, tuple[str, str]] = {
+    "mystical": ("Mystical", "Sacred geometry, indigo and gold"),
+    "modern": ("Modern", "Clean, editorial, muted gradients"),
+    "organic": ("Organic", "Botanical watercolour, earth tones"),
+    "celestial": ("Celestial", "Starfields, nebulae, violet and silver"),
+    "grounded": ("Grounded", "Stone, wood, terracotta, golden-hour"),
+}
+
+
+class ImageMetadata(BaseModel):
+    """Public metadata for a single stored generated image (no bytes)."""
+
+    id: str
+    prompt: str
+    style_preset: str | None
+    created_at: str
+    url: str
+
+
+class ImageListResponse(BaseModel):
+    """Response body for :func:`list_user_images`."""
+
+    images: list[ImageMetadata]
+    limit: int
+    offset: int
 
 
 # ── Dependency wrappers ───────────────────────────────────────────────
@@ -193,6 +239,112 @@ async def generate_art(
         url=f"/api/v1/art/{image_row.id}",
         prompt=result.prompt,
     )
+
+
+@router.get(
+    "/presets",
+    response_model=list[StylePresetOut],
+    responses={
+        200: {"description": "List of available style presets"},
+    },
+)
+async def list_style_presets() -> list[StylePresetOut]:
+    """Return the catalogue of style presets available to the studio.
+
+    Source of truth for preset ids is
+    :data:`alchymine.llm.art_prompts.STYLE_PRESETS` — this endpoint
+    projects each key through :data:`_PRESET_METADATA` to produce the
+    UI-facing label/description pair.
+    """
+    presets: list[StylePresetOut] = []
+    for preset_id in STYLE_PRESETS:
+        name, description = _PRESET_METADATA.get(
+            preset_id, (preset_id.title(), "Personalized style")
+        )
+        presets.append(StylePresetOut(id=preset_id, name=name, description=description))
+    return presets
+
+
+@router.get(
+    "/list",
+    response_model=ImageListResponse,
+    responses={
+        200: {"description": "List of the authenticated user's stored images"},
+        401: {"description": "Authentication required"},
+    },
+)
+async def list_user_images(
+    limit: int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+    current_user: dict = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db_session),
+) -> ImageListResponse:
+    """Return a page of the authenticated user's previously generated images.
+
+    Only metadata is returned — clients must call
+    ``GET /api/v1/art/{image_id}`` to stream the bytes. The default
+    page size of 20 covers the studio gallery on mount.
+    """
+    user_id = current_user.get("sub")
+    if not user_id:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="No user")
+
+    rows = await repository.list_generated_images_for_user(
+        session,
+        user_id,
+        limit=limit,
+        offset=offset,
+    )
+    images = [
+        ImageMetadata(
+            id=row.id,
+            prompt=row.prompt,
+            style_preset=row.style_preset,
+            # SQLAlchemy returns a datetime; ISO-8601 is the frontend format.
+            created_at=row.created_at.isoformat() if row.created_at is not None else "",
+            url=f"/api/v1/art/{row.id}",
+        )
+        for row in rows
+    ]
+    return ImageListResponse(images=images, limit=limit, offset=offset)
+
+
+@router.delete(
+    "/{image_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        204: {"description": "Image deleted"},
+        401: {"description": "Authentication required"},
+        404: {"description": "Image not found or not owned by the requesting user"},
+    },
+)
+async def delete_user_image(
+    image_id: str,
+    current_user: dict = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db_session),
+) -> Response:
+    """Delete a single stored image owned by the authenticated user.
+
+    Mirrors :func:`get_image`: cross-user access returns 404 (not 403)
+    to avoid leaking existence. If the DB row exists but the file on
+    disk is already missing, the row is still removed and 204 is
+    returned — the effective state is the same.
+    """
+    user_id = current_user.get("sub")
+    if not user_id:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="No user")
+
+    image = await repository.get_generated_image(session, image_id)
+    if image is None or image.user_id != user_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Image not found")
+
+    # Best-effort file unlink. We don't surface failures because the
+    # DB row is the source of truth for "does this image exist" — a
+    # stale file on disk without a row is orphaned and harmless.
+    delete_image(image.file_path)
+    await repository.delete_generated_image(session, image_id)
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get(

--- a/alchymine/config.py
+++ b/alchymine/config.py
@@ -67,6 +67,15 @@ class Settings(BaseSettings):
     anthropic_api_key: str = ""
     ollama_base_url: str = "http://localhost:11434"
 
+    # ── Gemini (Generative Art) ──────────────────────────────────────────
+    # Optional — when unset, the generative art endpoints degrade gracefully
+    # and return 204 No Content so the frontend can render placeholder art.
+    gemini_api_key: str = ""
+    gemini_model: str = "gemini-2.0-flash-preview-image-generation"
+    # Filesystem cache location for generated image bytes (relative paths
+    # are resolved against the project root at runtime).
+    art_cache_dir: str = "data/generated_images"
+
     # ── Celery ───────────────────────────────────────────────────────────
     celery_broker_url: str = "redis://localhost:6379/1"
     celery_result_backend: str = "redis://localhost:6379/2"

--- a/alchymine/db/migrations/versions/2026_03_10_0013_add_generated_images.py
+++ b/alchymine/db/migrations/versions/2026_03_10_0013_add_generated_images.py
@@ -1,0 +1,54 @@
+"""Add generated_images table for Gemini-generated art.
+
+Image bytes live on the filesystem at ART_CACHE_DIR/<user_id>/<id>.png;
+this table stores ownership and metadata so the router can verify
+access before serving bytes.
+
+Revision ID: 0013
+Revises: 0012
+Create Date: 2026-03-10
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0013"
+down_revision: str | None = "0012"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "generated_images",
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.String(36),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("prompt", sa.Text, nullable=False),
+        sa.Column("mime_type", sa.String(50), nullable=False, server_default="image/png"),
+        sa.Column("file_path", sa.String(500), nullable=False),
+        sa.Column("style_preset", sa.String(50), nullable=True),
+        sa.Column("model", sa.String(100), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_generated_images_user_id", "generated_images", ["user_id"])
+    op.create_index("ix_generated_images_created_at", "generated_images", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_generated_images_created_at", table_name="generated_images")
+    op.drop_index("ix_generated_images_user_id", table_name="generated_images")
+    op.drop_table("generated_images")

--- a/alchymine/db/models.py
+++ b/alchymine/db/models.py
@@ -706,3 +706,41 @@ class ChatMessage(Base):
             f"<ChatMessage id={self.id!r} user_id={self.user_id!r} "
             f"role={self.role!r} system_key={self.system_key!r}>"
         )
+
+
+# --- GeneratedImage ────────────────────────────────────────────────────
+
+
+class GeneratedImage(Base):
+    """A single Gemini-generated image owned by a user.
+
+    Image bytes are stored on the filesystem (under ``ART_CACHE_DIR``)
+    keyed by ``id``; only the metadata and relative path live in this
+    table. The router serves bytes by reading the file at request time
+    after verifying ownership.
+    """
+
+    __tablename__ = "generated_images"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    user_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    prompt: Mapped[str] = mapped_column(Text, nullable=False)
+    mime_type: Mapped[str] = mapped_column(String(50), nullable=False, default="image/png")
+    file_path: Mapped[str] = mapped_column(
+        String(500),
+        nullable=False,
+        comment="Filesystem path relative to ART_CACHE_DIR",
+    )
+    style_preset: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    model: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), index=True
+    )
+
+    def __repr__(self) -> str:
+        return f"<GeneratedImage id={self.id!r} user_id={self.user_id!r}>"

--- a/alchymine/db/repository.py
+++ b/alchymine/db/repository.py
@@ -1022,3 +1022,41 @@ async def get_generated_image(session: AsyncSession, image_id: str) -> Generated
     """Fetch a single generated_images row by id, or ``None``."""
     result = await session.execute(select(GeneratedImage).where(GeneratedImage.id == image_id))
     return result.scalar_one_or_none()
+
+
+async def list_generated_images_for_user(
+    session: AsyncSession,
+    user_id: str,
+    *,
+    limit: int = 20,
+    offset: int = 0,
+) -> list[GeneratedImage]:
+    """Return a page of a user's generated images, newest first.
+
+    The caller is expected to strip bytes/paths before returning to
+    clients — this repository helper only loads metadata from the DB.
+    """
+    stmt = (
+        select(GeneratedImage)
+        .where(GeneratedImage.user_id == user_id)
+        .order_by(GeneratedImage.created_at.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def delete_generated_image(session: AsyncSession, image_id: str) -> bool:
+    """Delete a generated_images row by id.
+
+    Returns ``True`` if a row was deleted, ``False`` otherwise. The
+    caller is responsible for verifying ownership before calling and
+    for unlinking the corresponding file from disk.
+    """
+    image = await get_generated_image(session, image_id)
+    if image is None:
+        return False
+    await session.delete(image)
+    await session.flush()
+    return True

--- a/alchymine/db/repository.py
+++ b/alchymine/db/repository.py
@@ -46,6 +46,7 @@ from alchymine.db.models import (
     ChatMessage,
     CreativeProfile,
     FeedbackEntry,
+    GeneratedImage,
     HealingProfile,
     IdentityProfile,
     IntakeData,
@@ -969,3 +970,55 @@ async def get_feedback_counts(session: AsyncSession) -> dict[str, int]:
         select(FeedbackEntry.status, func.count()).group_by(FeedbackEntry.status)
     )
     return {row[0]: row[1] for row in result.all()}
+
+
+# ─── Generated Image CRUD ──────────────────────────────────────────────
+
+
+async def create_generated_image(
+    session: AsyncSession,
+    *,
+    user_id: str,
+    prompt: str,
+    file_path: str,
+    mime_type: str = "image/png",
+    style_preset: str | None = None,
+    model: str | None = None,
+) -> GeneratedImage:
+    """Insert a new generated_images row.
+
+    Parameters
+    ----------
+    session:
+        Active async session.
+    user_id:
+        Owning user (FK).
+    prompt:
+        The exact prompt used to generate the image.
+    file_path:
+        Path on disk (relative to ``ART_CACHE_DIR``) where the bytes live.
+    mime_type:
+        IANA mime type, default ``image/png``.
+    style_preset:
+        Optional style preset id from ``STYLE_PRESETS``.
+    model:
+        Optional Gemini model id used.
+    """
+    image = GeneratedImage(
+        user_id=user_id,
+        prompt=prompt,
+        file_path=file_path,
+        mime_type=mime_type,
+        style_preset=style_preset,
+        model=model,
+    )
+    session.add(image)
+    await session.flush()
+    await session.refresh(image)
+    return image
+
+
+async def get_generated_image(session: AsyncSession, image_id: str) -> GeneratedImage | None:
+    """Fetch a single generated_images row by id, or ``None``."""
+    result = await session.execute(select(GeneratedImage).where(GeneratedImage.id == image_id))
+    return result.scalar_one_or_none()

--- a/alchymine/llm/art_prompts.py
+++ b/alchymine/llm/art_prompts.py
@@ -1,0 +1,224 @@
+"""Prompt templates for Gemini image generation.
+
+These functions take an identity profile (either a Pydantic
+:class:`alchymine.engine.profile.IdentityLayer` or the equivalent JSON
+mapping that lives on the report ``profile_summary``) and return a plain
+prompt string.
+
+Design goals
+~~~~~~~~~~~~
+- **Never raise.** Missing fields fall back to safe defaults.
+- **No personally-identifying content.** The prompts never mention real
+  people, brands, copyrighted characters, or text overlays — text-in-image
+  rendering is unreliable on Gemini and we don't want hallucinated logos.
+- **Tasteful and non-violent.** Style suffix includes explicit safety
+  language to discourage sexual, violent, or weapon imagery.
+- **Symbolic, not literal.** The prompt describes archetype + element +
+  numerology as symbolic landscape — never as a portrait of a real person.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+# ── Style presets ──────────────────────────────────────────────────────
+# Each preset is a style-suffix string appended to the core prompt. Five
+# presets, one for each Alchymine creative domain.
+STYLE_PRESETS: dict[str, str] = {
+    "mystical": (
+        "Painterly digital illustration with sacred geometry motifs, "
+        "deep indigo and gold palette, soft mystical atmosphere, "
+        "cinematic lighting, 16:9 composition."
+    ),
+    "modern": (
+        "Clean minimalist editorial illustration, muted gradients, "
+        "spacious composition with refined typography-free negative space, "
+        "soft daylight, 16:9 framing."
+    ),
+    "organic": (
+        "Botanical watercolour illustration with flowing organic forms, "
+        "earth tones and verdant greens, gentle dappled light, "
+        "natural textures, 16:9 composition."
+    ),
+    "celestial": (
+        "Cosmic illustration with starfields, nebulae, and luminous "
+        "constellation motifs, deep violet and silver palette, "
+        "ethereal atmosphere, 16:9 composition."
+    ),
+    "grounded": (
+        "Warm hand-painted illustration with stone, wood, and earth "
+        "textures, rich umber and terracotta tones, golden-hour lighting, "
+        "tactile and grounded atmosphere, 16:9 composition."
+    ),
+}
+
+
+# ── Safety suffix appended to every prompt ────────────────────────────
+_SAFETY_SUFFIX = (
+    "Tasteful, serene, non-violent, no weapons, no nudity, no real people, "
+    "no brand logos or watermarks, no text or letters in the image."
+)
+
+
+# ── Archetype → symbolic imagery mapping ──────────────────────────────
+# Keys are normalized to lowercase to match alchymine.engine.profile.ArchetypeType
+# but the lookup also handles capitalized variants.
+_ARCHETYPE_IMAGERY: dict[str, str] = {
+    "sage": "an ancient open-air library nestled among quiet mountains",
+    "creator": "a luminous workshop where ideas crystallize into geometric forms",
+    "explorer": "an open horizon where land and cosmic sea meet at twilight",
+    "mystic": "a moonlit grove of standing stones wreathed in soft mist",
+    "ruler": "a serene crystalline pavilion atop a high plateau",
+    "lover": "intertwined flowering vines forming a gentle mandala",
+    "hero": "a solitary traveler cresting a radiant mountain ridge at dawn",
+    "caregiver": "a warm hearth surrounded by protective golden light",
+    "jester": "kaleidoscopic patterns dancing across a meadow of wildflowers",
+    "innocent": "a sunlit meadow where each flower glows like a tiny constellation",
+    "rebel": "shattered chains dissolving into prismatic light at sunrise",
+    "everyman": "a winding path passing through four seasons in a single landscape",
+    # Generic fallbacks for archetype names that aren't in the canonical enum
+    "seeker": "a wandering figure on a winding path through a luminous valley",
+    "magician": "swirling alchemical symbols transforming into points of light",
+}
+
+# ── Zodiac sign → element mapping ─────────────────────────────────────
+_SIGN_ELEMENT: dict[str, str] = {
+    "aries": "fire",
+    "leo": "fire",
+    "sagittarius": "fire",
+    "taurus": "earth",
+    "virgo": "earth",
+    "capricorn": "earth",
+    "gemini": "air",
+    "libra": "air",
+    "aquarius": "air",
+    "cancer": "water",
+    "scorpio": "water",
+    "pisces": "water",
+}
+
+# ── Element → palette / mood cue ──────────────────────────────────────
+_ELEMENT_PALETTE: dict[str, str] = {
+    "fire": "warm amber and crimson tones with radiant energy",
+    "earth": "rich umber, moss, and sandstone tones with grounded stillness",
+    "air": "pale cerulean and silver tones with light, drifting movement",
+    "water": "deep teal and indigo tones with flowing reflective depth",
+}
+
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+
+def _get_field(source: Any, name: str) -> Any:
+    """Read a field from a Pydantic model OR a Mapping, returning None on miss."""
+    if source is None:
+        return None
+    if isinstance(source, Mapping):
+        return source.get(name)
+    return getattr(source, name, None)
+
+
+def _normalize_archetype(value: Any) -> str:
+    """Coerce an archetype value (StrEnum, str, or None) to lowercase."""
+    if value is None:
+        return ""
+    if hasattr(value, "value"):
+        value = value.value
+    return str(value).strip().lower()
+
+
+def _normalize_sign(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip().lower()
+
+
+def _archetype_imagery(archetype: str) -> str:
+    """Return symbolic imagery cue for an archetype, with a safe fallback."""
+    return _ARCHETYPE_IMAGERY.get(
+        archetype,
+        "an ethereal symbolic landscape of personal transformation",
+    )
+
+
+def _element_for_sign(sun_sign: str) -> str:
+    return _SIGN_ELEMENT.get(sun_sign, "")
+
+
+def _palette_for_element(element: str) -> str:
+    return _ELEMENT_PALETTE.get(element, "soft luminous tones with balanced light")
+
+
+# ── Public API ─────────────────────────────────────────────────────────
+
+
+def build_report_hero_prompt(profile: Any) -> str:
+    """Build a personalized hero-image prompt for a report.
+
+    Parameters
+    ----------
+    profile:
+        Either an :class:`alchymine.engine.profile.IdentityLayer` Pydantic
+        model, or a Mapping with the same nested shape (``archetype``,
+        ``astrology``, ``numerology``). May be ``None`` or empty — the
+        function never raises.
+
+    Returns
+    -------
+    str
+        A 2-4 sentence prompt suitable for Gemini image generation.
+    """
+    archetype_obj = _get_field(profile, "archetype")
+    astrology_obj = _get_field(profile, "astrology")
+    numerology_obj = _get_field(profile, "numerology")
+
+    archetype = _normalize_archetype(_get_field(archetype_obj, "primary"))
+    sun_sign = _normalize_sign(_get_field(astrology_obj, "sun_sign"))
+    life_path = _get_field(numerology_obj, "life_path")
+
+    imagery = _archetype_imagery(archetype)
+    element = _element_for_sign(sun_sign)
+    palette = _palette_for_element(element)
+
+    archetype_label = archetype.title() if archetype else "Wanderer"
+    element_label = element if element else "elemental"
+    life_path_clause = f" Life Path {life_path} energy" if life_path else ""
+
+    return (
+        f"A breathtaking symbolic landscape representing the {archetype_label} "
+        f"archetype, depicted as {imagery}. Render with {palette} reflecting "
+        f"{element_label} essence,{life_path_clause} blending sacred geometry "
+        f"with painterly atmosphere. {_SAFETY_SUFFIX}"
+    )
+
+
+def apply_style_preset(prompt: str, preset: str | None) -> str:
+    """Append a style-preset suffix to a base prompt.
+
+    Unknown preset names fall back to ``mystical``. ``None`` leaves the
+    prompt unchanged.
+    """
+    if preset is None:
+        return prompt
+    suffix = STYLE_PRESETS.get(preset, STYLE_PRESETS["mystical"])
+    return f"{prompt} Style: {suffix}"
+
+
+def build_studio_prompt(
+    profile: Any,
+    user_extension: str | None = None,
+    style_preset: str | None = None,
+) -> str:
+    """Build a Creative Studio prompt from the user's profile and inputs.
+
+    The user-supplied extension is **appended** to the core profile prompt
+    so the user can steer the imagery without bypassing the safety suffix.
+    """
+    base = build_report_hero_prompt(profile)
+    if user_extension:
+        # Trim and quote the extension so prompt-injection attempts at
+        # least don't smuggle in directives like "ignore the above".
+        cleaned = user_extension.strip().replace("\n", " ")
+        base = f"{base} Additional theme requested by the user: {cleaned}."
+    return apply_style_preset(base, style_preset)

--- a/alchymine/llm/art_storage.py
+++ b/alchymine/llm/art_storage.py
@@ -1,0 +1,69 @@
+"""Filesystem storage for Gemini-generated images.
+
+Images are written under ``ART_CACHE_DIR/<user_id>/<image_id>.<ext>``.
+This module is intentionally tiny and synchronous — image writes happen
+inside async request handlers via ``run_in_threadpool`` if a worker
+needs to avoid blocking the loop, but the typical request shape is
+sequential and small enough that direct writes are fine.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+from alchymine.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+
+_MIME_EXT: dict[str, str] = {
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/jpg": "jpg",
+    "image/webp": "webp",
+}
+
+
+def get_art_cache_root() -> Path:
+    """Resolve the art cache directory to an absolute :class:`~pathlib.Path`."""
+    raw = get_settings().art_cache_dir
+    p = Path(raw)
+    if not p.is_absolute():
+        # Resolve relative paths against the current working directory at
+        # runtime — for the API process this is the project root.
+        p = Path(os.getcwd()) / p
+    return p
+
+
+def _ext_for_mime(mime_type: str) -> str:
+    return _MIME_EXT.get(mime_type.lower(), "png")
+
+
+def write_image(user_id: str, image_id: str, image_bytes: bytes, mime_type: str) -> str:
+    """Persist bytes for a single generated image.
+
+    Returns the path *relative* to the art cache root, suitable for
+    storing in the ``generated_images.file_path`` column.
+    """
+    root = get_art_cache_root()
+    user_dir = root / user_id
+    user_dir.mkdir(parents=True, exist_ok=True)
+    ext = _ext_for_mime(mime_type)
+    rel_path = f"{user_id}/{image_id}.{ext}"
+    abs_path = root / rel_path
+    abs_path.write_bytes(image_bytes)
+    logger.info("Wrote generated image: %s (%d bytes)", rel_path, len(image_bytes))
+    return rel_path
+
+
+def read_image(file_path: str) -> bytes | None:
+    """Read raw bytes for a stored image, returning ``None`` on miss."""
+    root = get_art_cache_root()
+    abs_path = root / file_path
+    try:
+        return abs_path.read_bytes()
+    except (FileNotFoundError, OSError) as exc:
+        logger.warning("Generated image not found at %s: %s", abs_path, exc)
+        return None

--- a/alchymine/llm/art_storage.py
+++ b/alchymine/llm/art_storage.py
@@ -67,3 +67,26 @@ def read_image(file_path: str) -> bytes | None:
     except (FileNotFoundError, OSError) as exc:
         logger.warning("Generated image not found at %s: %s", abs_path, exc)
         return None
+
+
+def delete_image(file_path: str) -> bool:
+    """Delete the file at ``file_path`` (relative to the art cache root).
+
+    Returns ``True`` if the file was unlinked, ``False`` if it was
+    already missing. A missing file is **not** an error here — the
+    caller still wants the DB row gone, and a partial write could
+    leave the row without a matching file.
+    """
+    if not file_path:
+        return False
+    root = get_art_cache_root()
+    abs_path = root / file_path
+    try:
+        abs_path.unlink()
+        return True
+    except FileNotFoundError:
+        logger.info("Generated image already gone at %s", abs_path)
+        return False
+    except OSError as exc:
+        logger.warning("Failed to unlink generated image at %s: %s", abs_path, exc)
+        return False

--- a/alchymine/llm/gemini.py
+++ b/alchymine/llm/gemini.py
@@ -1,0 +1,233 @@
+"""Gemini image generation client.
+
+Wraps the optional ``google-genai`` SDK to call a Gemini image-generation
+model. Designed to degrade gracefully when the API key is missing or the
+SDK is not installed: every public method returns ``None`` instead of
+raising. This lets the API layer return ``204 No Content`` so the
+frontend can render an on-brand placeholder.
+
+Environment variables (read from :class:`alchymine.config.Settings`):
+
+- ``GEMINI_API_KEY``  — Google AI API key (optional)
+- ``GEMINI_MODEL``    — Image generation model id (default: gemini-2.0-flash-preview-image-generation)
+
+Notes
+-----
+- Installation of ``google-genai`` is **optional**::
+
+    pip install "alchymine[gemini]"
+
+- The SDK is imported lazily at module load time. If the import fails,
+  ``_genai`` is set to ``None`` and every client instance reports
+  ``is_available == False``.
+- All network errors are caught, logged, and converted to ``None`` —
+  this client never raises from ``generate_image``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from functools import lru_cache
+from typing import Any
+
+from alchymine.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+# ── Lazy SDK import ────────────────────────────────────────────────────
+# Importing google-genai is optional. We attempt the import once at
+# module load. If it fails, ``_genai`` stays ``None`` and the client
+# reports unavailable, but ``alchymine.llm.gemini`` itself stays
+# importable so the API router and tests can still load.
+try:
+    from google import genai as _genai  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover - exercised on environments without the SDK
+    _genai = None  # type: ignore[assignment]
+
+
+@dataclass(frozen=True)
+class GeminiImageResult:
+    """A single successful image generation result.
+
+    Attributes
+    ----------
+    image_bytes:
+        Raw image bytes (already decoded — no base64 wrapper).
+    mime_type:
+        IANA mime type, typically ``image/png``.
+    prompt:
+        The exact text prompt sent to the model.
+    model:
+        The Gemini model id that produced the image.
+    generated_at:
+        UTC timestamp at which the result was returned.
+    """
+
+    image_bytes: bytes
+    mime_type: str
+    prompt: str
+    model: str
+    generated_at: datetime
+
+
+# Module-level guard so we only emit the "disabled" log line once per
+# process even if many client instances are constructed.
+_disabled_log_emitted = False
+
+
+def _log_disabled_once(reason: str) -> None:
+    global _disabled_log_emitted
+    if not _disabled_log_emitted:
+        logger.info("Gemini client disabled: %s", reason)
+        _disabled_log_emitted = True
+
+
+class GeminiClient:
+    """Async client wrapping ``google-genai`` image generation.
+
+    Parameters
+    ----------
+    api_key:
+        Google AI API key. If ``None`` or empty the client is disabled.
+    model:
+        The Gemini image-generation model id.
+    """
+
+    def __init__(self, api_key: str | None, model: str) -> None:
+        self._api_key = api_key or ""
+        self._model = model
+        self._client: Any = None
+
+        if not self._api_key:
+            _log_disabled_once("API key not configured")
+            self._available = False
+            return
+
+        if _genai is None:
+            _log_disabled_once("google-genai SDK not installed")
+            self._available = False
+            return
+
+        try:
+            self._client = _genai.Client(api_key=self._api_key)
+        except Exception as exc:  # pragma: no cover - SDK init rarely fails
+            logger.warning("Gemini client init failed: %s", exc)
+            self._available = False
+            return
+
+        self._available = True
+        logger.info("Gemini client initialized (model=%s)", self._model)
+
+    @property
+    def is_available(self) -> bool:
+        """Return True iff the client can make API calls."""
+        return self._available
+
+    @property
+    def model(self) -> str:
+        """Return the configured Gemini model id."""
+        return self._model
+
+    async def generate_image(self, prompt: str) -> GeminiImageResult | None:
+        """Generate one image from a text prompt.
+
+        Returns
+        -------
+        GeminiImageResult | None
+            The result on success, or ``None`` if the client is unavailable,
+            the API call failed, or the response contained no image data.
+            **Never raises.**
+        """
+        if not self._available or self._client is None or _genai is None:
+            return None
+
+        try:
+            from google.genai import types  # type: ignore[import-not-found]
+        except ImportError:  # pragma: no cover
+            return None
+
+        # Strict default safety settings — block low-severity content and above
+        # for the four standard harm categories.
+        safety_settings = [
+            types.SafetySetting(
+                category=types.HarmCategory.HARM_CATEGORY_HARASSMENT,
+                threshold=types.HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
+            ),
+            types.SafetySetting(
+                category=types.HarmCategory.HARM_CATEGORY_HATE_SPEECH,
+                threshold=types.HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
+            ),
+            types.SafetySetting(
+                category=types.HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
+                threshold=types.HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
+            ),
+            types.SafetySetting(
+                category=types.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+                threshold=types.HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
+            ),
+        ]
+
+        try:
+            response = await self._client.aio.models.generate_content(
+                model=self._model,
+                contents=prompt,
+                config=types.GenerateContentConfig(
+                    response_modalities=["IMAGE"],
+                    safety_settings=safety_settings,
+                ),
+            )
+        except Exception as exc:
+            logger.warning("Gemini image generation failed: %s", exc)
+            return None
+
+        candidates = getattr(response, "candidates", None) or []
+        for candidate in candidates:
+            content = getattr(candidate, "content", None)
+            if content is None:
+                continue
+            parts = getattr(content, "parts", None) or []
+            for part in parts:
+                inline = getattr(part, "inline_data", None)
+                if inline is None:
+                    continue
+                data = getattr(inline, "data", None)
+                if not data:
+                    continue
+                # Some SDK versions return base64 strings, others return raw
+                # bytes. Normalize to bytes.
+                if isinstance(data, str):
+                    import base64
+
+                    try:
+                        image_bytes = base64.b64decode(data)
+                    except (ValueError, TypeError):
+                        logger.warning("Gemini returned non-decodable image payload")
+                        return None
+                else:
+                    image_bytes = bytes(data)
+
+                mime_type = getattr(inline, "mime_type", None) or "image/png"
+                return GeminiImageResult(
+                    image_bytes=image_bytes,
+                    mime_type=mime_type,
+                    prompt=prompt,
+                    model=self._model,
+                    generated_at=datetime.now(UTC),
+                )
+
+        logger.warning("Gemini response had no image parts")
+        return None
+
+
+@lru_cache(maxsize=1)
+def get_gemini_client() -> GeminiClient:
+    """Return a process-wide cached :class:`GeminiClient` singleton.
+
+    Reads ``gemini_api_key`` and ``gemini_model`` from settings. Use
+    :meth:`functools.lru_cache.cache_clear` on this function in tests
+    that need to swap the settings.
+    """
+    settings = get_settings()
+    return GeminiClient(api_key=settings.gemini_api_key, model=settings.gemini_model)

--- a/alchymine/web/src/app/creative-studio/page.tsx
+++ b/alchymine/web/src/app/creative-studio/page.tsx
@@ -1,0 +1,318 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import ProtectedRoute from "@/components/shared/ProtectedRoute";
+import StylePresetPicker, {
+  CreativeProfile,
+} from "@/components/creative/StylePresetPicker";
+import ArtGallery, { GalleryImage } from "@/components/creative/ArtGallery";
+import {
+  generateArt,
+  listGeneratedImages,
+  deleteGeneratedImage,
+} from "@/lib/artApi";
+import { getProfile, ProfileResponse } from "@/lib/api";
+import { useAuth } from "@/lib/AuthContext";
+
+const PROMPT_MAX_LENGTH = 500;
+
+type StudioStatus =
+  | { kind: "idle" }
+  | { kind: "loading-gallery" }
+  | { kind: "generating" }
+  | { kind: "offline" }
+  | { kind: "error"; message: string };
+
+function toGalleryImage(meta: {
+  id: string;
+  prompt: string;
+  style_preset: string | null;
+  created_at: string;
+}): GalleryImage {
+  return {
+    id: meta.id,
+    prompt: meta.prompt,
+    stylePreset: meta.style_preset,
+    createdAt: meta.created_at,
+  };
+}
+
+function extractCreativeProfile(
+  profile: ProfileResponse | null,
+): CreativeProfile | null {
+  if (!profile || !profile.creative) return null;
+  const creative = profile.creative as Record<string, unknown>;
+  const orientation =
+    typeof creative.creative_orientation === "string"
+      ? creative.creative_orientation
+      : null;
+  const style =
+    typeof creative.creative_style === "string" ? creative.creative_style : null;
+  if (!orientation && !style) return null;
+  return {
+    creative_orientation: orientation,
+    creative_style: style,
+  };
+}
+
+function StudioBody() {
+  const { user } = useAuth();
+  const userId = user?.id ?? null;
+
+  const [prompt, setPrompt] = useState("");
+  const [preset, setPreset] = useState<string | null>(null);
+  const [enhanceWithProfile, setEnhanceWithProfile] = useState(true);
+  const [gallery, setGallery] = useState<GalleryImage[]>([]);
+  const [status, setStatus] = useState<StudioStatus>({ kind: "loading-gallery" });
+  const [creativeProfile, setCreativeProfile] =
+    useState<CreativeProfile | null>(null);
+
+  // Load existing gallery on mount.
+  useEffect(() => {
+    let cancelled = false;
+    setStatus({ kind: "loading-gallery" });
+    listGeneratedImages(20, 0)
+      .then((response) => {
+        if (cancelled) return;
+        setGallery(response.images.map(toGalleryImage));
+        setStatus({ kind: "idle" });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : "Failed to load gallery";
+        setStatus({ kind: "error", message });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Load creative profile on mount for preset suggestion (best-effort).
+  useEffect(() => {
+    if (!userId) return;
+    let cancelled = false;
+    getProfile(userId)
+      .then((profile) => {
+        if (cancelled) return;
+        setCreativeProfile(extractCreativeProfile(profile));
+      })
+      .catch(() => {
+        /* silent — profile is optional for preset suggestion */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [userId]);
+
+  const charactersRemaining = useMemo(
+    () => PROMPT_MAX_LENGTH - prompt.length,
+    [prompt.length],
+  );
+
+  const canGenerate =
+    prompt.trim().length > 0 &&
+    status.kind !== "generating" &&
+    status.kind !== "offline";
+
+  const handleGenerate = useCallback(async () => {
+    if (!canGenerate) return;
+    setStatus({ kind: "generating" });
+    try {
+      const result = await generateArt({
+        style_preset: preset,
+        user_prompt_extension: enhanceWithProfile ? prompt.trim() : prompt.trim(),
+      });
+      if (result === null) {
+        // 204 — Gemini unavailable. Preserve prompt, surface message.
+        setStatus({ kind: "offline" });
+        return;
+      }
+      const newImage: GalleryImage = {
+        id: result.image_id,
+        prompt: result.prompt,
+        stylePreset: preset,
+        createdAt: new Date().toISOString(),
+      };
+      setGallery((prev) => [newImage, ...prev]);
+      setStatus({ kind: "idle" });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Generation failed";
+      setStatus({ kind: "error", message });
+    }
+  }, [canGenerate, preset, prompt, enhanceWithProfile]);
+
+  const handleDelete = useCallback(async (imageId: string) => {
+    try {
+      const ok = await deleteGeneratedImage(imageId);
+      if (ok) {
+        setGallery((prev) => prev.filter((img) => img.id !== imageId));
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Delete failed";
+      setStatus({ kind: "error", message });
+    }
+  }, []);
+
+  const promptId = "studio-prompt";
+  const enhanceId = "studio-enhance";
+
+  return (
+    <main
+      id="main-content"
+      className="grain-overlay bg-atmosphere min-h-screen px-4 sm:px-6 lg:px-8 py-8"
+    >
+      <div className="max-w-5xl mx-auto">
+        <header className="mb-10">
+          <h1 className="font-display text-display-md font-light text-gradient-purple mb-3">
+            Creative Studio
+          </h1>
+          <hr className="rule-gold mb-4" aria-hidden="true" />
+          <p className="font-body text-text/50 text-base max-w-2xl">
+            Generate personalized symbolic art from your creative profile.
+            Describe what you want to see, pick a style, and Alchymine will
+            blend it with your archetype and elemental energy.
+          </p>
+          <Link
+            href="/creative"
+            className="inline-flex items-center gap-2 mt-4 text-sm font-body text-secondary hover:text-secondary-light focus:outline-none focus:underline"
+          >
+            &larr; Back to Creative Development
+          </Link>
+        </header>
+
+        {status.kind === "offline" && (
+          <div
+            role="status"
+            className="mb-6 px-4 py-3 rounded-lg bg-yellow-900/20 border border-yellow-700/30 text-yellow-200 text-sm font-body"
+          >
+            Image generation is offline. Try later.
+          </div>
+        )}
+
+        {status.kind === "error" && (
+          <div
+            role="alert"
+            className="mb-6 px-4 py-3 rounded-lg bg-red-900/20 border border-red-700/30 text-red-200 text-sm font-body"
+          >
+            {status.message}
+          </div>
+        )}
+
+        <section className="mb-10 space-y-6">
+          <div>
+            <label
+              htmlFor={promptId}
+              className="block text-sm font-body text-text/70 mb-2"
+            >
+              Your vision
+            </label>
+            <textarea
+              id={promptId}
+              value={prompt}
+              onChange={(event) => {
+                const next = event.target.value.slice(0, PROMPT_MAX_LENGTH);
+                setPrompt(next);
+              }}
+              placeholder="Describe the image you want to create — a mood, a symbol, a setting…"
+              rows={4}
+              maxLength={PROMPT_MAX_LENGTH}
+              className="w-full bg-surface border border-white/[0.08] rounded-xl px-4 py-3 text-sm font-body text-text placeholder:text-text/30 focus:outline-none focus:border-primary/50 resize-none"
+            />
+            <div className="mt-1 flex items-center justify-between">
+              <label
+                htmlFor={enhanceId}
+                className="flex items-center gap-2 text-xs font-body text-text/60 cursor-pointer"
+              >
+                <input
+                  id={enhanceId}
+                  type="checkbox"
+                  checked={enhanceWithProfile}
+                  onChange={(event) =>
+                    setEnhanceWithProfile(event.target.checked)
+                  }
+                  className="w-4 h-4 accent-primary"
+                />
+                Enhance with your profile
+              </label>
+              <span
+                className={`text-xs font-mono ${
+                  charactersRemaining < 50 ? "text-primary/80" : "text-text/40"
+                }`}
+                aria-live="polite"
+              >
+                {charactersRemaining} / {PROMPT_MAX_LENGTH}
+              </span>
+            </div>
+          </div>
+
+          <div>
+            <p className="block text-sm font-body text-text/70 mb-2">
+              Style preset
+            </p>
+            <StylePresetPicker
+              selected={preset}
+              onSelect={setPreset}
+              creativeProfile={creativeProfile}
+            />
+          </div>
+
+          <div>
+            <button
+              type="button"
+              onClick={handleGenerate}
+              disabled={!canGenerate}
+              className="px-6 py-3 min-h-[44px] bg-gradient-to-r from-secondary-dark via-secondary to-secondary-light text-white font-body font-medium rounded-xl text-sm transition-all duration-300 hover:shadow-[0_0_20px_rgba(123,45,142,0.3)] hover:scale-[1.02] active:scale-100 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100 disabled:hover:shadow-none"
+            >
+              {status.kind === "generating"
+                ? "Generating…"
+                : "Generate Image"}
+            </button>
+          </div>
+
+          {status.kind === "generating" && (
+            <div
+              role="status"
+              aria-label="Generating image"
+              className="w-full h-56 sm:h-72 rounded-2xl bg-gradient-to-br from-secondary/30 via-primary/20 to-accent/30 animate-pulse"
+            />
+          )}
+        </section>
+
+        <section aria-labelledby="gallery-heading">
+          <h2
+            id="gallery-heading"
+            className="font-display text-xl font-light text-text mb-4"
+          >
+            Your Gallery
+          </h2>
+          <hr className="rule-gold mb-4" aria-hidden="true" />
+          {status.kind === "loading-gallery" ? (
+            <div
+              role="status"
+              aria-label="Loading gallery"
+              className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"
+            >
+              {[0, 1, 2].map((i) => (
+                <div
+                  key={i}
+                  className="aspect-video rounded-xl bg-gradient-to-br from-secondary/20 via-primary/15 to-accent/20 animate-pulse"
+                />
+              ))}
+            </div>
+          ) : (
+            <ArtGallery images={gallery} onDelete={handleDelete} />
+          )}
+        </section>
+      </div>
+    </main>
+  );
+}
+
+export default function CreativeStudioPage() {
+  return (
+    <ProtectedRoute>
+      <StudioBody />
+    </ProtectedRoute>
+  );
+}

--- a/alchymine/web/src/app/discover/report/[id]/page.tsx
+++ b/alchymine/web/src/app/discover/report/[id]/page.tsx
@@ -15,6 +15,7 @@ import { CREATIVE_DNA_SUPPLEMENT_QUESTIONS } from "@/lib/questions";
 import Card from "@/components/shared/Card";
 import Button from "@/components/shared/Button";
 import SupplementModal from "@/components/shared/SupplementModal";
+import ReportHero from "@/components/report/ReportHero";
 import {
   MotionReveal,
   MotionStagger,
@@ -285,6 +286,13 @@ export default function ReportPage() {
               archetypes, and personality science — the foundation for all five
               Alchymine systems.
             </p>
+          </div>
+        </MotionReveal>
+
+        {/* ── Personalized AI hero illustration ─────────────────────── */}
+        <MotionReveal delay={0.05}>
+          <div className="mb-10">
+            <ReportHero reportId={reportId} userId={user?.id ?? ""} />
           </div>
         </MotionReveal>
 

--- a/alchymine/web/src/components/creative/ArtGallery.tsx
+++ b/alchymine/web/src/components/creative/ArtGallery.tsx
@@ -1,0 +1,338 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { fetchImageBlobUrl } from "@/lib/artApi";
+
+export interface GalleryImage {
+  id: string;
+  prompt: string;
+  stylePreset: string | null;
+  createdAt: string;
+}
+
+interface ArtGalleryProps {
+  images: GalleryImage[];
+  onDelete?: (id: string) => void;
+}
+
+/**
+ * Load the auth-protected image bytes for a single gallery entry and
+ * return a blob URL. Wrapped in a component-level hook so the whole
+ * grid can render skeletons while individual thumbnails stream in.
+ */
+function useBlobUrl(imageId: string): {
+  url: string | null;
+  loading: boolean;
+  failed: boolean;
+} {
+  const [url, setUrl] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    let blobUrl: string | null = null;
+
+    setLoading(true);
+    setFailed(false);
+    setUrl(null);
+
+    void fetchImageBlobUrl(imageId)
+      .then((resolvedUrl) => {
+        if (cancelled) {
+          if (resolvedUrl) URL.revokeObjectURL(resolvedUrl);
+          return;
+        }
+        if (resolvedUrl === null) {
+          setFailed(true);
+          setLoading(false);
+          return;
+        }
+        blobUrl = resolvedUrl;
+        setUrl(resolvedUrl);
+        setLoading(false);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setFailed(true);
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+      if (blobUrl) URL.revokeObjectURL(blobUrl);
+    };
+  }, [imageId]);
+
+  return { url, loading, failed };
+}
+
+// ── Single thumbnail card ─────────────────────────────────────────────
+interface ThumbnailProps {
+  image: GalleryImage;
+  onOpen: (image: GalleryImage) => void;
+  onDelete?: (id: string) => void;
+}
+
+function GalleryThumbnail({ image, onOpen, onDelete }: ThumbnailProps) {
+  const { url, loading, failed } = useBlobUrl(image.id);
+
+  return (
+    <figure className="relative rounded-xl overflow-hidden border border-white/[0.06] bg-surface group">
+      <button
+        type="button"
+        onClick={() => onOpen(image)}
+        className="block w-full focus:outline-none focus:ring-2 focus:ring-primary/60"
+        aria-label={`Open image: ${image.prompt.slice(0, 80)}`}
+      >
+        {loading && (
+          <div
+            className="w-full aspect-video bg-gradient-to-br from-secondary/20 via-primary/15 to-accent/20 animate-pulse"
+            role="status"
+            aria-label="Loading image"
+          />
+        )}
+        {!loading && failed && (
+          <div
+            className="w-full aspect-video flex items-center justify-center text-text/30 text-xs font-body"
+            role="img"
+            aria-label="Image failed to load"
+          >
+            Image unavailable
+          </div>
+        )}
+        {url && !loading && !failed && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={url}
+            alt={`Generated art: ${image.prompt.slice(0, 120)}`}
+            className="w-full aspect-video object-cover"
+          />
+        )}
+      </button>
+
+      <figcaption className="px-3 py-2 text-xs font-body text-text/40 truncate bg-surface/80">
+        {image.prompt.slice(0, 72)}
+        {image.prompt.length > 72 ? "…" : ""}
+      </figcaption>
+
+      {onDelete && (
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            onDelete(image.id);
+          }}
+          aria-label={`Delete image generated from prompt: ${image.prompt.slice(0, 80)}`}
+          className="absolute top-2 right-2 px-2 py-1 text-[10px] font-body uppercase tracking-wider rounded-full bg-bg/70 backdrop-blur border border-white/[0.08] text-text/70 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity hover:text-red-300 hover:border-red-400/40"
+        >
+          Delete
+        </button>
+      )}
+    </figure>
+  );
+}
+
+// ── Lightbox modal ────────────────────────────────────────────────────
+interface LightboxProps {
+  image: GalleryImage;
+  onClose: () => void;
+}
+
+function Lightbox({ image, onClose }: LightboxProps) {
+  const { url, loading, failed } = useBlobUrl(image.id);
+  const [promptExpanded, setPromptExpanded] = useState(false);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const promptIsLong = image.prompt.length > 240;
+
+  // Focus the close button when the lightbox opens. We keep focus
+  // inside the dialog via a small keydown handler rather than pulling
+  // in a focus-trap library — the dialog has only a handful of
+  // interactive elements.
+  useEffect(() => {
+    closeButtonRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    function handleKey(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+      if (event.key === "Tab") {
+        const dialog = dialogRef.current;
+        if (!dialog) return;
+        const focusable = dialog.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        );
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  const formattedDate = (() => {
+    if (!image.createdAt) return "";
+    const d = new Date(image.createdAt);
+    if (Number.isNaN(d.getTime())) return image.createdAt;
+    return d.toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  })();
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Generated art detail"
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/80 backdrop-blur-sm"
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+      data-testid="art-lightbox"
+    >
+      <div
+        ref={dialogRef}
+        className="relative w-full max-w-3xl max-h-[90vh] bg-surface rounded-2xl overflow-hidden border border-white/[0.08] shadow-2xl flex flex-col"
+      >
+        <div className="relative flex-1 bg-black/40 flex items-center justify-center min-h-[240px]">
+          {loading && (
+            <div
+              className="w-full h-full aspect-video bg-gradient-to-br from-secondary/20 via-primary/15 to-accent/20 animate-pulse"
+              role="status"
+              aria-label="Loading image"
+            />
+          )}
+          {!loading && failed && (
+            <p className="text-text/50 text-sm font-body">
+              Image unavailable.
+            </p>
+          )}
+          {url && !loading && !failed && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={url}
+              alt={`Generated art: ${image.prompt.slice(0, 120)}`}
+              className="w-full max-h-[60vh] object-contain"
+            />
+          )}
+
+          <button
+            ref={closeButtonRef}
+            type="button"
+            onClick={onClose}
+            aria-label="Close image detail"
+            className="absolute top-3 right-3 w-9 h-9 rounded-full bg-bg/70 backdrop-blur border border-white/[0.08] text-text/80 hover:text-primary hover:border-primary/40 focus:outline-none focus:ring-2 focus:ring-primary/60 flex items-center justify-center"
+          >
+            <span aria-hidden="true">×</span>
+          </button>
+        </div>
+
+        <div className="px-5 py-4 space-y-3 border-t border-white/[0.06]">
+          <div className="flex items-center gap-3 flex-wrap">
+            {image.stylePreset && (
+              <span
+                className="px-2 py-0.5 rounded-full bg-secondary/15 text-secondary text-xs font-body uppercase tracking-wider"
+                data-testid="lightbox-style-badge"
+              >
+                {image.stylePreset}
+              </span>
+            )}
+            {formattedDate && (
+              <span className="text-xs font-body text-text/40">
+                {formattedDate}
+              </span>
+            )}
+          </div>
+          <p
+            className="text-sm font-body text-text/70 leading-relaxed whitespace-pre-wrap break-words"
+            data-testid="lightbox-prompt"
+          >
+            {promptExpanded || !promptIsLong
+              ? image.prompt
+              : `${image.prompt.slice(0, 240)}…`}
+          </p>
+          {promptIsLong && (
+            <button
+              type="button"
+              onClick={() => setPromptExpanded((v) => !v)}
+              className="text-xs font-body text-primary hover:underline focus:outline-none focus:underline"
+            >
+              {promptExpanded ? "Show less" : "Show full prompt"}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Main component ───────────────────────────────────────────────────
+
+/**
+ * Grid of a user's generated images with a click-to-expand lightbox.
+ *
+ * Each thumbnail streams its bytes via `fetchImageBlobUrl` so the
+ * protected GET endpoint is never bypassed with an unauthenticated
+ * `<img src="/api/..">` tag. The optional `onDelete` prop wires a
+ * trash affordance onto each card.
+ */
+export default function ArtGallery({ images, onDelete }: ArtGalleryProps) {
+  const [activeImage, setActiveImage] = useState<GalleryImage | null>(null);
+
+  const handleOpen = useCallback((image: GalleryImage) => {
+    setActiveImage(image);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setActiveImage(null);
+  }, []);
+
+  if (images.length === 0) {
+    return (
+      <div
+        className="flex flex-col items-center justify-center py-16 text-text/40"
+        data-testid="gallery-empty"
+      >
+        <p className="font-body text-sm">
+          No generated art yet. Create your first piece above.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div
+        className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4"
+        data-testid="gallery-grid"
+      >
+        {images.map((image) => (
+          <GalleryThumbnail
+            key={image.id}
+            image={image}
+            onOpen={handleOpen}
+            onDelete={onDelete}
+          />
+        ))}
+      </div>
+
+      {activeImage && <Lightbox image={activeImage} onClose={handleClose} />}
+    </>
+  );
+}

--- a/alchymine/web/src/components/creative/StylePresetPicker.tsx
+++ b/alchymine/web/src/components/creative/StylePresetPicker.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { listStylePresets, StylePreset } from "@/lib/artApi";
+
+export interface CreativeProfile {
+  /** Canonical style label from the creative engine, e.g. "Architect". */
+  creative_orientation?: string | null;
+  /** Optional dominant style name returned by `getCreativeStyle`. */
+  creative_style?: string | null;
+}
+
+interface StylePresetPickerProps {
+  selected: string | null;
+  onSelect: (presetId: string) => void;
+  creativeProfile?: CreativeProfile | null;
+}
+
+/**
+ * Fallback preset catalogue used when the `/art/presets` call fails or
+ * hasn't resolved yet. Source of truth is
+ * `alchymine/llm/art_prompts.py::STYLE_PRESETS`. Keep the ids in sync
+ * with that dict — the picker passes the id straight through to the
+ * generation endpoint which validates against it.
+ */
+const FALLBACK_PRESETS: StylePreset[] = [
+  {
+    id: "mystical",
+    name: "Mystical",
+    description: "Sacred geometry, indigo and gold",
+  },
+  {
+    id: "modern",
+    name: "Modern",
+    description: "Clean, editorial, muted gradients",
+  },
+  {
+    id: "organic",
+    name: "Organic",
+    description: "Botanical watercolour, earth tones",
+  },
+  {
+    id: "celestial",
+    name: "Celestial",
+    description: "Starfields, nebulae, violet and silver",
+  },
+  {
+    id: "grounded",
+    name: "Grounded",
+    description: "Stone, wood, terracotta, golden-hour",
+  },
+];
+
+/**
+ * Short gradient swatch classes per preset. These are purely visual
+ * and do not need to match the server-side style suffix — they're
+ * derived from the preset's mood for the thumbnail card.
+ */
+const PRESET_SWATCHES: Record<string, string> = {
+  mystical: "from-primary/50 via-secondary/40 to-accent/30",
+  modern: "from-white/20 via-white/10 to-surface",
+  organic: "from-emerald-700/50 via-amber-700/30 to-lime-900/40",
+  celestial: "from-indigo-900/60 via-violet-700/40 to-slate-200/20",
+  grounded: "from-amber-800/50 via-stone-700/40 to-orange-900/40",
+};
+
+/**
+ * Heuristic mapping from a user's creative orientation to the most
+ * fitting preset. Keyed on lowercased substrings of the style label
+ * so partial matches still fire. Add new rows here as the creative
+ * engine grows more orientations.
+ */
+const ORIENTATION_PRESET_HINTS: Array<[string, string]> = [
+  ["architect", "modern"],
+  ["explorer", "celestial"],
+  ["connector", "organic"],
+  ["alchemist", "mystical"],
+];
+
+function suggestPresetForProfile(
+  profile: CreativeProfile | null | undefined,
+): string | null {
+  if (!profile) return null;
+  const label = (
+    profile.creative_orientation ??
+    profile.creative_style ??
+    ""
+  ).toLowerCase();
+  if (!label) return null;
+  for (const [needle, presetId] of ORIENTATION_PRESET_HINTS) {
+    if (label.includes(needle)) return presetId;
+  }
+  return null;
+}
+
+/**
+ * Card grid of style presets for the Creative Studio.
+ *
+ * The picker is a roving-tabindex ARIA radio group: arrow keys move
+ * focus between cards, Enter/Space confirm the selection, and the
+ * selected card carries `aria-pressed="true"`.
+ */
+export default function StylePresetPicker({
+  selected,
+  onSelect,
+  creativeProfile,
+}: StylePresetPickerProps) {
+  const [presets, setPresets] = useState<StylePreset[]>(FALLBACK_PRESETS);
+  const buttonRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  // Load the live catalogue from the API; fall back silently on error.
+  useEffect(() => {
+    let cancelled = false;
+    void listStylePresets()
+      .then((next) => {
+        if (!cancelled && next.length > 0) setPresets(next);
+      })
+      .catch(() => {
+        /* keep FALLBACK_PRESETS — matches the server source of truth */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const suggestedPresetId = suggestPresetForProfile(creativeProfile);
+
+  function handleKeyDown(
+    event: React.KeyboardEvent<HTMLButtonElement>,
+    index: number,
+  ) {
+    const lastIndex = presets.length - 1;
+    if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+      event.preventDefault();
+      const nextIndex = index === lastIndex ? 0 : index + 1;
+      buttonRefs.current[nextIndex]?.focus();
+    } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+      event.preventDefault();
+      const prevIndex = index === 0 ? lastIndex : index - 1;
+      buttonRefs.current[prevIndex]?.focus();
+    } else if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      onSelect(presets[index].id);
+    } else if (event.key === "Home") {
+      event.preventDefault();
+      buttonRefs.current[0]?.focus();
+    } else if (event.key === "End") {
+      event.preventDefault();
+      buttonRefs.current[lastIndex]?.focus();
+    }
+  }
+
+  return (
+    <div
+      role="group"
+      aria-label="Choose a style preset"
+      className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3"
+    >
+      {presets.map((preset, index) => {
+        const isSelected = selected === preset.id;
+        const isSuggested = suggestedPresetId === preset.id;
+        const swatch =
+          PRESET_SWATCHES[preset.id] ??
+          "from-primary/40 via-secondary/30 to-accent/20";
+        return (
+          <button
+            key={preset.id}
+            ref={(el) => {
+              buttonRefs.current[index] = el;
+            }}
+            type="button"
+            aria-pressed={isSelected}
+            aria-label={`${preset.name} — ${preset.description}${
+              isSuggested ? ". Matched to your profile." : ""
+            }`}
+            tabIndex={
+              isSelected || (!selected && index === 0) || isSuggested ? 0 : -1
+            }
+            onClick={() => onSelect(preset.id)}
+            onKeyDown={(event) => handleKeyDown(event, index)}
+            className={`relative rounded-xl p-3 text-left border transition-all focus:outline-none focus:ring-2 focus:ring-primary/60 ${
+              isSelected
+                ? "border-primary bg-primary/10 shadow-[0_0_0_1px_rgba(123,45,142,0.5)]"
+                : "border-white/[0.06] bg-surface hover:border-white/20"
+            }`}
+            data-testid={`style-preset-${preset.id}`}
+          >
+            <div
+              className={`h-12 rounded-lg bg-gradient-to-br ${swatch} mb-2`}
+              aria-hidden="true"
+            />
+            <p className="font-display text-sm font-medium text-text">
+              {preset.name}
+            </p>
+            <p className="font-body text-xs text-text/50 mt-0.5 leading-snug">
+              {preset.description}
+            </p>
+            {isSuggested && (
+              <span
+                className="mt-2 inline-block px-2 py-0.5 rounded-full bg-secondary/20 text-secondary text-[10px] font-body uppercase tracking-wider"
+                data-testid={`style-preset-${preset.id}-badge`}
+              >
+                Matched to your profile
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/alchymine/web/src/components/creative/__tests__/ArtGallery.test.tsx
+++ b/alchymine/web/src/components/creative/__tests__/ArtGallery.test.tsx
@@ -1,0 +1,145 @@
+import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
+
+import ArtGallery, { GalleryImage } from "@/components/creative/ArtGallery";
+
+// Mock URL.createObjectURL / revokeObjectURL — jsdom doesn't ship them.
+beforeAll(() => {
+  global.URL.createObjectURL = jest.fn(() => "blob:mock-url");
+  global.URL.revokeObjectURL = jest.fn();
+});
+
+beforeEach(() => {
+  const mockBlob = new Blob([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], {
+    type: "image/png",
+  });
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    blob: async () => mockBlob,
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+const SAMPLE_IMAGES: GalleryImage[] = [
+  {
+    id: "img-1",
+    prompt: "A breathtaking symbolic landscape representing the Sage archetype",
+    stylePreset: "mystical",
+    createdAt: "2026-04-08T12:00:00Z",
+  },
+  {
+    id: "img-2",
+    prompt: "Cosmic illustration with starfields and nebulae swirling at twilight",
+    stylePreset: "celestial",
+    createdAt: "2026-04-07T18:30:00Z",
+  },
+];
+
+describe("ArtGallery", () => {
+  it("renders the empty state when no images are provided", () => {
+    render(<ArtGallery images={[]} />);
+    expect(screen.getByTestId("gallery-empty")).toBeInTheDocument();
+    expect(
+      screen.getByText(/no generated art yet/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders one card per image in a grid", async () => {
+    await act(async () => {
+      render(<ArtGallery images={SAMPLE_IMAGES} />);
+    });
+
+    expect(screen.getByTestId("gallery-grid")).toBeInTheDocument();
+    // Two open buttons, one per thumbnail.
+    await waitFor(() => {
+      const buttons = screen.getAllByRole("button", { name: /open image/i });
+      expect(buttons).toHaveLength(2);
+    });
+  });
+
+  it("opens the lightbox when a thumbnail is clicked", async () => {
+    await act(async () => {
+      render(<ArtGallery images={SAMPLE_IMAGES} />);
+    });
+
+    const firstThumb = (
+      await screen.findAllByRole("button", { name: /open image/i })
+    )[0];
+    await act(async () => {
+      fireEvent.click(firstThumb);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("art-lightbox")).toBeInTheDocument();
+    });
+    // Lightbox shows the prompt text.
+    expect(
+      screen.getByTestId("lightbox-prompt").textContent,
+    ).toContain("Sage archetype");
+    // Style badge is visible.
+    expect(screen.getByTestId("lightbox-style-badge")).toHaveTextContent(
+      /mystical/i,
+    );
+  });
+
+  it("closes the lightbox on ESC", async () => {
+    await act(async () => {
+      render(<ArtGallery images={SAMPLE_IMAGES} />);
+    });
+
+    const firstThumb = (
+      await screen.findAllByRole("button", { name: /open image/i })
+    )[0];
+    await act(async () => {
+      fireEvent.click(firstThumb);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("art-lightbox")).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("art-lightbox")).not.toBeInTheDocument();
+    });
+  });
+
+  it("closes the lightbox when the overlay is clicked", async () => {
+    await act(async () => {
+      render(<ArtGallery images={SAMPLE_IMAGES} />);
+    });
+
+    const firstThumb = (
+      await screen.findAllByRole("button", { name: /open image/i })
+    )[0];
+    await act(async () => {
+      fireEvent.click(firstThumb);
+    });
+    const overlay = await screen.findByTestId("art-lightbox");
+
+    // Click on the overlay itself (the outer element).
+    fireEvent.click(overlay);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("art-lightbox")).not.toBeInTheDocument();
+    });
+  });
+
+  it("renders a Delete button per card when onDelete is provided", async () => {
+    const onDelete = jest.fn();
+    await act(async () => {
+      render(<ArtGallery images={SAMPLE_IMAGES} onDelete={onDelete} />);
+    });
+
+    const deleteButtons = await screen.findAllByRole("button", {
+      name: /delete image generated from prompt/i,
+    });
+    expect(deleteButtons).toHaveLength(2);
+
+    fireEvent.click(deleteButtons[0]);
+    expect(onDelete).toHaveBeenCalledWith("img-1");
+  });
+});

--- a/alchymine/web/src/components/creative/__tests__/StylePresetPicker.test.tsx
+++ b/alchymine/web/src/components/creative/__tests__/StylePresetPicker.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
+
+import StylePresetPicker from "@/components/creative/StylePresetPicker";
+
+// Prevent the component's useEffect from hitting the real API.
+beforeEach(() => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => [
+      { id: "mystical", name: "Mystical", description: "Sacred geometry" },
+      { id: "modern", name: "Modern", description: "Clean editorial" },
+      { id: "organic", name: "Organic", description: "Botanical watercolour" },
+      { id: "celestial", name: "Celestial", description: "Starfields" },
+      { id: "grounded", name: "Grounded", description: "Earth tones" },
+    ],
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("StylePresetPicker", () => {
+  it("renders all five presets from the API", async () => {
+    await act(async () => {
+      render(<StylePresetPicker selected={null} onSelect={() => {}} />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("style-preset-mystical")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("style-preset-modern")).toBeInTheDocument();
+    expect(screen.getByTestId("style-preset-organic")).toBeInTheDocument();
+    expect(screen.getByTestId("style-preset-celestial")).toBeInTheDocument();
+    expect(screen.getByTestId("style-preset-grounded")).toBeInTheDocument();
+  });
+
+  it("falls back to the hardcoded list if the API errors", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+    }) as unknown as typeof fetch;
+
+    await act(async () => {
+      render(<StylePresetPicker selected={null} onSelect={() => {}} />);
+    });
+
+    // Fallback should render immediately (no await) since it's seeded
+    // into state before the effect runs.
+    expect(screen.getByTestId("style-preset-mystical")).toBeInTheDocument();
+    expect(screen.getByTestId("style-preset-grounded")).toBeInTheDocument();
+  });
+
+  it("invokes onSelect with the preset id when clicked", async () => {
+    const onSelect = jest.fn();
+    await act(async () => {
+      render(<StylePresetPicker selected={null} onSelect={onSelect} />);
+    });
+
+    fireEvent.click(screen.getByTestId("style-preset-celestial"));
+    expect(onSelect).toHaveBeenCalledWith("celestial");
+  });
+
+  it("marks the selected preset with aria-pressed=true", async () => {
+    await act(async () => {
+      render(<StylePresetPicker selected="modern" onSelect={() => {}} />);
+    });
+
+    const selected = screen.getByTestId("style-preset-modern");
+    expect(selected).toHaveAttribute("aria-pressed", "true");
+    const other = screen.getByTestId("style-preset-mystical");
+    expect(other).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("supports keyboard navigation: arrow keys move focus, Enter selects", async () => {
+    const onSelect = jest.fn();
+    await act(async () => {
+      render(<StylePresetPicker selected={null} onSelect={onSelect} />);
+    });
+
+    const firstCard = screen.getByTestId("style-preset-mystical");
+    firstCard.focus();
+    expect(document.activeElement).toBe(firstCard);
+
+    fireEvent.keyDown(firstCard, { key: "ArrowRight" });
+    const secondCard = screen.getByTestId("style-preset-modern");
+    expect(document.activeElement).toBe(secondCard);
+
+    fireEvent.keyDown(secondCard, { key: "Enter" });
+    expect(onSelect).toHaveBeenCalledWith("modern");
+  });
+
+  it("shows the matched badge when a creative profile is provided", async () => {
+    await act(async () => {
+      render(
+        <StylePresetPicker
+          selected={null}
+          onSelect={() => {}}
+          creativeProfile={{ creative_orientation: "The Architect" }}
+        />,
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("style-preset-modern")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByTestId("style-preset-modern-badge"),
+    ).toBeInTheDocument();
+  });
+});

--- a/alchymine/web/src/components/report/ReportHero.tsx
+++ b/alchymine/web/src/components/report/ReportHero.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { generateArt, artImageUrl } from "@/lib/artApi";
+
+interface ReportHeroProps {
+  reportId: string;
+  userId: string;
+}
+
+interface HeroState {
+  status: "idle" | "loading" | "ready" | "placeholder" | "error";
+  imageObjectUrl: string | null;
+  prompt: string | null;
+}
+
+const INITIAL_STATE: HeroState = {
+  status: "loading",
+  imageObjectUrl: null,
+  prompt: null,
+};
+
+/**
+ * Fetch the protected image bytes and return an object URL.
+ *
+ * The image GET endpoint requires the same auth as every other API
+ * call, so we cannot put the URL directly into an <img src=...>. Instead
+ * we fetch the bytes with credentials and create a blob URL.
+ */
+async function fetchImageBlobUrl(imageId: string): Promise<string | null> {
+  const url = artImageUrl(imageId);
+  const headers: Record<string, string> = {};
+  if (typeof window !== "undefined") {
+    const token = window.localStorage.getItem("access_token");
+    if (token) headers["Authorization"] = `Bearer ${token}`;
+  }
+  const res = await fetch(url, { headers, credentials: "include" });
+  if (!res.ok) return null;
+  const blob = await res.blob();
+  return URL.createObjectURL(blob);
+}
+
+export default function ReportHero({ reportId, userId }: ReportHeroProps) {
+  const [state, setState] = useState<HeroState>(INITIAL_STATE);
+  const [regenerating, setRegenerating] = useState(false);
+
+  const loadImage = useCallback(async () => {
+    setState((prev) => ({ ...prev, status: "loading" }));
+    try {
+      const result = await generateArt({});
+      if (result === null) {
+        // 204 — Gemini disabled. Render placeholder.
+        setState({
+          status: "placeholder",
+          imageObjectUrl: null,
+          prompt: null,
+        });
+        return;
+      }
+      const objectUrl = await fetchImageBlobUrl(result.image_id);
+      if (objectUrl === null) {
+        setState({
+          status: "placeholder",
+          imageObjectUrl: null,
+          prompt: result.prompt,
+        });
+        return;
+      }
+      setState({
+        status: "ready",
+        imageObjectUrl: objectUrl,
+        prompt: result.prompt,
+      });
+    } catch (err) {
+      // Network or 5xx — fall back to the placeholder so the report
+      // page never breaks because art is unavailable.
+      // eslint-disable-next-line no-console
+      console.warn("ReportHero generation failed:", err);
+      setState({
+        status: "placeholder",
+        imageObjectUrl: null,
+        prompt: null,
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadImage();
+    // Clean up the previous blob URL when the component unmounts.
+    return () => {
+      setState((prev) => {
+        if (prev.imageObjectUrl) URL.revokeObjectURL(prev.imageObjectUrl);
+        return prev;
+      });
+    };
+    // We intentionally re-run when reportId changes so the report page
+    // can swap reports without remounting the component tree.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [reportId, userId]);
+
+  const handleRegenerate = useCallback(async () => {
+    if (regenerating) return;
+    setRegenerating(true);
+    if (state.imageObjectUrl) URL.revokeObjectURL(state.imageObjectUrl);
+    await loadImage();
+    setRegenerating(false);
+  }, [loadImage, regenerating, state.imageObjectUrl]);
+
+  // ── Loading skeleton ──────────────────────────────────────────────
+  if (state.status === "loading") {
+    return (
+      <div
+        className="w-full h-56 sm:h-72 rounded-2xl bg-gradient-to-br from-secondary/30 via-primary/20 to-accent/30 animate-pulse"
+        role="status"
+        aria-label="Generating personalized illustration"
+      />
+    );
+  }
+
+  // ── Placeholder (Gemini disabled or network error) ────────────────
+  if (state.status === "placeholder" || !state.imageObjectUrl) {
+    return (
+      <div
+        className="relative w-full h-56 sm:h-72 rounded-2xl overflow-hidden border border-white/[0.06]"
+        role="img"
+        aria-label="Personalized illustration placeholder"
+      >
+        {/* On-brand gradient using the project palette tokens */}
+        <div className="absolute inset-0 bg-gradient-to-br from-secondary/50 via-primary/30 to-accent/40" />
+        <div
+          className="absolute inset-0"
+          style={{
+            background:
+              "radial-gradient(ellipse at 20% 80%, rgba(123,45,142,0.35) 0%, transparent 55%), radial-gradient(ellipse at 80% 20%, rgba(218,165,32,0.25) 0%, transparent 55%), radial-gradient(ellipse at 50% 50%, rgba(32,178,170,0.18) 0%, transparent 60%)",
+          }}
+        />
+        <div className="absolute inset-0 flex items-center justify-center">
+          <span className="text-xs font-body uppercase tracking-[0.2em] text-text/40">
+            Personalized art unavailable
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Image ready ───────────────────────────────────────────────────
+  return (
+    <figure className="relative w-full rounded-2xl overflow-hidden border border-white/[0.06] group">
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={state.imageObjectUrl}
+        alt={
+          state.prompt
+            ? `Personalized symbolic illustration: ${state.prompt.slice(0, 120)}`
+            : "Personalized symbolic illustration of your archetype and elemental energy"
+        }
+        className="w-full h-56 sm:h-72 object-cover"
+      />
+
+      <button
+        type="button"
+        onClick={handleRegenerate}
+        disabled={regenerating}
+        aria-label="Regenerate personalized illustration"
+        className="absolute top-3 right-3 px-3 py-1.5 text-xs font-body uppercase tracking-[0.15em] rounded-full bg-bg/70 backdrop-blur border border-white/[0.08] text-text/70 hover:text-primary hover:border-primary/40 transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-primary/40"
+      >
+        {regenerating ? "Generating…" : "Regenerate"}
+      </button>
+
+      {state.prompt && (
+        <figcaption className="px-4 py-2 text-[0.65rem] font-body text-text/30 bg-surface/60 truncate">
+          AI-generated illustration · {state.prompt.slice(0, 96)}
+          {state.prompt.length > 96 ? "…" : ""}
+        </figcaption>
+      )}
+    </figure>
+  );
+}

--- a/alchymine/web/src/components/report/__tests__/ReportHero.test.tsx
+++ b/alchymine/web/src/components/report/__tests__/ReportHero.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, waitFor, act } from "@testing-library/react";
+
+import ReportHero from "@/components/report/ReportHero";
+
+// Mock URL.createObjectURL / revokeObjectURL — jsdom doesn't ship them.
+beforeAll(() => {
+  global.URL.createObjectURL = jest.fn(() => "blob:mock-url");
+  global.URL.revokeObjectURL = jest.fn();
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("ReportHero", () => {
+  it("renders the loading skeleton on initial render", async () => {
+    // fetch returns a never-resolving promise so we stay in loading
+    global.fetch = jest.fn(
+      () => new Promise(() => {}),
+    ) as unknown as typeof fetch;
+
+    render(<ReportHero reportId="report-1" userId="user-1" />);
+    expect(
+      screen.getByLabelText(/generating personalized illustration/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the placeholder when the API returns 204", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 204,
+      json: async () => ({}),
+    }) as unknown as typeof fetch;
+
+    render(<ReportHero reportId="report-1" userId="user-1" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(/personalized illustration placeholder/i),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/personalized art unavailable/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the image and a regenerate button on 201", async () => {
+    const mockBlob = new Blob([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], {
+      type: "image/png",
+    });
+
+    global.fetch = jest
+      .fn()
+      // First call: POST /art/generate
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => ({
+          image_id: "img-123",
+          url: "/api/v1/art/img-123",
+          prompt: "A breathtaking symbolic landscape representing the Sage",
+        }),
+      })
+      // Second call: GET /art/img-123 (the bytes)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        blob: async () => mockBlob,
+      }) as unknown as typeof fetch;
+
+    await act(async () => {
+      render(<ReportHero reportId="report-1" userId="user-1" />);
+    });
+
+    await waitFor(() => {
+      const img = screen.getByRole("img", {
+        name: /personalized symbolic illustration/i,
+      });
+      expect(img).toBeInTheDocument();
+      expect((img as HTMLImageElement).src).toBe("blob:mock-url");
+    });
+
+    expect(
+      screen.getByRole("button", {
+        name: /regenerate personalized illustration/i,
+      }),
+    ).toBeInTheDocument();
+  });
+});

--- a/alchymine/web/src/lib/artApi.ts
+++ b/alchymine/web/src/lib/artApi.ts
@@ -66,3 +66,108 @@ export async function generateArt(
 export function artImageUrl(imageId: string): string {
   return `${API_BASE}/art/${imageId}`;
 }
+
+/**
+ * Fetch protected image bytes for a given image id and return a
+ * browser-local object URL pointing at the blob.
+ *
+ * The backend image GET endpoint requires the same Bearer auth as
+ * every other API call, so an `<img src="/api/v1/art/..">` tag will
+ * 401. Callers should instead:
+ *
+ * 1. Call `fetchImageBlobUrl(imageId)`
+ * 2. Assign the returned string to `<img src>`
+ * 3. Call `URL.revokeObjectURL` on unmount or before re-fetching
+ *
+ * Returns `null` on any non-2xx so callers can render a placeholder
+ * without having to catch.
+ */
+export async function fetchImageBlobUrl(
+  imageId: string,
+): Promise<string | null> {
+  const url = artImageUrl(imageId);
+  const res = await fetch(url, {
+    headers: { ...authHeaders() },
+    credentials: "include",
+  });
+  if (!res.ok) return null;
+  const blob = await res.blob();
+  return URL.createObjectURL(blob);
+}
+
+export interface StylePreset {
+  id: string;
+  name: string;
+  description: string;
+}
+
+/**
+ * Fetch the catalogue of available style presets.
+ *
+ * Source-of-truth lives in `alchymine/llm/art_prompts.py::STYLE_PRESETS`
+ * and is projected through `_PRESET_METADATA` in the generative art
+ * router. Callers that need to render the picker before auth can
+ * fall back to an empty array.
+ */
+export async function listStylePresets(): Promise<StylePreset[]> {
+  const res = await fetch(`${API_BASE}/art/presets`, {
+    headers: { ...authHeaders() },
+  });
+  if (!res.ok) {
+    throw new Error(`listStylePresets failed (${res.status})`);
+  }
+  return (await res.json()) as StylePreset[];
+}
+
+export interface GeneratedImageMetadata {
+  id: string;
+  prompt: string;
+  style_preset: string | null;
+  created_at: string;
+  url: string;
+}
+
+export interface GeneratedImageListResponse {
+  images: GeneratedImageMetadata[];
+  limit: number;
+  offset: number;
+}
+
+/**
+ * Fetch a page of the authenticated user's previously generated images.
+ *
+ * Metadata only — the actual bytes must be streamed via
+ * `fetchImageBlobUrl(imageId)` per-thumbnail.
+ */
+export async function listGeneratedImages(
+  limit = 20,
+  offset = 0,
+): Promise<GeneratedImageListResponse> {
+  const params = new URLSearchParams({
+    limit: String(limit),
+    offset: String(offset),
+  });
+  const res = await fetch(`${API_BASE}/art/list?${params.toString()}`, {
+    headers: { ...authHeaders() },
+  });
+  if (!res.ok) {
+    throw new Error(`listGeneratedImages failed (${res.status})`);
+  }
+  return (await res.json()) as GeneratedImageListResponse;
+}
+
+/**
+ * Delete a single previously generated image owned by the current user.
+ *
+ * Returns `true` on 204 success, `false` on 404 (already gone / not
+ * owned). Any other non-2xx throws so the caller can surface it.
+ */
+export async function deleteGeneratedImage(imageId: string): Promise<boolean> {
+  const res = await fetch(`${API_BASE}/art/${imageId}`, {
+    method: "DELETE",
+    headers: { ...authHeaders() },
+  });
+  if (res.status === 204) return true;
+  if (res.status === 404) return false;
+  throw new Error(`deleteGeneratedImage failed (${res.status})`);
+}

--- a/alchymine/web/src/lib/artApi.ts
+++ b/alchymine/web/src/lib/artApi.ts
@@ -1,0 +1,68 @@
+/**
+ * Typed fetch wrappers for the generative art endpoints.
+ *
+ * The backend returns 204 No Content when GEMINI_API_KEY is not
+ * configured (graceful degradation). All wrappers translate that into a
+ * `null` return value so callers can render placeholder UI without
+ * having to inspect HTTP status codes.
+ */
+
+const API_BASE = (process.env.NEXT_PUBLIC_API_URL ?? "") + "/api/v1";
+
+function authHeaders(): Record<string, string> {
+  if (typeof window === "undefined") return {};
+  const token = window.localStorage.getItem("access_token");
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+export interface ArtGenerateRequest {
+  style_preset?: string | null;
+  user_prompt_extension?: string | null;
+}
+
+export interface ArtGenerateResponse {
+  image_id: string;
+  url: string;
+  prompt: string;
+}
+
+/**
+ * Request a freshly generated personalized image for the current user.
+ *
+ * Returns:
+ * - `ArtGenerateResponse` on 201 success
+ * - `null` on 204 (Gemini disabled — caller should render placeholder)
+ *
+ * Throws on 4xx/5xx other than 204.
+ */
+export async function generateArt(
+  body: ArtGenerateRequest = {},
+): Promise<ArtGenerateResponse | null> {
+  const res = await fetch(`${API_BASE}/art/generate`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...authHeaders(),
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (res.status === 204) return null;
+  if (!res.ok) {
+    const message = await res.text().catch(() => "");
+    throw new Error(`generateArt failed (${res.status}): ${message}`);
+  }
+  return (await res.json()) as ArtGenerateResponse;
+}
+
+/**
+ * Build the absolute URL for fetching a previously generated image.
+ *
+ * Useful when wiring an `<img src=...>` tag — the image GET endpoint
+ * returns raw bytes so it can be used directly as an image source. The
+ * Authorization header still applies if the deployment uses cookie auth
+ * the browser will automatically include credentials.
+ */
+export function artImageUrl(imageId: string): string {
+  return `${API_BASE}/art/${imageId}`;
+}

--- a/docs/adr/009-archon-integration.md
+++ b/docs/adr/009-archon-integration.md
@@ -1,0 +1,145 @@
+# ADR-009: Archon Integration — Secrets Relocation and Docker Wrapper
+
+**Status:** Accepted
+
+**Date:** 2026-04-09
+
+**Authors:** Sammy + Claude Code session
+
+## Context
+
+On 2026-04-09 Alchymine was integrated with [Archon](https://github.com/coleam00/Archon), a remote agentic coding platform living at `I:\GithubI\Archon`. Archon spawns AI subprocesses (Claude Agent SDK, Codex SDK) against target repositories and drives them from chat platforms (Slack, Telegram, GitHub, Discord, Web). To use Archon against Alchymine, the Alchymine repository must be registered as an Archon "codebase".
+
+Registration failed on the first attempt. Two distinct — but related — problems surfaced.
+
+### Problem 1: Bun auto-loads `.env` into AI subprocesses
+
+Archon is built on Bun. When it spawns an AI subprocess with `cwd=<target repo>`, Bun auto-loads any `.env` (and similarly-named) file from that cwd directly into the subprocess environment. For Alchymine, that meant every secret in the repo-root `.env` would become visible to the AI subprocess:
+
+- `ANTHROPIC_API_KEY` (production key the Alchymine app itself uses for its own Claude calls — not a throwaway)
+- `JWT_SECRET_KEY`
+- `POSTGRES_PASSWORD`
+- `ALCHYMINE_ENCRYPTION_KEY`
+- `REDIS_PASSWORD`
+- `RESEND_API_KEY`
+- `PDF_SERVICE_TOKEN`
+- …and anything else ever added to `.env`
+
+Any of these could be exfiltrated via a `bash cat .env`, an `echo $ANTHROPIC_API_KEY`, a tool-call output, a prompt injection, or a well-meaning workflow that logs environment for debugging. The blast radius was the entire Alchymine production secret surface.
+
+### Problem 2: Archon's env-leak gate blocks registration
+
+Archon ships an env-leak scanner (`I:\GithubI\Archon\packages\core\src\utils\env-leak-scanner.ts`) that refuses to register a codebase when it finds AI-specific API keys in the repo root. The scanner:
+
+- Scans only the repo **root** (not subdirectories).
+- Scans only these filenames: `.env`, `.env.local`, `.env.development`, `.env.production`, `.env.development.local`, `.env.production.local`.
+- Flags these key names: `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `CLAUDE_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `OPENAI_API_KEY`, `CODEX_API_KEY`, `GEMINI_API_KEY`.
+
+`POST /api/codebases` returned 422 because Alchymine's `.env` contained `ANTHROPIC_API_KEY`. This gate is not the full safety story — it only flags the AI-specific subset — but it is a forcing function that surfaced Problem 1 before any AI subprocess actually ran.
+
+We needed to resolve both problems without compromising secrets and without breaking Alchymine's existing developer workflow (Docker Compose, Pydantic Settings, pytest, the Next.js frontend, and production deploys).
+
+## Decision
+
+Move Alchymine's runtime secrets from `.env` at the repo root to `.secrets/.env` inside the repo. Update `alchymine/config.py` to read from the new location. Add a `run.ps1` wrapper that invokes `docker compose --env-file .secrets/.env` so contributors do not have to remember the flag. Register Alchymine in Archon without granting any env-leak consent — the gate should be **satisfied**, not bypassed.
+
+The file stays inside the repo tree (so it travels with the project and stays close to the code that uses it), stays gitignored, and lives in a directory whose name makes its purpose unambiguous.
+
+## Alternatives Considered
+
+### 1. Grant Archon consent (`allowEnvKeys: true`)
+
+Archon allows a codebase owner to acknowledge the risk and bypass the gate via `PATCH /api/codebases/:id` with `{"allowEnvKeys": true}`. **Rejected** because:
+
+- The scanner only flags the AI-specific keys, but **all** keys in `.env` leak to the AI subprocess (JWT, DB password, encryption key, etc.). Granting consent is honest about one risk and silently exposes a much bigger surface.
+- `ANTHROPIC_API_KEY` in Alchymine's `.env` is the production key Alchymine itself uses. Leaking it has real blast radius.
+- Consent is a long-term liability: any future secret added to `.env` also leaks, silently, forever.
+
+### 2. Rename `.env` → `.env.local` in place
+
+**Rejected.** Bun still auto-loads `.env.local`, and Archon's gate also scans `.env.local`. This would change nothing.
+
+### 3. Rename `.env` → `.env.private` (or another non-auto-loaded name) in the repo root
+
+Would solve both the Bun auto-load problem and the Archon gate (since the gate only scans the specific filenames listed above). **Rejected** because Docker Compose specifically looks for `.env` in the project directory for variable substitution, and Alchymine's `docker-compose.yml` uses variable substitution extensively (`${ANTHROPIC_API_KEY:-}`, `${POSTGRES_PASSWORD:?...}`, etc.). We would have to pass `--env-file` on every `docker compose` invocation anyway — and if we are doing that, we may as well move the file to a more meaningful location.
+
+### 4. Move keys to a dedicated secrets manager (Doppler, 1Password CLI, Infisical)
+
+Structurally the best long-term answer: secrets never live on disk in the repo at all. **Rejected for this pass** because it is invasive (requires changing how every Alchymine component reads its config), the Archon integration was needed immediately, and the investment is significant. Captured as follow-up work.
+
+### 5. Move `.env` to a subdirectory inside the repo
+
+Chose between three candidate locations:
+
+- **`config/.env`** — `config/` already exists and holds runtime YAML. Rejected because mixing secrets into a non-secret directory reads ambiguously and fights the existing purpose of the folder.
+- **`~/.alchymine/.env`** (outside the repo entirely) — strongest isolation. Rejected because it requires setting the file up on every machine and CI runner, breaks repo-portability, and is awkward on Windows (`$HOME` ergonomics).
+- **`.secrets/.env`** — a clearly-labeled secrets subdirectory inside the repo, gitignored, obvious purpose, trivially reversible. **Chosen.**
+
+## Changes Made
+
+- **Created directory** `I:\GithubI\Alchymine\.secrets\`.
+- **Moved file** `I:\GithubI\Alchymine\.env` → `I:\GithubI\Alchymine\.secrets\.env`.
+- **Modified** `I:\GithubI\Alchymine\alchymine\config.py` line 30: `env_file=".env"` → `env_file=".secrets/.env"`.
+- **Modified** `I:\GithubI\Alchymine\.gitignore`: appended `.secrets/` under the `# ─── Environment & Secrets ───` section.
+- **Created** `I:\GithubI\Alchymine\run.ps1`: PowerShell wrapper that runs `docker compose --env-file .secrets/.env -f infrastructure/docker-compose.yml @args`. Usage: `./run.ps1 up -d`, `./run.ps1 logs -f api`, `./run.ps1 down`, `./run.ps1 config`.
+- **Modified** `I:\GithubI\Alchymine\.env.example`: added a 10-line header comment explaining the `.secrets/.env` convention and pointing to `docs/guides/archon-integration.md`.
+- **Copied** `I:\GithubI\Archon\.claude\skills\archon\` → `I:\GithubI\Alchymine\.claude\skills\archon\` so Claude Code sessions inside Alchymine can invoke the `archon` skill.
+- **Updated** `I:\GithubI\Alchymine\CLAUDE.md`: added a new "Archon Integration" section.
+- **Created** `I:\GithubI\Alchymine\docs\guides\archon-integration.md`: long-form reference guide.
+- **Registered** Alchymine in Archon via `POST /api/codebases` — codebase id `493dc1f45b4234ce0e3558c3351bad7d`, `allow_env_keys = 0` (the gate was **not** tripped after the move, so no consent was needed).
+
+## Consequences
+
+**Positive:**
+
+- Archon integration works with **zero** consent grants. No `allowEnvKeys: true` anywhere. The gate was satisfied, not bypassed.
+- AI subprocesses running with `cwd=I:\GithubI\Alchymine` do not see Alchymine's secrets via Bun auto-load.
+- Secrets are physically separated from application code. Harder to accidentally `git add .`, `tar cf`, or log-dump them.
+- A single explicit location for all runtime secrets — easier to audit, rotate, back up.
+- `.env.example` stays at the repo root where contributors expect it.
+- Tests were unaffected — `tests/test_config.py:22` passes `_env_file=None` and so never loads `.env` at all.
+- Production deploys (`docker-compose.prod.yml`) were unaffected — they already use `env_file: ../.env.production` via explicit paths.
+- The Next.js frontend was unaffected — it reads its own `.env*` files under `alchymine/web/`, not the repo root.
+- Reversible in under a minute (see Rollback Plan).
+
+**Negative:**
+
+- `docker compose up` directly (without `--env-file` or the wrapper) will fail because there is no `.env` in the cwd. Must use `./run.ps1` or pass the flag explicitly. Muscle memory risk.
+- `uvicorn alchymine.api.main:app`, `pytest`, and other Python invocations must be run from the Alchymine repo root (not from `alchymine/` or `tests/`) because Pydantic Settings resolves `.secrets/.env` relative to the cwd. A more robust fix would be to resolve the path relative to `__file__`, but that is a future improvement — and the cwd-relative path is what the code had before this change.
+- New contributors must be told about the convention; they will not discover `./run.ps1` by running `docker compose` from habit. Mitigated by the updated `.env.example` header, the `CLAUDE.md` section, and `docs/guides/archon-integration.md`.
+- If a future workflow or script assumes `I:\GithubI\Alchymine\.env` exists, it will break. The `scripts/` directory should be audited (see Follow-up Work).
+- `run.ps1` is Windows-only. Contributors on Linux/macOS would need a `run.sh` equivalent. Out of scope for this change; the primary developer is on Windows.
+
+**Risks:**
+
+- A secret added in future to `.secrets/.env` is still only as safe as the `.secrets/` directory's gitignore line. A careless `git add -f` can still commit it. The convention does not remove the need for pre-commit hygiene.
+
+## Rollback Plan
+
+If this decision needs to be reverted, the exact steps are:
+
+1. `mv I:\GithubI\Alchymine\.secrets\.env I:\GithubI\Alchymine\.env` — move the file back.
+2. Edit `alchymine\config.py` line 30: change `.secrets/.env` back to `.env`.
+3. Delete `I:\GithubI\Alchymine\run.ps1`.
+4. Remove `.secrets/` from `I:\GithubI\Alchymine\.gitignore`.
+5. Delete `I:\GithubI\Alchymine\.claude\skills\archon\` (optional — the skill does not hurt).
+6. Revert the `CLAUDE.md` and `.env.example` edits.
+7. Delete `I:\GithubI\Alchymine\docs\guides\archon-integration.md` and this planning doc.
+8. In Archon, either delete the Alchymine codebase (`DELETE /api/codebases/493dc1f45b4234ce0e3558c3351bad7d`) or grant consent (`PATCH /api/codebases/493dc1f45b4234ce0e3558c3351bad7d` with body `{"allowEnvKeys": true}`).
+
+## Follow-up Work
+
+- Audit `scripts/` for any shell scripts that read `.env` directly from the repo root.
+- Consider making `alchymine/config.py` resolve `env_file` relative to `Path(__file__).parent.parent` so it works regardless of cwd.
+- If Alchymine ever adds Linux/macOS dev support, add a `run.sh` equivalent to `run.ps1`.
+- Long-term: evaluate Doppler / Infisical / 1Password CLI as a cleaner secrets story that removes `.env` from disk entirely.
+- Periodically re-audit `.secrets/.env` contents against a documented inventory of required keys, to catch drift and stale secrets.
+
+## References
+
+- Archon integration guide: `I:\GithubI\Alchymine\docs\guides\archon-integration.md`
+- Archon env-leak scanner: `I:\GithubI\Archon\packages\core\src\utils\env-leak-scanner.ts`
+- Alchymine config loader: `I:\GithubI\Alchymine\alchymine\config.py` (see `env_file=".secrets/.env"` on line 30)
+- Docker Compose wrapper: `I:\GithubI\Alchymine\run.ps1`
+- Archon codebase registration API: `POST /api/codebases`, `PATCH /api/codebases/:id` (see `I:\GithubI\Archon\packages\server\src\routes\api.ts`)
+- Registered Archon codebase id: `493dc1f45b4234ce0e3558c3351bad7d` (`allow_env_keys = 0`)

--- a/docs/guides/archon-integration.md
+++ b/docs/guides/archon-integration.md
@@ -1,0 +1,633 @@
+# Alchymine — Archon Integration Guide
+
+How Alchymine uses [Archon](https://github.com/coleam00/Archon) as its remote
+agentic coding platform. This is the single authoritative reference for the
+integration — if something here conflicts with another doc, this file wins.
+
+**Target audience:** developers working on Alchymine who want to run AI
+workflows against the repo (fix an issue, review a PR, refactor a module,
+sweep the architecture) without manually pasting prompts into a chat window.
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Quick Start](#quick-start)
+3. [The `.secrets/.env` Convention](#the-secretsenv-convention)
+4. [Using Archon from Claude Code](#using-archon-from-claude-code)
+5. [Using Archon from the CLI](#using-archon-from-the-cli)
+6. [Using Archon from the Web UI](#using-archon-from-the-web-ui)
+7. [Recommended Workflows for Alchymine](#recommended-workflows-for-alchymine)
+8. [Where Secrets Live](#where-secrets-live)
+9. [Gotchas and Rollback](#gotchas-and-rollback)
+10. [Further Reading](#further-reading)
+
+---
+
+## Overview
+
+**Archon** is a remote agentic coding platform built on Bun + TypeScript +
+SQLite. It runs AI workflows (Claude Code SDK, Codex SDK) inside isolated git
+worktrees and can be driven from:
+
+- A CLI (`archon ...` — global command, works from any directory)
+- A Web UI (React, SSE streaming, dashboards)
+- Telegram (`@ArchonOkieBot` with a user whitelist)
+- GitHub webhooks (`@archon` mentions in issue/PR comments)
+
+Archon lives at `I:\GithubI\Archon`. Alchymine is registered with it as the
+codebase `realsammyt/Alchymine` pointing at `I:\GithubI\Alchymine`. Every
+workflow run creates its own git worktree so concurrent runs never stomp on
+each other or on your working copy.
+
+**Why we wired it up:** Alchymine has enough moving parts (FastAPI backend,
+Next.js frontend, Celery workers, Postgres, Redis, infra scripts) that
+long-running AI tasks — "fix issue #123", "review PR #42", "refactor the
+encryption module" — benefit from running in an isolated worktree rather than
+blocking the working copy. Archon gives us that isolation for free, plus
+multi-transport access (Claude Code, CLI, web, Telegram, GitHub webhooks).
+
+**What changed when we integrated it** (2026-04-09):
+
+| Change                                                 | Reason                                                                 |
+| ------------------------------------------------------ | ---------------------------------------------------------------------- |
+| Secrets moved from `.env` → `.secrets/.env`            | Archon's env-leak gate refuses registration if repo-root `.env` exists |
+| `alchymine/config.py:30` now reads `.secrets/.env`     | Pydantic Settings needs to follow the new path                         |
+| `.gitignore` ignores `.secrets/`                       | Keep secrets out of git (they already were, but make it explicit)      |
+| New `run.ps1` at repo root                             | Pins `docker compose` to `--env-file .secrets/.env` so muscle-memory `docker compose up` still works |
+| `.claude/skills/archon/` copied into the repo          | Claude Code sessions in Alchymine auto-load the archon skill           |
+| `.env.example` updated with a header comment           | New devs learn the convention immediately                              |
+
+Alchymine is registered with `allow_env_keys = 0` — we do **not** bypass the
+env-leak gate, we satisfy it.
+
+---
+
+## Quick Start
+
+The shortest path from a fresh clone to running your first workflow.
+
+```powershell
+# 1. Clone and install
+git clone https://github.com/realsammyt/Alchymine.git
+cd Alchymine
+# ... your normal setup (uv sync, bun install, etc.) ...
+
+# 2. Create your secrets file
+mkdir .secrets
+copy .env.example .secrets\.env
+# Fill in ANTHROPIC_API_KEY, JWT_SECRET_KEY, POSTGRES_PASSWORD, etc.
+
+# 3. Verify Archon can see Alchymine
+archon workflow list
+# Should print ~20 workflows with no errors
+
+# 4. Run your first workflow in the background (isolated worktree)
+archon workflow run archon-assist --branch assist/first-try "What does alchymine/config.py do?"
+
+# 5. Watch it run
+archon workflow status
+```
+
+From Claude Code running inside Alchymine, the same thing is even simpler — the
+archon skill is preloaded, so you just say:
+
+> use archon to explain what `alchymine/config.py` does
+
+Claude Code will translate that into an `archon workflow run archon-assist ...`
+invocation and launch it as a background task.
+
+---
+
+## Usage Patterns
+
+Use direct Claude Code for interactive, exploratory work in your live checkout.
+Delegate long-running, isolated, or multi-pass work to Archon via the preloaded
+skill — runs land in a dedicated worktree and you keep coding.
+
+| Task                                          | Use                          |
+| --------------------------------------------- | ---------------------------- |
+| Debug a Celery worker hang, poke at a file    | Claude Code (direct)         |
+| Fix a filed GitHub issue end-to-end           | `archon-fix-github-issue`    |
+| Refactor `alchymine/services/encryption.py`   | `archon-refactor-safely`     |
+| Architectural sweep of `alchymine/services/`  | `archon-architect`           |
+| Deep review of a PR                           | `archon-comprehensive-pr-review` |
+
+For the full cross-project decision tree, see the canonical usage-patterns doc:
+`.claude\skills\archon\references\usage-patterns.md`
+
+For anti-patterns, the "typical day" example, and project-onboarding steps,
+see the canonical doc.
+
+---
+
+## The `.secrets/.env` Convention
+
+**This is the most important section of this doc.** If you only read one
+thing, read this.
+
+### The Rule
+
+Alchymine's secrets live at `I:\GithubI\Alchymine\.secrets\.env`. **Never** put
+them in the repo-root `.env`. Don't even create an empty repo-root `.env`.
+
+```
+I:\GithubI\Alchymine\
+  .env.example          <- committed, template with header comment
+  .secrets\
+    .env                <- gitignored, real secrets go here
+  .gitignore            <- ignores .secrets/
+```
+
+### Why (The Long Version)
+
+When Archon spawns a Claude or Codex subprocess inside a repo, that subprocess
+runs on the Bun runtime. **Bun auto-loads `.env` from its cwd at startup.**
+This means any `.env` file at the Alchymine repo root gets read by every AI
+subprocess Archon runs — completely bypassing Archon's internal env allowlist.
+
+Alchymine's secrets include (at minimum):
+
+- `ANTHROPIC_API_KEY` — billing-linked
+- `JWT_SECRET_KEY` — auth tokens
+- `POSTGRES_PASSWORD` — database
+- `ALCHYMINE_ENCRYPTION_KEY` — at-rest encryption
+- `REDIS_PASSWORD` — cache / queue
+- `RESEND_API_KEY` — transactional email
+- ...plus provider keys, webhook secrets, feature flags
+
+Any of these leaking into an AI subprocess is a security incident. So Archon's
+**env-leak gate** refuses to register a codebase if the repo root contains any
+of:
+
+```
+.env
+.env.local
+.env.development
+.env.production
+.env.development.local
+.env.production.local
+```
+
+The scan is **root-only** — subdirectories are not checked. That's why
+`.secrets/.env` works: it's outside both the scan path *and* Bun's auto-load
+path.
+
+When Alchymine was first registered, Archon returned a 422 at
+`POST /api/codebases` listing the forbidden files. The fix was:
+
+```powershell
+# From I:\GithubI\Alchymine
+mkdir .secrets
+move .env .secrets\.env
+```
+
+Then updating the Pydantic Settings loader at
+`I:\GithubI\Alchymine\alchymine\config.py:30` from `env_file=".env"` to
+`env_file=".secrets/.env"`.
+
+### What Reads From Where
+
+| Component            | File it reads                     | Resolution                                            |
+| -------------------- | --------------------------------- | ----------------------------------------------------- |
+| Pydantic Settings    | `.secrets/.env`                   | Relative to **cwd** — you must run from repo root     |
+| Docker Compose       | `.secrets/.env` (via `--env-file`)| Must pass `--env-file` explicitly or use `run.ps1`    |
+| Next.js (dev)        | `.env.local` in `frontend/`       | Frontend has its own env — unaffected by this change  |
+| pytest               | `.secrets/.env`                   | Same as Pydantic Settings — run from repo root        |
+| CI (GitHub Actions)  | Repository secrets                | Injected via `env:` in workflow YAML — unaffected     |
+| Archon subprocesses  | Nothing from this repo            | Archon injects its own allowlisted env                |
+
+### Docker Compose Wrapper
+
+Because `docker compose up` out of the box looks for a cwd-relative `.env`,
+we ship `I:\GithubI\Alchymine\run.ps1`:
+
+```powershell
+# run.ps1 — pins env-file and compose-file so muscle memory still works
+docker compose --env-file .secrets/.env -f infrastructure/docker-compose.yml @args
+```
+
+Use it exactly like `docker compose`:
+
+```powershell
+.\run.ps1 up -d
+.\run.ps1 logs -f api
+.\run.ps1 down
+.\run.ps1 exec api bash
+```
+
+If you run `docker compose` directly without `--env-file`, it will fail with
+missing-variable errors. That's the intended guardrail.
+
+---
+
+## Using Archon from Claude Code
+
+This is the common case — you're already in a Claude Code session inside
+`I:\GithubI\Alchymine`, and you want Archon to go do a thing.
+
+### The Skill Is Preloaded
+
+`.claude/skills/archon/SKILL.md` is copied into the Alchymine repo, so Claude
+Code auto-discovers it. You don't need to invoke it manually.
+
+### How to Ask
+
+Use natural phrasing with an "archon" trigger:
+
+- *"use archon to fix issue #123"*
+- *"have archon review PR #42"*
+- *"let archon refactor the encryption module"*
+- *"ask archon why the Celery worker is hanging"*
+- *"run archon architect on the alchymine/services folder"*
+
+Claude Code maps those to the right `archon workflow run ...` command. You
+don't need to remember workflow names.
+
+### Always in the Background
+
+Archon workflows take **minutes to hours**. Claude Code will launch them with
+`run_in_background: true` on the Bash tool so your interactive session stays
+responsive. You can keep working while the workflow runs.
+
+Under the hood it looks like:
+
+```powershell
+archon workflow run archon-fix-github-issue --branch fix/issue-123 "Fix issue #123"
+```
+
+...launched as a background bash task. The foreground Claude Code session gets
+the run ID immediately and can poll for status.
+
+### Checking on a Running Workflow
+
+Ask Claude Code things like:
+
+- *"what's the status of the archon run?"*
+- *"show me the latest archon workflows"*
+- *"is the fix-issue-123 workflow done?"*
+
+Or directly:
+
+```powershell
+archon workflow status
+archon workflow status <run-id>
+```
+
+### Interactive Workflows
+
+A few workflows need foreground execution with approval gates:
+
+- `archon-piv-loop` — interactive guided development
+- `archon-interactive-prd` — interactive PRD creation
+
+These use a "transparent relay" protocol where the workflow pauses and asks
+the user for approval via the web UI or chat adapter. **Don't background
+these.** If Claude Code suggests one of these, switch to the Web UI for the
+interactive part.
+
+---
+
+## Using Archon from the CLI
+
+Every command below runs from `I:\GithubI\Alchymine` unless noted. The
+`archon` binary is linked globally, so it works from any directory — but
+workflow / isolation commands need to be run from inside a git repo (or
+subdirectory — they resolve to the repo root).
+
+### Listing
+
+```powershell
+# All workflows (bundled + repo-specific)
+archon workflow list
+
+# Machine-readable
+archon workflow list --json
+
+# All active worktrees across all projects
+archon isolation list
+```
+
+### Running a Workflow
+
+Every run creates an isolated worktree by default. Pass `--branch` to name it:
+
+```powershell
+# General Q&A, exploration, debugging
+archon workflow run archon-assist --branch assist/celery-hang `
+  "Why is the Celery worker hanging on the encrypt_payload task?"
+
+# Fix a GitHub issue end-to-end (clone → implement → tests → PR)
+archon workflow run archon-fix-github-issue --branch fix/issue-123 "Fix issue #123"
+
+# Review a PR in depth (multiple agent passes)
+archon workflow run archon-comprehensive-pr-review --branch review/pr-42 "Review PR #42"
+
+# Lighter, faster PR review
+archon workflow run archon-smart-pr-review --branch review/pr-42 "Review PR #42"
+
+# Run tests + linters on a PR branch
+archon workflow run archon-validate-pr --branch validate/pr-42 "Validate PR #42"
+
+# Implement from an existing plan document
+archon workflow run archon-plan-to-pr --branch feat/billing `
+  "Execute docs/plans/2026-04-15-billing.md"
+
+# Architectural sweep / complexity reduction
+archon workflow run archon-architect --branch arch/services-sweep `
+  "Sweep alchymine/services for complexity hotspots"
+```
+
+You can start **multiple runs in parallel** — each gets its own worktree and
+branch, so they don't collide.
+
+### Status and Resume
+
+```powershell
+# All runs
+archon workflow status
+
+# Specific run
+archon workflow status <run-id>
+
+# Resume a failed run (re-runs, skipping completed nodes)
+archon workflow resume <run-id>
+
+# Abandon a non-terminal run (marks as cancelled)
+archon workflow abandon <run-id>
+```
+
+### Worktree Cleanup
+
+Archon worktrees for Alchymine live at:
+
+```
+C:\Users\info\.archon\workspaces\realsammyt\Alchymine\worktrees\<branch-name>\
+```
+
+You can `cd` into any of them to inspect state mid-run or post-run. To clean
+up:
+
+```powershell
+# Clean up worktrees older than 7 days
+archon isolation cleanup
+
+# Clean up worktrees whose branches are merged into main
+# (also deletes the remote branches)
+archon isolation cleanup --merged
+
+# Also remove worktrees with closed (abandoned) PRs
+archon isolation cleanup --merged --include-closed
+
+# Complete lifecycle for one branch (remove worktree + local + remote branch)
+archon complete fix/issue-123
+```
+
+---
+
+## Using Archon from the Web UI
+
+The Web UI is the best interface for monitoring multiple runs at once and for
+interactive workflows that need approval gates.
+
+### Starting the Archon Server
+
+The CLI works standalone, but the Web UI, GitHub webhooks, and Telegram all
+need the server running.
+
+```powershell
+cd I:\GithubI\Archon
+bun run dev
+```
+
+This starts:
+
+- Backend on `http://localhost:3000` (we set `PORT=3000` in
+  `I:\GithubI\Archon\.env` — Archon's default is 3090, but we collide with
+  Alchymine's backend on that port)
+- Frontend dev server on `http://localhost:5173` (proxies API calls to :3000)
+
+> **Log tip:** `bun run dev` from the Archon repo root truncates sub-process
+> logs (a known Bun filter quirk — see `I:\GithubI\Archon\.claude\rules\dx-quirks.md`).
+> If the server errors and you need full logs, run it directly:
+>
+> ```powershell
+> cd I:\GithubI\Archon\packages\server
+> bun --watch src/index.ts
+> ```
+
+The production build serves both API and UI from `http://localhost:3000`.
+
+### Opening the UI
+
+- Dev: [http://localhost:5173](http://localhost:5173)
+- Prod: [http://localhost:3000](http://localhost:3000)
+
+### Running a Workflow
+
+1. In the sidebar, click the project selector and pick `realsammyt/Alchymine`
+2. At the top of the sidebar, the workflow invoker lets you:
+   - Pick a workflow from the dropdown
+   - Write a message / prompt
+   - Click **Run**
+3. A new conversation is created and the workflow starts in the background
+4. The conversation view shows streaming output (SSE) from the workflow
+
+### Dashboard
+
+Navigate to [http://localhost:5173/dashboard](http://localhost:5173/dashboard)
+(or `:3000/dashboard` in prod). You'll see:
+
+- All running workflows across all projects
+- Recent completed / failed runs
+- Per-run timeline with node-level progress
+- Artifact files produced by each run
+- Resume / abandon / delete actions
+
+---
+
+## Recommended Workflows for Alchymine
+
+A curated subset of Archon's bundled workflows, with Alchymine-specific
+guidance. Run `archon workflow list` to see the full catalog.
+
+| Workflow                          | When to use it                                          | Example                                                                                     |
+| --------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `archon-assist`                   | General Q&A, exploration, debugging — the fallback      | `archon workflow run archon-assist --branch assist/debug "Why does celery hang?"`           |
+| `archon-fix-github-issue`         | End-to-end fix for a filed issue                        | `archon workflow run archon-fix-github-issue --branch fix/issue-123 "Fix issue #123"`       |
+| `archon-comprehensive-pr-review`  | Deep multi-pass review of a PR                          | `archon workflow run archon-comprehensive-pr-review --branch review/pr-42 "Review PR #42"`  |
+| `archon-smart-pr-review`          | Lighter / faster review — good for small PRs            | `archon workflow run archon-smart-pr-review --branch review/pr-42 "Review PR #42"`          |
+| `archon-validate-pr`              | Run tests + linters against a PR branch                 | `archon workflow run archon-validate-pr --branch validate/pr-42 "Validate PR #42"`          |
+| `archon-feature-development`      | Implement a feature from a plan document                | `archon workflow run archon-feature-development --branch feat/billing "Implement billing per docs/plans/..."` |
+| `archon-plan-to-pr`               | Execute an existing plan.md end-to-end to a PR          | `archon workflow run archon-plan-to-pr --branch feat/billing "docs/plans/2026-04-15-billing.md"` |
+| `archon-idea-to-pr`               | Plan AND implement a rough idea end-to-end              | `archon workflow run archon-idea-to-pr --branch feat/idea "Add webhook retry backoff"`     |
+| `archon-refactor-safely`          | Refactoring with safety checks (tests, diffs, review)   | `archon workflow run archon-refactor-safely --branch refactor/services "Refactor alchymine/services/encryption.py"` |
+| `archon-architect`                | Architectural sweep, complexity reduction               | `archon workflow run archon-architect --branch arch/services "Sweep alchymine/services"`   |
+| `archon-resolve-conflicts`        | Resolve merge conflicts on a PR                         | `archon workflow run archon-resolve-conflicts --branch conflicts/pr-42 "Resolve conflicts on PR #42"` |
+| `archon-create-issue`             | Draft and file a new GitHub issue                       | `archon workflow run archon-create-issue --branch issue/new "File issue for the Celery bug"` |
+
+### Interactive workflows (run in Web UI, not background)
+
+| Workflow                  | When to use it                                              |
+| ------------------------- | ----------------------------------------------------------- |
+| `archon-piv-loop`         | Interactive guided development with approval gates         |
+| `archon-interactive-prd`  | Interactive PRD creation with live feedback                 |
+
+These need foreground execution and use Archon's transparent relay protocol.
+Run them from the Web UI so the approval gates have somewhere to land.
+
+---
+
+## Where Secrets Live
+
+Three separate `.env` files exist on this machine. They serve different
+purposes — do not merge them.
+
+| Path                                       | Contains                                                          | Who reads it                                                                                 |
+| ------------------------------------------ | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `C:\Users\info\.archon\.env`               | Archon CLI credentials (API keys, webhook secrets, bot tokens)    | `archon` CLI when run from any directory — global infra config                              |
+| `I:\GithubI\Archon\.env`                   | Same content as `~/.archon/.env`                                  | Archon **server** when started via `bun run dev` — server reads from its repo root           |
+| `I:\GithubI\Alchymine\.secrets\.env`       | Alchymine application secrets (DB, JWT, encryption, provider keys)| Alchymine's Pydantic Settings, `run.ps1` docker compose, pytest — **all cwd-relative**       |
+
+Key Archon environment flags set on this machine:
+
+- `PORT=3000` — in `I:\GithubI\Archon\.env`. Archon defaults to 3090, but we
+  moved it to avoid a collision with Alchymine's backend.
+- `CLAUDE_USE_GLOBAL_AUTH=true` — in both Archon `.env` files. Uses Claude
+  Code's existing login instead of a separate API key.
+- `TELEGRAM_ALLOWED_USER_IDS=<your id>` — whitelist for `@ArchonOkieBot`.
+
+Archon's SQLite database is at `C:\Users\info\.archon\archon.db`. No setup
+needed — Archon auto-initializes it on first run.
+
+---
+
+## Gotchas and Rollback
+
+### 1. Don't restore `.env` to the repo root
+
+Doing this will:
+
+- Re-trigger Archon's env-leak gate — next registration or scan refresh fails
+  with a 422
+- Expose every Alchymine secret to any AI subprocess Archon spawns with
+  `cwd=I:\GithubI\Alchymine`
+
+If you find yourself wanting to do this, fix the consumer instead (make it
+read from `.secrets/.env`).
+
+### 2. `docker compose` without `--env-file`
+
+If you run `docker compose up` from the Alchymine repo root out of muscle
+memory, it will fail because there's no cwd-relative `.env`. Use:
+
+```powershell
+.\run.ps1 up -d
+# or, if you must call docker compose directly:
+docker compose --env-file .secrets/.env -f infrastructure/docker-compose.yml up -d
+```
+
+### 3. uvicorn / pytest / CLI from subdirectories
+
+Pydantic Settings resolves `.secrets/.env` **relative to the current working
+directory**. If you run `pytest` or `uvicorn` from, say, `alchymine/services/`,
+the path won't resolve and you'll get a stack of "missing required env
+variable" errors. Always run from the repo root.
+
+```powershell
+cd I:\GithubI\Alchymine
+uv run uvicorn alchymine.main:app --reload
+uv run pytest
+```
+
+### 4. Archon server must be running for Web UI / webhooks / Telegram
+
+The CLI works standalone. But the Web UI, GitHub webhooks, and Telegram
+adapters all need `bun run dev` running inside `I:\GithubI\Archon`. If the
+dashboard won't load, that's the first thing to check.
+
+### 5. Archon worktrees live outside the repo
+
+Don't go looking for workflow output in `I:\GithubI\Alchymine` — it's not
+there. It's at:
+
+```
+C:\Users\info\.archon\workspaces\realsammyt\Alchymine\worktrees\<branch>\
+```
+
+You can `cd` into any of these to inspect state. They're real git worktrees,
+so you can run `git log`, `git diff`, etc.
+
+### 6. Docker port collisions inside worktrees
+
+If a workflow runs `./run.ps1 up` inside a worktree, it'll try to bind the
+same ports as any other running Alchymine stack. **Stop the main stack first**,
+or be aware that the worktree run will fail on port binding. (In general,
+workflows shouldn't be starting the full Docker stack — prefer unit tests and
+isolated services.)
+
+### 7. Rotate secrets if `.secrets/.env` is ever compromised
+
+The file is gitignored, but screen shares, logs, and crash dumps are still
+risks. If you suspect exposure, rotate:
+
+- `ANTHROPIC_API_KEY` at [console.anthropic.com](https://console.anthropic.com/)
+- `JWT_SECRET_KEY` — generate a new random value, restart the API
+- `POSTGRES_PASSWORD` — `ALTER USER alchymine WITH PASSWORD '...';` then
+  update the env file
+- `ALCHYMINE_ENCRYPTION_KEY` — **careful**, this invalidates at-rest encrypted
+  data; only rotate with a re-encryption migration
+- `REDIS_PASSWORD` — update both Redis config and env file
+- `RESEND_API_KEY` at [resend.com](https://resend.com/api-keys)
+- Any provider keys (Stripe, webhooks, etc.)
+
+### How to Un-Integrate (You Shouldn't, But)
+
+If for some reason you need to fully back out the Archon integration:
+
+```powershell
+cd I:\GithubI\Alchymine
+
+# 1. Restore .env to the repo root (this re-exposes secrets to AI subprocesses!)
+move .secrets\.env .env
+rmdir .secrets
+
+# 2. Revert the Pydantic Settings change
+# Edit alchymine/config.py:30 — change env_file=".secrets/.env" back to env_file=".env"
+
+# 3. Remove the docker wrapper
+del run.ps1
+
+# 4. Remove the archon skill from the repo
+rmdir /s /q .claude\skills\archon
+
+# 5. Revert .env.example header comment and .gitignore changes
+
+# 6. Deregister Alchymine from Archon
+archon codebase remove realsammyt/Alchymine   # or via Web UI
+```
+
+**Do not do this lightly.** The `.secrets/.env` convention exists for
+security reasons that long outlive the Archon integration.
+
+---
+
+## Further Reading
+
+- **Archon usage patterns** (when to use Archon vs direct Claude Code, decision tree, cross-project best practices):
+  `.claude\skills\archon\references\usage-patterns.md`
+- **Archon skill reference** (deep dive on workflow authoring):
+  `I:\GithubI\Archon\.claude\skills\archon\references\`
+- **Archon skill guides** (how-to articles):
+  `I:\GithubI\Archon\.claude\skills\archon\guides\`
+- **Archon docs site source** (user-facing documentation):
+  `I:\GithubI\Archon\packages\docs-web\src\content\docs\`
+- **Archon source code** (for tweaking Archon itself):
+  `I:\GithubI\Archon\`
+- **ADR-009: Archon Integration** (the why/how decision record):
+  `I:\GithubI\Alchymine\docs\adr\009-archon-integration.md`
+- **Alchymine deployment guide** (production deployment):
+  `I:\GithubI\Alchymine\docs\guides\deployment-guide.md`
+- **Alchymine config loader** (the line that reads `.secrets/.env`):
+  `I:\GithubI\Alchymine\alchymine\config.py:30`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,11 @@ mcp = [
 pdf = [
     "playwright>=1.40.0",
 ]
+# Generative art via Gemini — optional. The core install never depends
+# on this; the GeminiClient gracefully degrades when the SDK is missing.
+gemini = [
+    "google-genai>=1.0",
+]
 dev = [
     # Testing
     "pytest>=8.3.0",
@@ -134,6 +139,8 @@ module = [
     "playwright.*",
     "langgraph.*",
     "resend.*",
+    "google.genai.*",
+    "google.*",
 ]
 ignore_missing_imports = true
 

--- a/run.ps1
+++ b/run.ps1
@@ -1,0 +1,14 @@
+# Alchymine docker compose wrapper
+#
+# Reads secrets from .secrets/.env instead of the repo root .env.
+# The secrets directory is gitignored and kept out of the repo root so
+# AI coding tools (e.g. Claude / Codex via Archon) that spawn subprocesses
+# in this repo cannot auto-load them via Bun's .env auto-loading.
+#
+# Usage:
+#   ./run.ps1 up -d
+#   ./run.ps1 logs -f api
+#   ./run.ps1 down
+#   ./run.ps1 config    # to verify env substitution
+
+docker compose --env-file .secrets/.env -f infrastructure/docker-compose.yml @args

--- a/scripts/reset-dev-db.sh
+++ b/scripts/reset-dev-db.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Reset the local dev DB and re-seed with a dev user + invite code.
+# Used when switching between feature branches that have conflicting migrations
+# (e.g., Track 2 chat_messages 0012 vs Track 3 generated_images 0012).
+#
+# Usage: scripts/reset-dev-db.sh
+#
+# After running: log in at http://localhost:3200/login with dev@example.com / devpassword123
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+echo "==> Stopping db + dropping volume"
+docker compose -f infrastructure/docker-compose.yml -f infrastructure/docker-compose.dev.yml --env-file .env stop db
+docker compose -f infrastructure/docker-compose.yml -f infrastructure/docker-compose.dev.yml --env-file .env rm -f db
+docker volume rm alchymine-db-data 2>/dev/null || true
+
+echo "==> Starting fresh db"
+docker compose -f infrastructure/docker-compose.yml -f infrastructure/docker-compose.dev.yml --env-file .env up -d db
+sleep 3
+
+echo "==> Restarting api so alembic can run against fresh db"
+docker compose -f infrastructure/docker-compose.yml -f infrastructure/docker-compose.dev.yml --env-file .env restart api
+
+echo "==> Waiting for api to be healthy"
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  if curl -sf http://localhost:8200/health >/dev/null 2>&1; then
+    echo "    api ready"
+    break
+  fi
+  sleep 2
+done
+
+echo "==> Running alembic upgrade head"
+MSYS_NO_PATHCONV=1 docker exec -w /app alchymine-api alembic upgrade head
+
+echo "==> Seeding invite code DEVLOCAL"
+docker exec -i alchymine-db psql -U alchymine -d alchymine -c \
+  "INSERT INTO invite_codes (code, max_uses, uses_count, is_active, note) VALUES ('DEVLOCAL', 100, 0, true, 'Local dev');" >/dev/null
+
+echo "==> Registering dev@example.com"
+curl -sf -X POST http://localhost:8200/api/v1/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"email":"dev@example.com","password":"devpassword123","promo_code":"DEVLOCAL"}' \
+  >/dev/null
+
+echo "==> Promoting to admin"
+docker exec -i alchymine-db psql -U alchymine -d alchymine -c \
+  "UPDATE users SET is_admin = true WHERE email = 'dev@example.com';" >/dev/null
+
+echo ""
+echo "Done. Log in at http://localhost:3200/login"
+echo "  email:    dev@example.com"
+echo "  password: devpassword123"

--- a/tests/api/test_generative_art.py
+++ b/tests/api/test_generative_art.py
@@ -1,0 +1,277 @@
+"""Tests for the generative art API router.
+
+Mocks GeminiClient at the module level so no real API calls are made.
+Uses an in-memory SQLite DB so persistence and ownership checks run
+end-to-end.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+import alchymine.db.models  # noqa: F401 — register models with metadata
+from alchymine.api.auth import get_current_user
+from alchymine.api.deps import get_db_session
+from alchymine.api.main import app
+from alchymine.api.routers.generative_art import _gemini_dependency
+from alchymine.db.base import Base
+from alchymine.db.models import IdentityProfile, User
+from alchymine.llm.gemini import GeminiImageResult
+
+
+TEST_USER_ID = "user-art-1"
+OTHER_USER_ID = "user-art-other"
+
+
+# ── DB fixtures ─────────────────────────────────────────────────────────
+
+
+def _build_engine():
+    return create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        echo=False,
+    )
+
+
+async def _init_schema(engine) -> None:
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+def _make_session_factory(engine):
+    return async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+
+def _seed_users(factory) -> None:
+    async def _create() -> None:
+        async with factory() as session:
+            session.add(
+                User(
+                    id=TEST_USER_ID,
+                    email="art-test@example.com",
+                    is_active=True,
+                )
+            )
+            session.add(
+                User(
+                    id=OTHER_USER_ID,
+                    email="other-art-test@example.com",
+                    is_active=True,
+                )
+            )
+            session.add(
+                IdentityProfile(
+                    user_id=TEST_USER_ID,
+                    archetype={"primary": "sage"},
+                    astrology={"sun_sign": "Pisces"},
+                    numerology={"life_path": 7},
+                )
+            )
+            await session.commit()
+
+    asyncio.run(_create())
+
+
+@pytest.fixture
+def _db_factory():
+    engine = _build_engine()
+    loop = asyncio.new_event_loop()
+    loop.run_until_complete(_init_schema(engine))
+    loop.close()
+    factory = _make_session_factory(engine)
+    _seed_users(factory)
+    return factory
+
+
+# ── Fake GeminiClient ───────────────────────────────────────────────────
+
+
+class _FakeGemini:
+    """Stand-in for GeminiClient that captures the last prompt."""
+
+    def __init__(self, available: bool = True, succeed: bool = True):
+        self._available = available
+        self._succeed = succeed
+        self.last_prompt: str | None = None
+
+    @property
+    def is_available(self) -> bool:
+        return self._available
+
+    async def generate_image(self, prompt: str) -> GeminiImageResult | None:
+        self.last_prompt = prompt
+        if not self._succeed:
+            return None
+        # Echo the prompt back so the router persists the real personalized
+        # text — this lets tests assert that the build_studio_prompt output
+        # actually flowed through the request handler.
+        return GeminiImageResult(
+            image_bytes=b"\x89PNG\r\n\x1a\nfake-image",
+            mime_type="image/png",
+            prompt=prompt,
+            model="gemini-test",
+            generated_at=datetime.now(UTC),
+        )
+
+
+# ── Test client fixture ─────────────────────────────────────────────────
+
+
+@pytest.fixture
+def client(_db_factory, tmp_path) -> TestClient:
+    """TestClient wired to the in-memory DB and a tmpdir art cache.
+
+    Auth is overridden to return TEST_USER_ID.
+    Gemini is overridden via dependency_overrides; individual tests
+    swap their fake instances by calling client.app.dependency_overrides.
+    """
+    factory = _db_factory
+
+    async def _override_db() -> AsyncGenerator[AsyncSession, None]:
+        async with factory() as session:
+            try:
+                yield session
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                raise
+
+    async def _override_user() -> dict:
+        return {"sub": TEST_USER_ID, "email": "art-test@example.com"}
+
+    app.dependency_overrides[get_db_session] = _override_db
+    app.dependency_overrides[get_current_user] = _override_user
+
+    # Point the storage helper at a temp dir for the duration of the test
+    with patch(
+        "alchymine.llm.art_storage.get_art_cache_root",
+        return_value=tmp_path,
+    ):
+        tc = TestClient(app)
+        yield tc
+
+    app.dependency_overrides.pop(get_db_session, None)
+    app.dependency_overrides.pop(get_current_user, None)
+    app.dependency_overrides.pop(_gemini_dependency, None)
+
+
+# ── POST /api/v1/art/generate ───────────────────────────────────────────
+
+
+class TestGenerateArt:
+    """Tests for POST /api/v1/art/generate."""
+
+    def test_returns_201_on_success(self, client: TestClient) -> None:
+        fake = _FakeGemini(available=True, succeed=True)
+        app.dependency_overrides[_gemini_dependency] = lambda: fake
+
+        response = client.post(
+            "/api/v1/art/generate",
+            json={"style_preset": "celestial"},
+        )
+        assert response.status_code == 201
+        body = response.json()
+        assert "image_id" in body
+        assert body["url"] == f"/api/v1/art/{body['image_id']}"
+        assert "Sage" in body["prompt"]  # personalized from seeded identity
+        assert "Cosmic illustration" in body["prompt"]  # celestial style applied
+
+    def test_returns_204_when_gemini_unavailable(self, client: TestClient) -> None:
+        fake = _FakeGemini(available=False)
+        app.dependency_overrides[_gemini_dependency] = lambda: fake
+
+        response = client.post(
+            "/api/v1/art/generate",
+            json={},
+        )
+        assert response.status_code == 204
+        assert response.content == b""
+
+    def test_returns_204_when_generation_fails(self, client: TestClient) -> None:
+        """Even if available, a None result from the SDK collapses to 204."""
+        fake = _FakeGemini(available=True, succeed=False)
+        app.dependency_overrides[_gemini_dependency] = lambda: fake
+
+        response = client.post(
+            "/api/v1/art/generate",
+            json={},
+        )
+        assert response.status_code == 204
+
+    def test_invalid_style_preset_returns_400(self, client: TestClient) -> None:
+        fake = _FakeGemini(available=True, succeed=True)
+        app.dependency_overrides[_gemini_dependency] = lambda: fake
+
+        response = client.post(
+            "/api/v1/art/generate",
+            json={"style_preset": "not-a-real-preset"},
+        )
+        assert response.status_code == 400
+        assert "style_preset" in response.json()["detail"]
+
+    def test_blocked_user_extension_returns_400(self, client: TestClient) -> None:
+        """Content filter rejects extensions containing harmful patterns."""
+        fake = _FakeGemini(available=True, succeed=True)
+        app.dependency_overrides[_gemini_dependency] = lambda: fake
+
+        response = client.post(
+            "/api/v1/art/generate",
+            json={
+                "user_prompt_extension": "kill someone violently with illegal weapons",
+            },
+        )
+        assert response.status_code == 400
+        detail = response.json()["detail"]
+        assert "blocked" in detail.lower()
+
+    def test_unauthenticated_returns_401(self, client: TestClient) -> None:
+        """Removing the auth override produces 401 from the real dependency."""
+        # Drop the auth override and the gemini override
+        app.dependency_overrides.pop(get_current_user, None)
+
+        response = client.post("/api/v1/art/generate", json={})
+        assert response.status_code == 401
+
+
+# ── GET /api/v1/art/{image_id} ──────────────────────────────────────────
+
+
+class TestGetImage:
+    """Tests for GET /api/v1/art/{image_id}."""
+
+    def _create_image(self, client: TestClient) -> str:
+        fake = _FakeGemini(available=True, succeed=True)
+        app.dependency_overrides[_gemini_dependency] = lambda: fake
+        response = client.post("/api/v1/art/generate", json={})
+        assert response.status_code == 201
+        return response.json()["image_id"]
+
+    def test_returns_image_bytes_for_owner(self, client: TestClient) -> None:
+        image_id = self._create_image(client)
+
+        response = client.get(f"/api/v1/art/{image_id}")
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("image/")
+        assert response.content.startswith(b"\x89PNG")
+
+    def test_returns_404_for_other_user(self, client: TestClient) -> None:
+        image_id = self._create_image(client)
+
+        async def _override_other() -> dict:
+            return {"sub": OTHER_USER_ID, "email": "other-art-test@example.com"}
+
+        app.dependency_overrides[get_current_user] = _override_other
+        response = client.get(f"/api/v1/art/{image_id}")
+        assert response.status_code == 404
+
+    def test_returns_404_for_unknown_id(self, client: TestClient) -> None:
+        response = client.get("/api/v1/art/no-such-image")
+        assert response.status_code == 404

--- a/tests/api/test_generative_art.py
+++ b/tests/api/test_generative_art.py
@@ -275,3 +275,132 @@ class TestGetImage:
     def test_returns_404_for_unknown_id(self, client: TestClient) -> None:
         response = client.get("/api/v1/art/no-such-image")
         assert response.status_code == 404
+
+
+# ── GET /api/v1/art/presets ─────────────────────────────────────────────
+
+
+class TestListStylePresets:
+    """Tests for GET /api/v1/art/presets."""
+
+    def test_returns_all_presets(self, client: TestClient) -> None:
+        from alchymine.llm.art_prompts import STYLE_PRESETS
+
+        response = client.get("/api/v1/art/presets")
+        assert response.status_code == 200
+        body = response.json()
+        assert isinstance(body, list)
+        ids = {entry["id"] for entry in body}
+        assert ids == set(STYLE_PRESETS.keys())
+        for entry in body:
+            assert entry["name"]
+            assert entry["description"]
+
+
+# ── GET /api/v1/art/list ────────────────────────────────────────────────
+
+
+class TestListUserImages:
+    """Tests for GET /api/v1/art/list."""
+
+    def _seed_image(self, client: TestClient) -> str:
+        fake = _FakeGemini(available=True, succeed=True)
+        app.dependency_overrides[_gemini_dependency] = lambda: fake
+        response = client.post("/api/v1/art/generate", json={"style_preset": "mystical"})
+        assert response.status_code == 201
+        return response.json()["image_id"]
+
+    def test_returns_empty_list_for_user_with_no_images(self, client: TestClient) -> None:
+        response = client.get("/api/v1/art/list")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["images"] == []
+        assert body["limit"] == 20
+        assert body["offset"] == 0
+
+    def test_returns_user_images_metadata(self, client: TestClient) -> None:
+        image_id = self._seed_image(client)
+        response = client.get("/api/v1/art/list")
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body["images"]) == 1
+        entry = body["images"][0]
+        assert entry["id"] == image_id
+        assert entry["style_preset"] == "mystical"
+        assert entry["url"] == f"/api/v1/art/{image_id}"
+        assert entry["prompt"]
+        assert entry["created_at"]
+
+    def test_respects_limit_and_offset(self, client: TestClient) -> None:
+        self._seed_image(client)
+        self._seed_image(client)
+
+        response = client.get("/api/v1/art/list?limit=1&offset=0")
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body["images"]) == 1
+        assert body["limit"] == 1
+
+        response2 = client.get("/api/v1/art/list?limit=1&offset=1")
+        assert response2.status_code == 200
+        body2 = response2.json()
+        assert len(body2["images"]) == 1
+        # Different offsets should return different images.
+        assert body["images"][0]["id"] != body2["images"][0]["id"]
+
+    def test_does_not_leak_other_users_images(self, client: TestClient) -> None:
+        self._seed_image(client)
+
+        async def _override_other() -> dict:
+            return {"sub": OTHER_USER_ID, "email": "other-art-test@example.com"}
+
+        app.dependency_overrides[get_current_user] = _override_other
+        response = client.get("/api/v1/art/list")
+        assert response.status_code == 200
+        assert response.json()["images"] == []
+
+
+# ── DELETE /api/v1/art/{image_id} ───────────────────────────────────────
+
+
+class TestDeleteUserImage:
+    """Tests for DELETE /api/v1/art/{image_id}."""
+
+    def _seed_image(self, client: TestClient) -> str:
+        fake = _FakeGemini(available=True, succeed=True)
+        app.dependency_overrides[_gemini_dependency] = lambda: fake
+        response = client.post("/api/v1/art/generate", json={})
+        assert response.status_code == 201
+        return response.json()["image_id"]
+
+    def test_owner_can_delete_own_image(self, client: TestClient) -> None:
+        image_id = self._seed_image(client)
+
+        response = client.delete(f"/api/v1/art/{image_id}")
+        assert response.status_code == 204
+
+        # Follow-up GET should now 404.
+        follow_up = client.get(f"/api/v1/art/{image_id}")
+        assert follow_up.status_code == 404
+
+    def test_cross_user_delete_returns_404(self, client: TestClient) -> None:
+        image_id = self._seed_image(client)
+
+        async def _override_other() -> dict:
+            return {"sub": OTHER_USER_ID, "email": "other-art-test@example.com"}
+
+        app.dependency_overrides[get_current_user] = _override_other
+        response = client.delete(f"/api/v1/art/{image_id}")
+        assert response.status_code == 404
+
+        # Restore the primary user — the image should still be fetchable.
+        async def _override_primary() -> dict:
+            return {"sub": TEST_USER_ID, "email": "art-test@example.com"}
+
+        app.dependency_overrides[get_current_user] = _override_primary
+        follow_up = client.get(f"/api/v1/art/{image_id}")
+        assert follow_up.status_code == 200
+
+    def test_delete_unknown_id_returns_404(self, client: TestClient) -> None:
+        response = client.delete("/api/v1/art/no-such-image")
+        assert response.status_code == 404

--- a/tests/db/test_migrations.py
+++ b/tests/db/test_migrations.py
@@ -101,7 +101,7 @@ class TestMigrationCompleteness:
             rows = result.fetchall()
 
         assert len(rows) == 1, f"Expected 1 head revision, got {len(rows)}: {rows}"
-        assert rows[0][0] == "0013", f"Expected head at 0012, got {rows[0][0]}"
+        assert rows[0][0] == "0013", f"Expected head at 0013, got {rows[0][0]}"
 
     def test_reports_table_has_all_columns(self, fresh_migration_engine):
         """Reports table (added in migration 0006) has all expected columns."""
@@ -178,12 +178,13 @@ class TestStampAndUpgrade:
         engine = create_engine(sync_url)
         Base.metadata.create_all(engine)
 
-        # Drop tables that later migrations will CREATE (0011 creates feedback_entries
-        # and 0012 creates chat_messages, but create_all() already made them from the
-        # ORM models)
+        # Drop tables that later migrations will CREATE (0011 creates feedback_entries,
+        # 0012 creates chat_messages, 0013 creates generated_images — all already made
+        # by create_all() from ORM models)
         with engine.begin() as conn:
             conn.execute(text("DROP TABLE IF EXISTS feedback_entries"))
             conn.execute(text("DROP TABLE IF EXISTS chat_messages"))
+            conn.execute(text("DROP TABLE IF EXISTS generated_images"))
 
         # Manually drop pdf_data to simulate the missing column
         with engine.begin() as conn:
@@ -218,6 +219,6 @@ class TestStampAndUpgrade:
         with engine.connect() as conn:
             result = conn.execute(text("SELECT version_num FROM alembic_version"))
             version = result.scalar_one()
-        assert version == "0013", f"Expected 0012, got {version}"
+        assert version == "0013", f"Expected 0013, got {version}"
 
         engine.dispose()

--- a/tests/db/test_migrations.py
+++ b/tests/db/test_migrations.py
@@ -101,7 +101,7 @@ class TestMigrationCompleteness:
             rows = result.fetchall()
 
         assert len(rows) == 1, f"Expected 1 head revision, got {len(rows)}: {rows}"
-        assert rows[0][0] == "0012", f"Expected head at 0012, got {rows[0][0]}"
+        assert rows[0][0] == "0013", f"Expected head at 0012, got {rows[0][0]}"
 
     def test_reports_table_has_all_columns(self, fresh_migration_engine):
         """Reports table (added in migration 0006) has all expected columns."""
@@ -218,6 +218,6 @@ class TestStampAndUpgrade:
         with engine.connect() as conn:
             result = conn.execute(text("SELECT version_num FROM alembic_version"))
             version = result.scalar_one()
-        assert version == "0012", f"Expected 0012, got {version}"
+        assert version == "0013", f"Expected 0012, got {version}"
 
         engine.dispose()

--- a/tests/llm/__init__.py
+++ b/tests/llm/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the alchymine.llm package."""

--- a/tests/llm/test_art_prompts.py
+++ b/tests/llm/test_art_prompts.py
@@ -1,0 +1,249 @@
+"""Tests for the Gemini art prompt builders.
+
+These tests do not call the Gemini API. They verify that the prompt
+builders produce safe, personalized text from a variety of profile
+shapes (Pydantic models, plain dicts, and missing data).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from alchymine.llm.art_prompts import (
+    STYLE_PRESETS,
+    apply_style_preset,
+    build_report_hero_prompt,
+    build_studio_prompt,
+)
+
+# ── Forbidden tokens that must never appear in any prompt ─────────────
+# (case-insensitive substring match). These are tokens that would
+# instruct Gemini to *generate* problematic content. We deliberately do
+# NOT include negation words (e.g. "no weapons") here, since the safety
+# suffix uses such phrases to constrain output.
+_FORBIDDEN = [
+    # No explicit instructions to render text
+    "text says",
+    "the words",
+    "with the text",
+    # No real brand or trademark cues
+    "nike",
+    "apple inc",
+    "disney",
+    "marvel",
+    # No explicit violent / sexual subject directives
+    "depict naked",
+    "depict nude",
+    "wielding a weapon",
+    "holding a gun",
+    "covered in blood",
+]
+
+
+def _assert_safe(prompt: str) -> None:
+    """Assert a prompt contains required safety phrases and no forbidden tokens."""
+    assert isinstance(prompt, str)
+    assert len(prompt) > 50, "prompt unreasonably short"
+    lowered = prompt.lower()
+    for token in _FORBIDDEN:
+        assert token not in lowered, f"forbidden token found in prompt: {token!r}"
+    # Required safety language
+    assert "tasteful" in lowered
+    assert "non-violent" in lowered
+    assert "no real people" in lowered
+    assert "no text" in lowered or "no letters" in lowered
+
+
+# ── Synthetic profile fixtures ────────────────────────────────────────
+
+
+@pytest.fixture
+def sage_water_profile() -> dict:
+    """A Sage archetype with a Pisces (water) sun sign."""
+    return {
+        "archetype": {"primary": "sage", "secondary": "creator"},
+        "astrology": {"sun_sign": "Pisces", "moon_sign": "Cancer"},
+        "numerology": {"life_path": 7},
+    }
+
+
+@pytest.fixture
+def hero_fire_profile() -> dict:
+    """A Hero archetype with a Leo (fire) sun sign."""
+    return {
+        "archetype": {"primary": "hero"},
+        "astrology": {"sun_sign": "Leo"},
+        "numerology": {"life_path": 1},
+    }
+
+
+@pytest.fixture
+def explorer_air_profile() -> dict:
+    """An Explorer with a Gemini (air) sun sign."""
+    return {
+        "archetype": {"primary": "explorer"},
+        "astrology": {"sun_sign": "Gemini"},
+        "numerology": {"life_path": 5},
+    }
+
+
+@pytest.fixture
+def caregiver_earth_profile() -> dict:
+    """A Caregiver with a Taurus (earth) sun sign."""
+    return {
+        "archetype": {"primary": "caregiver"},
+        "astrology": {"sun_sign": "Taurus"},
+        "numerology": {"life_path": 6},
+    }
+
+
+@pytest.fixture
+def mystic_water_profile() -> dict:
+    """A Mystic with a Scorpio (water) sun sign and master number."""
+    return {
+        "archetype": {"primary": "mystic"},
+        "astrology": {"sun_sign": "Scorpio"},
+        "numerology": {"life_path": 11},
+    }
+
+
+# ── Core hero prompt tests ────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "profile_fixture,archetype_cue,element_cue",
+    [
+        ("sage_water_profile", "Sage", "water"),
+        ("hero_fire_profile", "Hero", "fire"),
+        ("explorer_air_profile", "Explorer", "air"),
+        ("caregiver_earth_profile", "Caregiver", "earth"),
+        ("mystic_water_profile", "Mystic", "water"),
+    ],
+)
+def test_report_hero_prompt_includes_archetype_and_element(
+    profile_fixture: str,
+    archetype_cue: str,
+    element_cue: str,
+    request: pytest.FixtureRequest,
+) -> None:
+    """Each prompt must mention both the archetype and the elemental cue."""
+    profile = request.getfixturevalue(profile_fixture)
+    prompt = build_report_hero_prompt(profile)
+    _assert_safe(prompt)
+    assert archetype_cue in prompt, f"missing archetype: {archetype_cue}"
+    assert element_cue in prompt.lower(), f"missing element: {element_cue}"
+
+
+def test_report_hero_prompt_includes_life_path_when_present(
+    sage_water_profile: dict,
+) -> None:
+    prompt = build_report_hero_prompt(sage_water_profile)
+    assert "Life Path 7" in prompt
+
+
+def test_report_hero_prompt_handles_empty_profile() -> None:
+    """An empty profile must not raise — fallback prompt is returned."""
+    prompt = build_report_hero_prompt({})
+    _assert_safe(prompt)
+    assert "Wanderer" in prompt
+
+
+def test_report_hero_prompt_handles_none() -> None:
+    """A None profile is handled gracefully."""
+    prompt = build_report_hero_prompt(None)
+    _assert_safe(prompt)
+
+
+def test_report_hero_prompt_handles_unknown_archetype() -> None:
+    """Unknown archetypes use the fallback imagery."""
+    profile = {"archetype": {"primary": "wanderer-of-the-void"}}
+    prompt = build_report_hero_prompt(profile)
+    _assert_safe(prompt)
+    # The fallback imagery describes ethereal transformation
+    assert "transformation" in prompt.lower()
+
+
+def test_report_hero_prompt_accepts_pydantic_like_object() -> None:
+    """Profiles exposed as objects with attribute access also work."""
+
+    class _AttrMap:
+        def __init__(self, **kwargs: object) -> None:
+            for k, v in kwargs.items():
+                setattr(self, k, v)
+
+    archetype = _AttrMap(primary="creator", secondary=None)
+    astrology = _AttrMap(sun_sign="Aries")
+    numerology = _AttrMap(life_path=3)
+    profile = _AttrMap(archetype=archetype, astrology=astrology, numerology=numerology)
+
+    prompt = build_report_hero_prompt(profile)
+    _assert_safe(prompt)
+    assert "Creator" in prompt
+    assert "fire" in prompt.lower()
+    assert "Life Path 3" in prompt
+
+
+# ── Style preset tests ────────────────────────────────────────────────
+
+
+def test_style_presets_dict_has_five_entries() -> None:
+    assert len(STYLE_PRESETS) == 5
+    assert set(STYLE_PRESETS.keys()) == {
+        "mystical",
+        "modern",
+        "organic",
+        "celestial",
+        "grounded",
+    }
+
+
+def test_apply_style_preset_appends_suffix(sage_water_profile: dict) -> None:
+    base = build_report_hero_prompt(sage_water_profile)
+    styled = apply_style_preset(base, "celestial")
+    assert "Style:" in styled
+    assert "Cosmic illustration" in styled
+    _assert_safe(styled)
+
+
+def test_apply_style_preset_unknown_falls_back(sage_water_profile: dict) -> None:
+    base = build_report_hero_prompt(sage_water_profile)
+    styled = apply_style_preset(base, "nonsense-preset")
+    # Falls back to mystical
+    assert "sacred geometry" in styled.lower()
+
+
+def test_apply_style_preset_none_is_passthrough(sage_water_profile: dict) -> None:
+    base = build_report_hero_prompt(sage_water_profile)
+    assert apply_style_preset(base, None) == base
+
+
+# ── Studio prompt tests ───────────────────────────────────────────────
+
+
+def test_studio_prompt_includes_user_extension(sage_water_profile: dict) -> None:
+    prompt = build_studio_prompt(
+        sage_water_profile,
+        user_extension="featuring autumn leaves",
+        style_preset="organic",
+    )
+    _assert_safe(prompt)
+    assert "autumn leaves" in prompt
+    assert "Botanical watercolour" in prompt
+
+
+def test_studio_prompt_strips_newlines_from_extension(
+    sage_water_profile: dict,
+) -> None:
+    """Newlines in user input are flattened so they can't fake new instructions."""
+    prompt = build_studio_prompt(
+        sage_water_profile,
+        user_extension="line one\nline two\nline three",
+    )
+    assert "\nline" not in prompt
+    assert "line one line two line three" in prompt
+
+
+def test_studio_prompt_no_extension(sage_water_profile: dict) -> None:
+    prompt = build_studio_prompt(sage_water_profile, user_extension=None)
+    _assert_safe(prompt)
+    assert "Additional theme" not in prompt

--- a/tests/llm/test_gemini.py
+++ b/tests/llm/test_gemini.py
@@ -1,0 +1,143 @@
+"""Tests for the Gemini image generation client.
+
+These tests never hit the real Gemini API — every call is mocked.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from alchymine.llm.gemini import (
+    GeminiClient,
+    GeminiImageResult,
+    get_gemini_client,
+)
+
+
+def test_image_result_dataclass_holds_image_metadata() -> None:
+    """GeminiImageResult is a frozen dataclass with the documented fields."""
+    now = datetime.utcnow()
+    result = GeminiImageResult(
+        image_bytes=b"\x89PNG\r\n\x1a\n",
+        mime_type="image/png",
+        prompt="a serene forest",
+        model="gemini-test",
+        generated_at=now,
+    )
+    assert result.image_bytes == b"\x89PNG\r\n\x1a\n"
+    assert result.mime_type == "image/png"
+    assert result.prompt == "a serene forest"
+    assert result.model == "gemini-test"
+    assert result.generated_at == now
+
+
+def test_client_unavailable_when_api_key_missing() -> None:
+    """Client gracefully reports unavailable when no API key is configured."""
+    client = GeminiClient(api_key=None, model="gemini-test")
+    assert client.is_available is False
+
+
+def test_client_unavailable_when_api_key_empty_string() -> None:
+    """Empty string is treated identically to a missing key."""
+    client = GeminiClient(api_key="", model="gemini-test")
+    assert client.is_available is False
+
+
+@pytest.mark.asyncio
+async def test_generate_image_returns_none_when_unavailable() -> None:
+    """generate_image returns None (not raises) when client is unavailable."""
+    client = GeminiClient(api_key=None, model="gemini-test")
+    result = await client.generate_image("a serene forest")
+    assert result is None
+
+
+def test_client_unavailable_when_sdk_missing() -> None:
+    """If google-genai is not importable, the client must degrade gracefully."""
+    # Patch the module-level _genai reference to None to simulate missing SDK.
+    with patch("alchymine.llm.gemini._genai", None):
+        client = GeminiClient(api_key="fake-key", model="gemini-test")
+        assert client.is_available is False
+
+
+@pytest.mark.asyncio
+async def test_generate_image_returns_result_on_success() -> None:
+    """Successful SDK call yields a GeminiImageResult with decoded bytes."""
+    raw_bytes = b"\x89PNG\r\n\x1a\nfake-image-payload"
+
+    fake_part = MagicMock()
+    fake_part.inline_data = MagicMock()
+    fake_part.inline_data.data = raw_bytes
+    fake_part.inline_data.mime_type = "image/png"
+
+    fake_response = MagicMock()
+    fake_response.candidates = [MagicMock(content=MagicMock(parts=[fake_part]))]
+
+    fake_genai_module = MagicMock()
+    fake_client = MagicMock()
+    fake_client.aio.models.generate_content = AsyncMock(return_value=fake_response)
+    fake_genai_module.Client.return_value = fake_client
+
+    with patch("alchymine.llm.gemini._genai", fake_genai_module):
+        client = GeminiClient(api_key="fake-key", model="gemini-test")
+        assert client.is_available is True
+        result = await client.generate_image("a serene forest")
+
+    assert result is not None
+    assert result.image_bytes == raw_bytes
+    assert result.mime_type == "image/png"
+    assert result.prompt == "a serene forest"
+    assert result.model == "gemini-test"
+
+
+@pytest.mark.asyncio
+async def test_generate_image_returns_none_on_sdk_exception() -> None:
+    """Network or auth errors are logged and swallowed — never raised."""
+    fake_genai_module = MagicMock()
+    fake_client = MagicMock()
+    fake_client.aio.models.generate_content = AsyncMock(
+        side_effect=RuntimeError("network unreachable")
+    )
+    fake_genai_module.Client.return_value = fake_client
+
+    with patch("alchymine.llm.gemini._genai", fake_genai_module):
+        client = GeminiClient(api_key="fake-key", model="gemini-test")
+        result = await client.generate_image("a serene forest")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_generate_image_returns_none_when_no_image_part() -> None:
+    """Response with no inline image data returns None gracefully."""
+    fake_response = MagicMock()
+    fake_response.candidates = []
+
+    fake_genai_module = MagicMock()
+    fake_client = MagicMock()
+    fake_client.aio.models.generate_content = AsyncMock(return_value=fake_response)
+    fake_genai_module.Client.return_value = fake_client
+
+    with patch("alchymine.llm.gemini._genai", fake_genai_module):
+        client = GeminiClient(api_key="fake-key", model="gemini-test")
+        result = await client.generate_image("a serene forest")
+
+    assert result is None
+
+
+def test_get_gemini_client_returns_singleton() -> None:
+    """The factory caches a single client instance per process."""
+    fake_settings = MagicMock()
+    fake_settings.gemini_api_key = ""
+    fake_settings.gemini_model = "gemini-test"
+
+    # Clear cache and patch settings so we never touch the real env file
+    get_gemini_client.cache_clear()
+    with patch("alchymine.llm.gemini.get_settings", return_value=fake_settings):
+        a = get_gemini_client()
+        b = get_gemini_client()
+    assert a is b
+    assert isinstance(a, GeminiClient)
+    get_gemini_client.cache_clear()


### PR DESCRIPTION
## Summary
- **Issues:** #166 (Gemini client + art API), #167 (creative studio UI)
- Gemini client with graceful degradation (returns None/204 when unavailable)
- Art prompts module: 5 style presets, profile-personalized hero prompts
- API: `GET /presets`, `POST /generate`, `GET /list`, `DELETE /{id}`
- Creative Studio page: prompt textarea, StylePresetPicker (5 cards, keyboard nav), ArtGallery (responsive grid, lightbox, delete)
- DB: `generated_images` table, migration `0012_add_generated_images`
- ⚠️ **Migration note:** Both this and Track 2 have `0012_*` — whichever merges second should renumber to `0013`

## Test plan
- [ ] `pytest tests/api/test_generative_art.py -v` — presets/list/delete/generate
- [ ] `cd alchymine/web && npm test` — StylePresetPicker + ArtGallery tests
- [ ] `ruff check && ruff format --check` — lint clean

Closes #166, closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)