### PR TITLE
feat(mcp): JSON-RPC 2.0 HTTP transport + healing skill tools

### DIFF
--- a/alchymine/api/main.py
+++ b/alchymine/api/main.py
@@ -9,7 +9,7 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 
-from fastapi import FastAPI
+from fastapi import APIRouter, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from alchymine import __version__
@@ -44,6 +44,7 @@ from alchymine.api.routers import (
     wealth,
 )
 from alchymine.config import get_settings
+from alchymine.mcp.transport import mount_all_mcp_routers
 
 
 class _JSONFormatter(logging.Formatter):
@@ -132,3 +133,8 @@ app.include_router(spiral.router, prefix="/api/v1", tags=["spiral"])
 app.include_router(integration.router, prefix="/api/v1", tags=["integration"])
 app.include_router(admin.router, prefix="/api/v1", tags=["admin"])
 app.include_router(feedback.router, prefix="/api/v1", tags=["feedback"])
+
+# MCP transport — JSON-RPC 2.0 endpoints for all five systems
+mcp_parent = APIRouter()
+mount_all_mcp_routers(mcp_parent)
+app.include_router(mcp_parent)

--- a/alchymine/mcp/__init__.py
+++ b/alchymine/mcp/__init__.py
@@ -11,9 +11,12 @@ Each system has its own server module:
 """
 
 from .base import MCPServer, ResourceDefinition, ToolDefinition
+from .transport import make_mcp_router, mount_all_mcp_routers
 
 __all__ = [
     "MCPServer",
     "ResourceDefinition",
     "ToolDefinition",
+    "make_mcp_router",
+    "mount_all_mcp_routers",
 ]

--- a/alchymine/mcp/healing_server.py
+++ b/alchymine/mcp/healing_server.py
@@ -10,6 +10,11 @@ tool is the highest-priority tool in this server.
 from __future__ import annotations
 
 from alchymine.engine.healing import detect_crisis, get_breathwork_pattern, match_modalities
+from alchymine.engine.healing.skills import (
+    SkillNotFoundError,
+    SkillRegistry,
+    get_default_yaml_dir,
+)
 from alchymine.engine.profile import (
     ArchetypeType,
     BigFiveScores,
@@ -20,6 +25,19 @@ from alchymine.engine.profile import (
 from .base import MCPServer
 
 server = MCPServer(name="alchymine-healing", version="1.0.0")
+
+# Module-level skill registry, loaded lazily on first tool call.
+_skill_registry: SkillRegistry | None = None
+
+
+def _get_skill_registry() -> SkillRegistry:
+    """Return the lazily-initialised skill registry."""
+    global _skill_registry
+    if _skill_registry is None:
+        reg = SkillRegistry()
+        reg.load_directory(get_default_yaml_dir())
+        _skill_registry = reg
+    return _skill_registry
 
 
 # ─── Tool: detect_crisis ────────────────────────────────────────────────
@@ -166,6 +184,98 @@ def get_breathwork_tool(difficulty: str, intention: str | None = None) -> dict:
         "cycles": pattern.cycles,
         "difficulty": pattern.difficulty.value,
         "description": pattern.description,
+    }
+
+
+# ─── Tool: list_skills ──────────────────────────────────────────────────
+
+
+@server.tool(
+    name="list_skills",
+    description=(
+        "List all available healing skills, optionally filtered by modality. "
+        "Returns a list of skill summaries (name, title, modality, evidence "
+        "rating, duration). Use run_skill to get full details and guided steps."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "modality": {
+                "type": "string",
+                "description": (
+                    "Optional: filter by modality (e.g., 'breathwork', 'somatic', "
+                    "'language', 'nature'). Omit to list all skills."
+                ),
+            },
+        },
+        "required": [],
+    },
+)
+def list_skills_tool(modality: str | None = None) -> list[dict]:
+    """List healing skills from the SkillRegistry."""
+    registry = _get_skill_registry()
+    if modality is not None:
+        skills = registry.list_by_modality(modality)
+    else:
+        skills = registry.list_all()
+    return [
+        {
+            "name": s.name,
+            "title": s.title,
+            "modality": s.modality,
+            "evidence_rating": s.evidence_rating,
+            "duration_minutes": s.duration_minutes,
+        }
+        for s in skills
+    ]
+
+
+# ─── Tool: run_skill ───────────────────────────────────────────────────
+
+
+@server.tool(
+    name="run_skill",
+    description=(
+        "Retrieve a healing skill by name and return its full practice card "
+        "including guided steps, contraindications, and evidence rating. "
+        "The caller should present the steps to the user sequentially."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": (
+                    "The skill slug, e.g. 'breathwork-box-breathing' or "
+                    "'somatic-grounding-5-4-3-2-1'."
+                ),
+            },
+        },
+        "required": ["name"],
+    },
+)
+def run_skill_tool(name: str) -> dict:
+    """Return the full practice card for a single healing skill.
+
+    Raises
+    ------
+    ValueError
+        If the skill name is not found in the registry.
+    """
+    registry = _get_skill_registry()
+    try:
+        skill = registry.get(name)
+    except SkillNotFoundError as exc:
+        raise ValueError(f"Skill not found: {name}") from exc
+    return {
+        "name": skill.name,
+        "title": skill.title,
+        "modality": skill.modality,
+        "description": skill.description,
+        "steps": list(skill.steps),
+        "evidence_rating": skill.evidence_rating,
+        "contraindications": list(skill.contraindications),
+        "duration_minutes": skill.duration_minutes,
     }
 
 

--- a/alchymine/mcp/transport.py
+++ b/alchymine/mcp/transport.py
@@ -1,0 +1,152 @@
+"""JSON-RPC 2.0 HTTP transport layer for MCP servers.
+
+Wraps each ``MCPServer`` instance in a FastAPI router with three
+endpoints:
+
+    POST /call    — invoke a tool (JSON-RPC 2.0 request/response)
+    GET  /tools   — list available tools
+    GET  /resources — list available resources
+
+The ``make_mcp_router`` factory produces the router for a single
+server; ``mount_all_mcp_routers`` mounts all five system routers
+under ``/mcp/{system}``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+
+from .base import MCPServer
+
+logger = logging.getLogger(__name__)
+
+# ─── JSON-RPC 2.0 request / response models ────────────────────────────
+
+
+class JSONRPCRequest(BaseModel):
+    """JSON-RPC 2.0 request envelope for tool calls."""
+
+    jsonrpc: str = Field(default="2.0", pattern=r"^2\.0$")
+    method: str = Field(..., description="Tool name to invoke")
+    params: dict[str, Any] = Field(default_factory=dict, description="Tool arguments")
+    id: int | str | None = Field(default=None, description="Request identifier")
+
+
+class JSONRPCResponse(BaseModel):
+    """JSON-RPC 2.0 success response."""
+
+    jsonrpc: str = "2.0"
+    result: Any = None
+    id: int | str | None = None
+
+
+class JSONRPCError(BaseModel):
+    """JSON-RPC 2.0 error detail."""
+
+    code: int
+    message: str
+    data: Any | None = None
+
+
+class JSONRPCErrorResponse(BaseModel):
+    """JSON-RPC 2.0 error response."""
+
+    jsonrpc: str = "2.0"
+    error: JSONRPCError
+    id: int | str | None = None
+
+
+# Standard JSON-RPC 2.0 error codes
+METHOD_NOT_FOUND = -32601
+INVALID_PARAMS = -32602
+INTERNAL_ERROR = -32603
+
+
+# ─── Router factory ─────────────────────────────────────────────────────
+
+
+def make_mcp_router(server: MCPServer, prefix: str = "") -> APIRouter:
+    """Create a FastAPI router that exposes *server* over JSON-RPC 2.0.
+
+    Parameters
+    ----------
+    server:
+        The ``MCPServer`` instance whose tools/resources to expose.
+    prefix:
+        Optional path prefix forwarded to ``APIRouter(prefix=...)``.
+    """
+    router = APIRouter(prefix=prefix)
+
+    @router.post("/call", response_model=JSONRPCResponse | JSONRPCErrorResponse)
+    async def call_tool(request: JSONRPCRequest) -> JSONRPCResponse | JSONRPCErrorResponse:
+        """Invoke a tool via JSON-RPC 2.0."""
+        try:
+            result = await server.call_tool(request.method, request.params)
+            return JSONRPCResponse(result=result, id=request.id)
+        except ValueError as exc:
+            error_msg = str(exc)
+            if "Unknown tool" in error_msg:
+                code = METHOD_NOT_FOUND
+            elif "Missing required argument" in error_msg:
+                code = INVALID_PARAMS
+            else:
+                code = INVALID_PARAMS
+            return JSONRPCErrorResponse(
+                error=JSONRPCError(code=code, message=error_msg),
+                id=request.id,
+            )
+        except Exception as exc:
+            logger.exception("Internal error in tool call: %s", request.method)
+            return JSONRPCErrorResponse(
+                error=JSONRPCError(code=INTERNAL_ERROR, message=str(exc)),
+                id=request.id,
+            )
+
+    @router.get("/tools")
+    async def list_tools() -> list[dict[str, Any]]:
+        """List all tools registered with this MCP server."""
+        return server.list_tools()
+
+    @router.get("/resources")
+    async def list_resources() -> list[dict[str, Any]]:
+        """List all resources registered with this MCP server."""
+        return server.list_resources()
+
+    return router
+
+
+# ─── Convenience: mount all five system routers ─────────────────────────
+
+
+def mount_all_mcp_routers(app_router: APIRouter) -> None:
+    """Mount MCP transport routers for all five Alchymine systems.
+
+    Each system is accessible at ``/mcp/{system}/call``,
+    ``/mcp/{system}/tools``, and ``/mcp/{system}/resources``.
+
+    Parameters
+    ----------
+    app_router:
+        The parent router (or ``FastAPI`` app) to include the sub-routers on.
+    """
+    from .creative_server import server as creative_server
+    from .healing_server import server as healing_server
+    from .intelligence_server import server as intelligence_server
+    from .perspective_server import server as perspective_server
+    from .wealth_server import server as wealth_server
+
+    systems: dict[str, MCPServer] = {
+        "intelligence": intelligence_server,
+        "healing": healing_server,
+        "wealth": wealth_server,
+        "creative": creative_server,
+        "perspective": perspective_server,
+    }
+
+    for system_name, mcp_server in systems.items():
+        router = make_mcp_router(mcp_server, prefix=f"/mcp/{system_name}")
+        app_router.include_router(router, tags=[f"mcp-{system_name}"])

--- a/tests/mcp/test_healing_server.py
+++ b/tests/mcp/test_healing_server.py
@@ -4,14 +4,19 @@ import pytest
 
 from alchymine.mcp.healing_server import server
 
-
 # ─── Test: tool listing ──────────────────────────────────────────────────
 
 
 def test_lists_all_tools():
     tools = server.list_tools()
     names = {t["name"] for t in tools}
-    assert names == {"detect_crisis", "match_modalities", "get_breathwork"}
+    assert names == {
+        "detect_crisis",
+        "match_modalities",
+        "get_breathwork",
+        "list_skills",
+        "run_skill",
+    }
 
 
 def test_tool_schemas_valid():
@@ -236,3 +241,63 @@ async def test_get_breathwork_invalid_difficulty():
             "get_breathwork",
             {"difficulty": "impossible"},
         )
+
+
+# ─── Test: list_skills ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_skills_all():
+    result = await server.call_tool("list_skills", {})
+    assert isinstance(result, list)
+    assert len(result) >= 15
+    for item in result:
+        assert "name" in item
+        assert "title" in item
+        assert "modality" in item
+        assert "evidence_rating" in item
+        assert "duration_minutes" in item
+
+
+@pytest.mark.asyncio
+async def test_list_skills_by_modality():
+    result = await server.call_tool("list_skills", {"modality": "breathwork"})
+    assert isinstance(result, list)
+    assert len(result) >= 1
+    for item in result:
+        assert item["modality"] == "breathwork"
+
+
+@pytest.mark.asyncio
+async def test_list_skills_unknown_modality():
+    result = await server.call_tool("list_skills", {"modality": "nonexistent"})
+    assert result == []
+
+
+# ─── Test: run_skill ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_skill_valid():
+    result = await server.call_tool("run_skill", {"name": "breathwork-box-breathing"})
+    assert result["name"] == "breathwork-box-breathing"
+    assert result["title"] == "Box Breathing (4-4-4-4)"
+    assert result["modality"] == "breathwork"
+    assert isinstance(result["steps"], list)
+    assert len(result["steps"]) > 0
+    assert result["evidence_rating"] == "B"
+    assert isinstance(result["contraindications"], list)
+    assert result["duration_minutes"] == 6
+    assert "description" in result
+
+
+@pytest.mark.asyncio
+async def test_run_skill_not_found():
+    with pytest.raises(ValueError, match="Skill not found"):
+        await server.call_tool("run_skill", {"name": "nonexistent-skill"})
+
+
+@pytest.mark.asyncio
+async def test_run_skill_missing_name():
+    with pytest.raises(ValueError, match="Missing required argument"):
+        await server.call_tool("run_skill", {})

--- a/tests/mcp/test_transport.py
+++ b/tests/mcp/test_transport.py
@@ -1,0 +1,424 @@
+"""Tests for the MCP JSON-RPC 2.0 HTTP transport layer.
+
+Covers:
+- ``make_mcp_router`` factory with a standalone test MCPServer
+- JSON-RPC 2.0 call semantics (success, method-not-found, invalid-params)
+- ``/tools`` and ``/resources`` listing endpoints
+- ``mount_all_mcp_routers`` with all five system servers
+- Healing-specific ``list_skills`` and ``run_skill`` tools via transport
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import APIRouter, FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from alchymine.mcp.base import MCPServer
+from alchymine.mcp.transport import (
+    INTERNAL_ERROR,
+    INVALID_PARAMS,
+    METHOD_NOT_FOUND,
+    make_mcp_router,
+    mount_all_mcp_routers,
+)
+
+# ─── Helpers ────────────────────────────────────────────────────────────
+
+
+def _make_test_server() -> MCPServer:
+    """Create a minimal MCPServer for transport tests."""
+    srv = MCPServer(name="test-transport", version="0.1.0")
+
+    @srv.tool(
+        name="echo",
+        description="Return the input message",
+        input_schema={
+            "type": "object",
+            "properties": {"message": {"type": "string"}},
+            "required": ["message"],
+        },
+    )
+    def echo(message: str) -> dict:
+        return {"echo": message}
+
+    @srv.tool(
+        name="add",
+        description="Add two numbers",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "a": {"type": "number"},
+                "b": {"type": "number"},
+            },
+            "required": ["a", "b"],
+        },
+    )
+    def add(a: int | float, b: int | float) -> dict:
+        return {"sum": a + b}
+
+    @srv.resource(
+        uri="test://info",
+        name="Test Info",
+        description="Test resource",
+    )
+    def info() -> dict:
+        return {"status": "ok"}
+
+    return srv
+
+
+def _make_test_app(server: MCPServer | None = None) -> FastAPI:
+    """Build a FastAPI app with the transport router mounted."""
+    app = FastAPI()
+    srv = server or _make_test_server()
+    router = make_mcp_router(srv, prefix="/mcp/test")
+    app.include_router(router)
+    return app
+
+
+@pytest.fixture
+def test_app() -> FastAPI:
+    return _make_test_app()
+
+
+@pytest.fixture
+async def client(test_app: FastAPI) -> AsyncClient:
+    transport = ASGITransport(app=test_app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as c:
+        yield c
+
+
+# ─── POST /call — success ──────────────────────────────────────────────
+
+
+async def test_call_echo(client: AsyncClient) -> None:
+    resp = await client.post(
+        "/mcp/test/call",
+        json={"jsonrpc": "2.0", "method": "echo", "params": {"message": "hello"}, "id": 1},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["jsonrpc"] == "2.0"
+    assert body["result"] == {"echo": "hello"}
+    assert body["id"] == 1
+
+
+async def test_call_add(client: AsyncClient) -> None:
+    resp = await client.post(
+        "/mcp/test/call",
+        json={"jsonrpc": "2.0", "method": "add", "params": {"a": 3, "b": 4}, "id": 2},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["result"] == {"sum": 7}
+    assert body["id"] == 2
+
+
+async def test_call_with_string_id(client: AsyncClient) -> None:
+    resp = await client.post(
+        "/mcp/test/call",
+        json={
+            "jsonrpc": "2.0",
+            "method": "echo",
+            "params": {"message": "test"},
+            "id": "abc-123",
+        },
+    )
+    body = resp.json()
+    assert body["id"] == "abc-123"
+    assert body["result"] == {"echo": "test"}
+
+
+async def test_call_with_null_id(client: AsyncClient) -> None:
+    resp = await client.post(
+        "/mcp/test/call",
+        json={"jsonrpc": "2.0", "method": "echo", "params": {"message": "notify"}},
+    )
+    body = resp.json()
+    assert body["id"] is None
+    assert body["result"] == {"echo": "notify"}
+
+
+# ─── POST /call — errors ───────────────────────────────────────────────
+
+
+async def test_call_unknown_method(client: AsyncClient) -> None:
+    resp = await client.post(
+        "/mcp/test/call",
+        json={"jsonrpc": "2.0", "method": "nonexistent", "params": {}, "id": 10},
+    )
+    assert resp.status_code == 200  # JSON-RPC errors are 200 with error payload
+    body = resp.json()
+    assert "error" in body
+    assert body["error"]["code"] == METHOD_NOT_FOUND
+    assert "Unknown tool" in body["error"]["message"]
+    assert body["id"] == 10
+
+
+async def test_call_missing_required_param(client: AsyncClient) -> None:
+    resp = await client.post(
+        "/mcp/test/call",
+        json={"jsonrpc": "2.0", "method": "add", "params": {"a": 1}, "id": 11},
+    )
+    body = resp.json()
+    assert "error" in body
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "Missing required argument" in body["error"]["message"]
+
+
+async def test_call_empty_params(client: AsyncClient) -> None:
+    resp = await client.post(
+        "/mcp/test/call",
+        json={"jsonrpc": "2.0", "method": "echo", "params": {}, "id": 12},
+    )
+    body = resp.json()
+    assert "error" in body
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+# ─── POST /call — internal error ───────────────────────────────────────
+
+
+async def test_call_internal_error() -> None:
+    """A tool that raises a non-ValueError should produce INTERNAL_ERROR."""
+    srv = MCPServer(name="err-test")
+
+    @srv.tool(
+        name="boom",
+        description="Always fails",
+        input_schema={"type": "object", "properties": {}, "required": []},
+    )
+    def boom() -> None:
+        raise RuntimeError("kaboom")
+
+    app = _make_test_app(srv)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        resp = await client.post(
+            "/mcp/test/call",
+            json={"jsonrpc": "2.0", "method": "boom", "params": {}, "id": 99},
+        )
+    body = resp.json()
+    assert "error" in body
+    assert body["error"]["code"] == INTERNAL_ERROR
+    assert "kaboom" in body["error"]["message"]
+
+
+# ─── GET /tools ─────────────────────────────────────────────────────────
+
+
+async def test_list_tools(client: AsyncClient) -> None:
+    resp = await client.get("/mcp/test/tools")
+    assert resp.status_code == 200
+    tools = resp.json()
+    names = {t["name"] for t in tools}
+    assert names == {"echo", "add"}
+    for t in tools:
+        assert "description" in t
+        assert "inputSchema" in t
+
+
+# ─── GET /resources ─────────────────────────────────────────────────────
+
+
+async def test_list_resources(client: AsyncClient) -> None:
+    resp = await client.get("/mcp/test/resources")
+    assert resp.status_code == 200
+    resources = resp.json()
+    assert len(resources) == 1
+    assert resources[0]["uri"] == "test://info"
+    assert resources[0]["name"] == "Test Info"
+
+
+# ─── mount_all_mcp_routers — smoke test ─────────────────────────────────
+
+
+async def test_mount_all_systems_tools() -> None:
+    """All five system routers should be reachable via /mcp/{system}/tools."""
+    app = FastAPI()
+    parent = APIRouter()
+    mount_all_mcp_routers(parent)
+    app.include_router(parent)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        for system in ("intelligence", "healing", "wealth", "creative", "perspective"):
+            resp = await client.get(f"/mcp/{system}/tools")
+            assert resp.status_code == 200, f"/mcp/{system}/tools failed"
+            tools = resp.json()
+            assert isinstance(tools, list)
+            assert len(tools) > 0, f"/mcp/{system}/tools returned no tools"
+
+
+async def test_mount_all_systems_resources() -> None:
+    """All five system routers should expose their resources."""
+    app = FastAPI()
+    parent = APIRouter()
+    mount_all_mcp_routers(parent)
+    app.include_router(parent)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        for system in ("intelligence", "healing", "wealth", "creative", "perspective"):
+            resp = await client.get(f"/mcp/{system}/resources")
+            assert resp.status_code == 200, f"/mcp/{system}/resources failed"
+
+
+async def test_mount_healing_call_detect_crisis() -> None:
+    """Verify a real tool call works through the transport layer."""
+    app = FastAPI()
+    parent = APIRouter()
+    mount_all_mcp_routers(parent)
+    app.include_router(parent)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        resp = await client.post(
+            "/mcp/healing/call",
+            json={
+                "jsonrpc": "2.0",
+                "method": "detect_crisis",
+                "params": {"text": "I had a great day"},
+                "id": 1,
+            },
+        )
+    body = resp.json()
+    assert body["jsonrpc"] == "2.0"
+    assert body["result"] is None  # no crisis
+    assert body["id"] == 1
+
+
+# ─── Healing skill tools via transport ──────────────────────────────────
+
+
+async def test_healing_list_skills_via_transport() -> None:
+    """list_skills should return skills through the JSON-RPC transport."""
+    app = FastAPI()
+    parent = APIRouter()
+    mount_all_mcp_routers(parent)
+    app.include_router(parent)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        resp = await client.post(
+            "/mcp/healing/call",
+            json={
+                "jsonrpc": "2.0",
+                "method": "list_skills",
+                "params": {},
+                "id": 1,
+            },
+        )
+    body = resp.json()
+    assert "result" in body
+    skills = body["result"]
+    assert isinstance(skills, list)
+    assert len(skills) >= 15  # 15 seed skills
+    for s in skills:
+        assert "name" in s
+        assert "title" in s
+        assert "modality" in s
+        assert "evidence_rating" in s
+        assert "duration_minutes" in s
+
+
+async def test_healing_list_skills_by_modality_via_transport() -> None:
+    """list_skills with modality filter should return only matching skills."""
+    app = FastAPI()
+    parent = APIRouter()
+    mount_all_mcp_routers(parent)
+    app.include_router(parent)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        resp = await client.post(
+            "/mcp/healing/call",
+            json={
+                "jsonrpc": "2.0",
+                "method": "list_skills",
+                "params": {"modality": "breathwork"},
+                "id": 2,
+            },
+        )
+    body = resp.json()
+    skills = body["result"]
+    assert isinstance(skills, list)
+    assert len(skills) >= 1
+    for s in skills:
+        assert s["modality"] == "breathwork"
+
+
+async def test_healing_run_skill_via_transport() -> None:
+    """run_skill should return the full practice card through transport."""
+    app = FastAPI()
+    parent = APIRouter()
+    mount_all_mcp_routers(parent)
+    app.include_router(parent)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        resp = await client.post(
+            "/mcp/healing/call",
+            json={
+                "jsonrpc": "2.0",
+                "method": "run_skill",
+                "params": {"name": "breathwork-box-breathing"},
+                "id": 3,
+            },
+        )
+    body = resp.json()
+    assert "result" in body
+    skill = body["result"]
+    assert skill["name"] == "breathwork-box-breathing"
+    assert skill["title"] == "Box Breathing (4-4-4-4)"
+    assert skill["modality"] == "breathwork"
+    assert isinstance(skill["steps"], list)
+    assert len(skill["steps"]) > 0
+    assert skill["evidence_rating"] == "B"
+    assert isinstance(skill["contraindications"], list)
+    assert skill["duration_minutes"] == 6
+
+
+async def test_healing_run_skill_not_found_via_transport() -> None:
+    """run_skill with unknown name should return JSON-RPC error."""
+    app = FastAPI()
+    parent = APIRouter()
+    mount_all_mcp_routers(parent)
+    app.include_router(parent)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        resp = await client.post(
+            "/mcp/healing/call",
+            json={
+                "jsonrpc": "2.0",
+                "method": "run_skill",
+                "params": {"name": "nonexistent-skill"},
+                "id": 4,
+            },
+        )
+    body = resp.json()
+    assert "error" in body
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "Skill not found" in body["error"]["message"]
+
+
+async def test_healing_tools_include_skill_tools() -> None:
+    """The healing server /tools endpoint should include list_skills and run_skill."""
+    app = FastAPI()
+    parent = APIRouter()
+    mount_all_mcp_routers(parent)
+    app.include_router(parent)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        resp = await client.get("/mcp/healing/tools")
+    tools = resp.json()
+    names = {t["name"] for t in tools}
+    assert "list_skills" in names
+    assert "run_skill" in names
+    # Original tools should still be present
+    assert "detect_crisis" in names
+    assert "match_modalities" in names
+    assert "get_breathwork" in names


### PR DESCRIPTION
## Summary
- **Issue:** #157 (T1-S2 MCP HTTP/SSE transport)
- `make_mcp_router(server, prefix)` factory wrapping MCPServer in JSON-RPC 2.0 FastAPI router
- Mounted at `/mcp/{system}` for all 5 systems: `POST /call`, `GET /tools`, `GET /resources`
- `list_skills` and `run_skill` tools added to HealingMCPServer backed by SkillRegistry
- 24 new tests (18 transport + 6 skill tools), 130 MCP tests total

## Test plan
- [ ] `pytest tests/mcp/ -v` — 130 MCP tests
- [ ] `ruff check && ruff format --check` — lint clean

Stacked on #188. Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)