### PR TITLE
feat(web): interactive healing UX — skill drawer, breathwork, journal, mood

### DIFF
--- a/alchymine/web/src/components/healing/BreathworkGuide.tsx
+++ b/alchymine/web/src/components/healing/BreathworkGuide.tsx
@@ -1,0 +1,345 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import Button from "@/components/shared/Button";
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface BreathPhase {
+  label: string;
+  seconds: number;
+}
+
+export interface BreathPattern {
+  name: string;
+  description: string;
+  phases: BreathPhase[];
+  cycles: number;
+}
+
+interface BreathworkGuideProps {
+  /** Breath pattern to run. */
+  pattern: BreathPattern;
+  /** Called when all cycles are completed. */
+  onComplete?: (durationSeconds: number) => void;
+  /** Called when user exits early. */
+  onExit?: () => void;
+}
+
+// ── Default patterns from common YAML skills ────────────────────────
+
+export const DEFAULT_PATTERNS: BreathPattern[] = [
+  {
+    name: "Box Breathing (4-4-4-4)",
+    description: "Equal inhale, hold, exhale, hold pattern used by Navy SEALs.",
+    phases: [
+      { label: "Inhale", seconds: 4 },
+      { label: "Hold", seconds: 4 },
+      { label: "Exhale", seconds: 4 },
+      { label: "Hold", seconds: 4 },
+    ],
+    cycles: 8,
+  },
+  {
+    name: "4-7-8 Relaxation",
+    description: "A calming pattern that extends the exhale for deeper relaxation.",
+    phases: [
+      { label: "Inhale", seconds: 4 },
+      { label: "Hold", seconds: 7 },
+      { label: "Exhale", seconds: 8 },
+    ],
+    cycles: 4,
+  },
+  {
+    name: "Coherence Breathing",
+    description: "Simple 5-in, 5-out rhythm for heart-rate variability coherence.",
+    phases: [
+      { label: "Inhale", seconds: 5 },
+      { label: "Exhale", seconds: 5 },
+    ],
+    cycles: 12,
+  },
+];
+
+// ── Phase → circle scale mapping ────────────────────────────────────
+
+function getScale(label: string, progress: number): number {
+  const normalized = label.toLowerCase();
+  if (normalized === "inhale") return 0.55 + progress * 0.45;
+  if (normalized === "exhale") return 1.0 - progress * 0.45;
+  return 0.75; // hold phases stay mid-size
+}
+
+function getPhaseColor(label: string): string {
+  const normalized = label.toLowerCase();
+  if (normalized === "inhale") return "#20b2aa";
+  if (normalized === "exhale") return "#7b2d8e";
+  return "#DAA520"; // hold
+}
+
+// ── Component ────────────────────────────────────────────────────────
+
+export default function BreathworkGuide({
+  pattern,
+  onComplete,
+  onExit,
+}: BreathworkGuideProps) {
+  const [state, setState] = useState<"idle" | "running" | "done">("idle");
+  const [phaseIndex, setPhaseIndex] = useState(0);
+  const [cycle, setCycle] = useState(1);
+  const [elapsed, setElapsed] = useState(0); // within current phase
+  const [totalElapsed, setTotalElapsed] = useState(0);
+  const rafRef = useRef<number | null>(null);
+  const lastTickRef = useRef<number>(0);
+  const stateRef = useRef({ phaseIndex: 0, cycle: 1, elapsed: 0 });
+
+  const currentPhase = pattern.phases[phaseIndex];
+  const phaseDuration = currentPhase.seconds;
+  const progress = Math.min(elapsed / phaseDuration, 1);
+  const scale = getScale(currentPhase.label, progress);
+  const color = getPhaseColor(currentPhase.label);
+
+  // Sync ref with state
+  useEffect(() => {
+    stateRef.current = { phaseIndex, cycle, elapsed };
+  }, [phaseIndex, cycle, elapsed]);
+
+  const stop = useCallback(() => {
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+  }, []);
+
+  const tick = useCallback(
+    (now: number) => {
+      const dt = (now - lastTickRef.current) / 1000;
+      lastTickRef.current = now;
+      const { phaseIndex: pi, cycle: cy, elapsed: el } = stateRef.current;
+
+      const newElapsed = el + dt;
+      const phase = pattern.phases[pi];
+
+      if (newElapsed >= phase.seconds) {
+        // Advance to next phase
+        let nextPhase = pi + 1;
+        let nextCycle = cy;
+        if (nextPhase >= pattern.phases.length) {
+          nextPhase = 0;
+          nextCycle = cy + 1;
+          if (nextCycle > pattern.cycles) {
+            // Session complete
+            stop();
+            setState("done");
+            return;
+          }
+          setCycle(nextCycle);
+        }
+        setPhaseIndex(nextPhase);
+        setElapsed(0);
+        setTotalElapsed((t) => t + dt);
+        stateRef.current = { phaseIndex: nextPhase, cycle: nextCycle, elapsed: 0 };
+      } else {
+        setElapsed(newElapsed);
+        setTotalElapsed((t) => t + dt);
+        stateRef.current = { ...stateRef.current, elapsed: newElapsed };
+      }
+
+      rafRef.current = requestAnimationFrame(tick);
+    },
+    [pattern, stop],
+  );
+
+  const start = useCallback(() => {
+    setState("running");
+    setPhaseIndex(0);
+    setCycle(1);
+    setElapsed(0);
+    setTotalElapsed(0);
+    stateRef.current = { phaseIndex: 0, cycle: 1, elapsed: 0 };
+    lastTickRef.current = performance.now();
+    rafRef.current = requestAnimationFrame(tick);
+  }, [tick]);
+
+  useEffect(() => {
+    return stop;
+  }, [stop]);
+
+  // ── Idle / pre-start ────────────────────────────────────────────
+
+  if (state === "idle") {
+    return (
+      <div className="card-surface p-6 text-center" data-testid="breathwork-guide-idle">
+        <h2 className="font-display text-xl font-light text-text mb-1">
+          {pattern.name}
+        </h2>
+        <p className="font-body text-sm text-text/50 mb-4">{pattern.description}</p>
+
+        <div className="flex flex-wrap justify-center gap-2 mb-4">
+          {pattern.phases.map((ph, i) => (
+            <span
+              key={i}
+              className="px-2.5 py-1 rounded-full text-xs font-body border border-white/10 text-text/60"
+            >
+              {ph.label} {ph.seconds}s
+            </span>
+          ))}
+          <span className="px-2.5 py-1 rounded-full text-xs font-body border border-white/10 text-text/40">
+            {pattern.cycles} cycles
+          </span>
+        </div>
+
+        <div className="flex gap-3 justify-center">
+          <Button variant="primary" onClick={start}>
+            Begin
+          </Button>
+          {onExit && (
+            <Button variant="ghost" onClick={onExit}>
+              Back
+            </Button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // ── Done ────────────────────────────────────────────────────────
+
+  if (state === "done") {
+    const totalSec = Math.round(totalElapsed);
+    return (
+      <div className="card-surface p-6 text-center" data-testid="breathwork-guide-done">
+        <h2 className="font-display text-xl font-light mb-2">
+          <span className="text-gradient-teal">Session Complete</span>
+        </h2>
+        <p className="font-body text-sm text-text/50 mb-2">{pattern.name}</p>
+        <p className="font-body text-xs text-text/40 mb-4">
+          {pattern.cycles} cycles in {Math.floor(totalSec / 60)}m {totalSec % 60}s
+        </p>
+        <div className="flex gap-3 justify-center">
+          <Button variant="primary" onClick={start}>
+            Repeat
+          </Button>
+          <Button
+            variant="ghost"
+            onClick={() => onComplete?.(totalSec)}
+          >
+            Done
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Running ─────────────────────────────────────────────────────
+
+  const remaining = Math.max(0, phaseDuration - elapsed);
+
+  return (
+    <div
+      className="card-surface p-6 text-center"
+      role="timer"
+      aria-live="polite"
+      data-testid="breathwork-guide-running"
+    >
+      <p className="font-body text-xs text-text/40 mb-6">
+        Cycle {cycle} of {pattern.cycles}
+      </p>
+
+      {/* Animated circle */}
+      <div className="relative w-48 h-48 mx-auto mb-6">
+        {/* Background ring */}
+        <svg className="absolute inset-0" viewBox="0 0 200 200" aria-hidden="true">
+          <circle
+            cx="100"
+            cy="100"
+            r="90"
+            fill="none"
+            stroke="rgba(255,255,255,0.06)"
+            strokeWidth="3"
+          />
+          <circle
+            cx="100"
+            cy="100"
+            r="90"
+            fill="none"
+            stroke={color}
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeDasharray={`${2 * Math.PI * 90}`}
+            strokeDashoffset={`${2 * Math.PI * 90 * (1 - progress)}`}
+            className="transition-none"
+            style={{ opacity: 0.5, transform: "rotate(-90deg)", transformOrigin: "center" }}
+          />
+        </svg>
+
+        {/* Breathing circle */}
+        <div
+          className="absolute rounded-full"
+          style={{
+            inset: 18,
+            background: `radial-gradient(circle at center, ${color}20, ${color}08)`,
+            border: `2px solid ${color}44`,
+            transform: `scale(${scale})`,
+            transition: "transform 0.05s linear",
+          }}
+          aria-hidden="true"
+        />
+
+        {/* Center text */}
+        <div className="absolute inset-0 flex flex-col items-center justify-center">
+          <span
+            className="font-body text-sm uppercase tracking-wider"
+            style={{ color }}
+            aria-label={`Phase: ${currentPhase.label}`}
+          >
+            {currentPhase.label}
+          </span>
+          <span
+            className="font-display text-3xl font-light mt-1 text-text"
+            aria-label={`${Math.ceil(remaining)} seconds remaining`}
+          >
+            {Math.ceil(remaining)}
+          </span>
+        </div>
+      </div>
+
+      {/* Phase indicators */}
+      <div className="flex justify-center gap-2 mb-4 flex-wrap">
+        {pattern.phases.map((ph, idx) => (
+          <span
+            key={idx}
+            className={`px-2.5 py-1 rounded-full text-xs font-body transition-all duration-200 ${
+              idx === phaseIndex
+                ? "font-semibold border"
+                : "text-text/30 border border-transparent"
+            }`}
+            style={
+              idx === phaseIndex
+                ? {
+                    color: getPhaseColor(ph.label),
+                    background: `${getPhaseColor(ph.label)}18`,
+                    borderColor: `${getPhaseColor(ph.label)}30`,
+                  }
+                : undefined
+            }
+          >
+            {ph.label} {ph.seconds}s
+          </span>
+        ))}
+      </div>
+
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => {
+          stop();
+          setState("idle");
+          onExit?.();
+        }}
+      >
+        End Session
+      </Button>
+    </div>
+  );
+}

--- a/alchymine/web/src/components/healing/JournalEntryActions.tsx
+++ b/alchymine/web/src/components/healing/JournalEntryActions.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import {
+  updateJournalEntry,
+  deleteJournalEntry,
+  JournalEntry,
+} from "@/lib/api";
+import Button from "@/components/shared/Button";
+
+// ── Props ────────────────────────────────────────────────────────────
+
+interface JournalEntryActionsProps {
+  /** The journal entry to act on. */
+  entry: JournalEntry;
+  /** Called after a successful update with the updated entry. */
+  onUpdated?: (updated: JournalEntry) => void;
+  /** Called after a successful deletion. */
+  onDeleted?: (entryId: string) => void;
+}
+
+// ── Component ────────────────────────────────────────────────────────
+
+export default function JournalEntryActions({
+  entry,
+  onUpdated,
+  onDeleted,
+}: JournalEntryActionsProps) {
+  const [mode, setMode] = useState<"view" | "edit" | "confirm-delete">("view");
+  const [editTitle, setEditTitle] = useState(entry.title);
+  const [editContent, setEditContent] = useState(entry.content);
+  const [editMoodScore, setEditMoodScore] = useState<number | null>(
+    entry.mood_score,
+  );
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const updated = await updateJournalEntry(entry.id, {
+        title: editTitle,
+        content: editContent,
+        mood_score: editMoodScore,
+      });
+      onUpdated?.(updated);
+      setMode("view");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save changes");
+    } finally {
+      setSaving(false);
+    }
+  }, [entry.id, editTitle, editContent, editMoodScore, onUpdated]);
+
+  const handleDelete = useCallback(async () => {
+    setDeleting(true);
+    setError(null);
+    try {
+      await deleteJournalEntry(entry.id);
+      onDeleted?.(entry.id);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete entry");
+      setDeleting(false);
+    }
+  }, [entry.id, onDeleted]);
+
+  const handleCancelEdit = useCallback(() => {
+    setEditTitle(entry.title);
+    setEditContent(entry.content);
+    setEditMoodScore(entry.mood_score);
+    setError(null);
+    setMode("view");
+  }, [entry]);
+
+  // ── View mode: show entry with edit / delete buttons ──────────
+
+  if (mode === "view") {
+    return (
+      <div data-testid="journal-entry-actions">
+        {/* Entry display */}
+        <div className="mb-4">
+          <h3 className="font-display text-lg font-light text-text mb-1">
+            {entry.title}
+          </h3>
+          <div className="flex items-center gap-2 text-xs font-body text-text/40 mb-3">
+            <span>{entry.system}</span>
+            <span aria-hidden="true">|</span>
+            <span>{entry.entry_type}</span>
+            {entry.mood_score !== null && (
+              <>
+                <span aria-hidden="true">|</span>
+                <span>Mood: {entry.mood_score}/10</span>
+              </>
+            )}
+          </div>
+          <p className="font-body text-sm text-text/70 leading-relaxed whitespace-pre-wrap">
+            {entry.content}
+          </p>
+          {entry.tags.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 mt-3">
+              {entry.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="px-2 py-0.5 rounded-full text-xs font-body bg-white/5 text-text/50 border border-white/10"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Action buttons */}
+        <div className="flex gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setMode("edit")}
+            data-testid="journal-edit-btn"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="mr-1"
+            >
+              <path d="M17 3a2.83 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
+            </svg>
+            Edit
+          </Button>
+          <button
+            onClick={() => setMode("confirm-delete")}
+            className="inline-flex items-center gap-1 px-4 py-2 text-sm font-body font-medium rounded-lg border border-red-400/30 text-red-400 hover:bg-red-400/10 transition-colors"
+            data-testid="journal-delete-btn"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M3 6h18" />
+              <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
+              <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
+            </svg>
+            Delete
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Delete confirmation ────────────────────────────────────────
+
+  if (mode === "confirm-delete") {
+    return (
+      <div data-testid="journal-delete-confirm">
+        <div className="bg-red-400/10 border border-red-400/20 rounded-xl p-4 mb-4">
+          <p className="font-body text-sm text-red-400 mb-1 font-medium">
+            Delete this journal entry?
+          </p>
+          <p className="font-body text-xs text-text/50">
+            This action cannot be undone. The entry &ldquo;{entry.title}&rdquo;
+            will be permanently removed.
+          </p>
+        </div>
+        {error && (
+          <p className="font-body text-sm text-red-400 mb-3">{error}</p>
+        )}
+        <div className="flex gap-2">
+          <button
+            onClick={handleDelete}
+            disabled={deleting}
+            className="inline-flex items-center gap-1 px-4 py-2 text-sm font-body font-medium rounded-lg bg-red-500 text-white hover:bg-red-600 disabled:opacity-50 transition-colors"
+            data-testid="journal-confirm-delete-btn"
+          >
+            {deleting ? "Deleting..." : "Yes, Delete"}
+          </button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              setError(null);
+              setMode("view");
+            }}
+          >
+            Cancel
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Edit mode ──────────────────────────────────────────────────
+
+  return (
+    <div data-testid="journal-edit-form">
+      <div className="space-y-4 mb-4">
+        {/* Title */}
+        <div>
+          <label
+            htmlFor="edit-title"
+            className="block font-body text-xs text-text/40 uppercase tracking-wider mb-1"
+          >
+            Title
+          </label>
+          <input
+            id="edit-title"
+            type="text"
+            value={editTitle}
+            onChange={(e) => setEditTitle(e.target.value)}
+            className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 font-body text-sm text-text placeholder:text-text/30 focus:outline-none focus:border-accent/50"
+            data-testid="journal-edit-title"
+          />
+        </div>
+
+        {/* Content */}
+        <div>
+          <label
+            htmlFor="edit-content"
+            className="block font-body text-xs text-text/40 uppercase tracking-wider mb-1"
+          >
+            Content
+          </label>
+          <textarea
+            id="edit-content"
+            value={editContent}
+            onChange={(e) => setEditContent(e.target.value)}
+            rows={6}
+            className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 font-body text-sm text-text placeholder:text-text/30 focus:outline-none focus:border-accent/50 resize-y"
+            data-testid="journal-edit-content"
+          />
+        </div>
+
+        {/* Mood score */}
+        <div>
+          <label
+            htmlFor="edit-mood"
+            className="block font-body text-xs text-text/40 uppercase tracking-wider mb-1"
+          >
+            Mood Score (1-10)
+          </label>
+          <input
+            id="edit-mood"
+            type="number"
+            min={1}
+            max={10}
+            value={editMoodScore ?? ""}
+            onChange={(e) => {
+              const v = e.target.value;
+              setEditMoodScore(v === "" ? null : Math.min(10, Math.max(1, Number(v))));
+            }}
+            className="w-24 bg-white/5 border border-white/10 rounded-lg px-3 py-2 font-body text-sm text-text placeholder:text-text/30 focus:outline-none focus:border-accent/50"
+            placeholder="-"
+            data-testid="journal-edit-mood"
+          />
+        </div>
+      </div>
+
+      {error && (
+        <p className="font-body text-sm text-red-400 mb-3">{error}</p>
+      )}
+
+      <div className="flex gap-2">
+        <Button
+          variant="primary"
+          size="sm"
+          loading={saving}
+          onClick={handleSave}
+          data-testid="journal-save-btn"
+        >
+          Save Changes
+        </Button>
+        <Button variant="ghost" size="sm" onClick={handleCancelEdit}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/alchymine/web/src/components/healing/MoodSparkline.tsx
+++ b/alchymine/web/src/components/healing/MoodSparkline.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useMemo } from "react";
+
+// ── Types ────────────────────────────────────────────────────────────
+
+interface MoodDataPoint {
+  /** ISO date string or label. */
+  date: string;
+  /** Mood score (1-10). */
+  score: number;
+}
+
+interface MoodSparklineProps {
+  /** Mood data points to render (newest last). Max 14 shown. */
+  data: MoodDataPoint[];
+  /** SVG width in pixels. Default 180. */
+  width?: number;
+  /** SVG height in pixels. Default 40. */
+  height?: number;
+  /** Stroke color. Default "#20b2aa" (teal accent). */
+  color?: string;
+  /** Optional label shown to the left of the sparkline. */
+  label?: string;
+}
+
+// ── Component ────────────────────────────────────────────────────────
+
+export default function MoodSparkline({
+  data,
+  width = 180,
+  height = 40,
+  color = "#20b2aa",
+  label,
+}: MoodSparklineProps) {
+  // Use up to the last 14 entries that have scores
+  const points = useMemo(() => {
+    return data.filter((d) => d.score >= 1 && d.score <= 10).slice(-14);
+  }, [data]);
+
+  const { polyline, dots, average, gradientId } = useMemo(() => {
+    if (points.length === 0) {
+      return { polyline: "", dots: [], average: null, gradientId: "" };
+    }
+
+    const id = `mood-gradient-${Math.random().toString(36).slice(2, 8)}`;
+    const padX = 4;
+    const padY = 4;
+    const innerW = width - padX * 2;
+    const innerH = height - padY * 2;
+
+    const minScore = 1;
+    const maxScore = 10;
+
+    const coords = points.map((p, i) => {
+      const x =
+        points.length === 1
+          ? width / 2
+          : padX + (i / (points.length - 1)) * innerW;
+      const y =
+        padY +
+        innerH -
+        ((p.score - minScore) / (maxScore - minScore)) * innerH;
+      return { x, y, score: p.score, date: p.date };
+    });
+
+    const line = coords.map((c) => `${c.x},${c.y}`).join(" ");
+    const avg = points.reduce((s, p) => s + p.score, 0) / points.length;
+
+    return { polyline: line, dots: coords, average: avg, gradientId: id };
+  }, [points, width, height]);
+
+  if (points.length === 0) {
+    return (
+      <div
+        className="flex items-center gap-2"
+        data-testid="mood-sparkline-empty"
+      >
+        {label && (
+          <span className="font-body text-xs text-text/40">{label}</span>
+        )}
+        <span className="font-body text-xs text-text/30 italic">
+          No mood data
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="flex items-center gap-2"
+      data-testid="mood-sparkline"
+    >
+      {label && (
+        <span className="font-body text-xs text-text/40 whitespace-nowrap">
+          {label}
+        </span>
+      )}
+      <svg
+        width={width}
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+        role="img"
+        aria-label={`Mood trend over ${points.length} entries, average ${average?.toFixed(1)}`}
+        className="flex-shrink-0"
+      >
+        <defs>
+          <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={color} stopOpacity="0.3" />
+            <stop offset="100%" stopColor={color} stopOpacity="0.02" />
+          </linearGradient>
+        </defs>
+
+        {/* Filled area under the line */}
+        {dots.length > 1 && (
+          <polygon
+            points={`${dots[0].x},${height} ${polyline} ${dots[dots.length - 1].x},${height}`}
+            fill={`url(#${gradientId})`}
+          />
+        )}
+
+        {/* Polyline */}
+        <polyline
+          points={polyline}
+          fill="none"
+          stroke={color}
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+
+        {/* Dots */}
+        {dots.map((d, i) => (
+          <circle
+            key={i}
+            cx={d.x}
+            cy={d.y}
+            r={points.length <= 7 ? 2.5 : 1.5}
+            fill={color}
+          >
+            <title>
+              {d.date}: {d.score}/10
+            </title>
+          </circle>
+        ))}
+      </svg>
+
+      {average !== null && (
+        <span className="font-body text-xs text-text/50 whitespace-nowrap">
+          avg {average.toFixed(1)}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/alchymine/web/src/components/healing/SkillDetailDrawer.tsx
+++ b/alchymine/web/src/components/healing/SkillDetailDrawer.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import { useEffect, useRef, useCallback } from "react";
+import { useApi } from "@/lib/useApi";
+import { getHealingSkill, HealingSkill } from "@/lib/api";
+import Button from "@/components/shared/Button";
+
+// ── Evidence rating display ─────────────────────────────────────────
+
+const EVIDENCE_LABELS: Record<string, { label: string; color: string }> = {
+  A: { label: "Strong (RCT / Meta-Analytic)", color: "#22c55e" },
+  B: { label: "Moderate (Controlled Studies)", color: "#eab308" },
+  C: { label: "Limited (Observational)", color: "#f97316" },
+  D: { label: "Traditional / Anecdotal", color: "#a78bfa" },
+};
+
+function EvidenceTag({ rating }: { rating: string }) {
+  const info = EVIDENCE_LABELS[rating] ?? {
+    label: rating,
+    color: "#94a3b8",
+  };
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-body font-medium"
+      style={{
+        background: `${info.color}18`,
+        color: info.color,
+        border: `1px solid ${info.color}30`,
+      }}
+    >
+      <span
+        className="w-1.5 h-1.5 rounded-full"
+        style={{ background: info.color }}
+        aria-hidden="true"
+      />
+      {info.label}
+    </span>
+  );
+}
+
+// ── Props ────────────────────────────────────────────────────────────
+
+interface SkillDetailDrawerProps {
+  /** Skill name slug to fetch detail for. `null` closes the drawer. */
+  skillName: string | null;
+  /** Called when the drawer should close. */
+  onClose: () => void;
+  /** Optional callback when user wants to start a practice. */
+  onStartPractice?: (skill: HealingSkill) => void;
+}
+
+// ── Component ────────────────────────────────────────────────────────
+
+export default function SkillDetailDrawer({
+  skillName,
+  onClose,
+  onStartPractice,
+}: SkillDetailDrawerProps) {
+  const open = skillName !== null;
+  const drawerRef = useRef<HTMLDivElement>(null);
+
+  const { data: skill, loading, error } = useApi<HealingSkill>(
+    skillName ? (signal) => getHealingSkill(skillName) : null,
+    [skillName],
+  );
+
+  // Close on Escape key
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape" && open) onClose();
+    },
+    [open, onClose],
+  );
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
+
+  // Trap focus inside drawer when open
+  useEffect(() => {
+    if (open) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  return (
+    <>
+      {/* Backdrop */}
+      {open && (
+        <div
+          className="fixed inset-0 bg-black/50 backdrop-blur-sm z-40 transition-opacity"
+          onClick={onClose}
+          data-testid="drawer-backdrop"
+          aria-hidden="true"
+        />
+      )}
+
+      {/* Drawer panel */}
+      <div
+        ref={drawerRef}
+        role="dialog"
+        aria-modal={open}
+        aria-label={skill?.title ?? "Skill details"}
+        className={`fixed top-0 right-0 h-full w-full max-w-md bg-bg border-l border-white/10 z-50 transform transition-transform duration-300 ease-out overflow-y-auto ${
+          open ? "translate-x-0" : "translate-x-full"
+        }`}
+        data-testid="skill-detail-drawer"
+      >
+        {/* Header */}
+        <div className="sticky top-0 bg-bg/90 backdrop-blur-md border-b border-white/5 px-6 py-4 flex items-center justify-between z-10">
+          <h2 className="font-display text-lg font-light text-text truncate">
+            {loading ? "Loading..." : skill?.title ?? "Skill Detail"}
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-text/40 hover:text-text/70 transition-colors p-1"
+            aria-label="Close drawer"
+            data-testid="drawer-close"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M18 6 6 18" />
+              <path d="m6 6 12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="p-6 space-y-6">
+          {loading && (
+            <div className="animate-pulse space-y-4" data-testid="drawer-loading">
+              <div className="h-4 bg-white/10 rounded w-3/4" />
+              <div className="h-4 bg-white/10 rounded w-1/2" />
+              <div className="h-20 bg-white/10 rounded" />
+            </div>
+          )}
+
+          {error && (
+            <div className="text-red-400 font-body text-sm" data-testid="drawer-error">
+              Failed to load skill: {error}
+            </div>
+          )}
+
+          {skill && !loading && (
+            <>
+              {/* Meta badges */}
+              <div className="flex flex-wrap gap-2">
+                <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-body bg-white/5 text-text/60 border border-white/10">
+                  {skill.modality.replace(/_/g, " ")}
+                </span>
+                <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-body bg-white/5 text-text/60 border border-white/10">
+                  {skill.duration_minutes} min
+                </span>
+                <EvidenceTag rating={skill.evidence_rating} />
+              </div>
+
+              {/* Description */}
+              <div>
+                <h3 className="font-body text-xs text-text/40 uppercase tracking-wider mb-2">
+                  Description
+                </h3>
+                <p className="font-body text-sm text-text/70 leading-relaxed">
+                  {skill.description}
+                </p>
+              </div>
+
+              {/* Steps */}
+              <div>
+                <h3 className="font-body text-xs text-text/40 uppercase tracking-wider mb-3">
+                  Steps
+                </h3>
+                <ol className="space-y-3">
+                  {skill.steps.map((step, idx) => (
+                    <li key={idx} className="flex gap-3">
+                      <span className="flex-shrink-0 w-6 h-6 rounded-full bg-accent/15 text-accent text-xs font-body flex items-center justify-center border border-accent/25 mt-0.5">
+                        {idx + 1}
+                      </span>
+                      <span className="font-body text-sm text-text/70 leading-relaxed">
+                        {step}
+                      </span>
+                    </li>
+                  ))}
+                </ol>
+              </div>
+
+              {/* Contraindications */}
+              {skill.contraindications.length > 0 && (
+                <div>
+                  <h3 className="font-body text-xs text-text/40 uppercase tracking-wider mb-2">
+                    Contraindications
+                  </h3>
+                  <ul className="space-y-1.5">
+                    {skill.contraindications.map((ci, idx) => (
+                      <li
+                        key={idx}
+                        className="flex items-start gap-2 font-body text-sm text-red-400/80"
+                      >
+                        <span className="mt-1 w-1.5 h-1.5 rounded-full bg-red-400/60 flex-shrink-0" />
+                        {ci}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {/* Action button */}
+              {onStartPractice && (
+                <div className="pt-2">
+                  <Button
+                    variant="primary"
+                    className="w-full"
+                    onClick={() => onStartPractice(skill)}
+                  >
+                    Start Practice
+                  </Button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/alchymine/web/src/components/healing/__tests__/BreathworkGuide.test.tsx
+++ b/alchymine/web/src/components/healing/__tests__/BreathworkGuide.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import BreathworkGuide, {
+  BreathPattern,
+  DEFAULT_PATTERNS,
+} from "../BreathworkGuide";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const shortPattern: BreathPattern = {
+  name: "Test Pattern",
+  description: "A test breath pattern",
+  phases: [
+    { label: "Inhale", seconds: 1 },
+    { label: "Exhale", seconds: 1 },
+  ],
+  cycles: 1,
+};
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("BreathworkGuide", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("renders idle state with pattern details", () => {
+    render(<BreathworkGuide pattern={shortPattern} />);
+
+    expect(screen.getByTestId("breathwork-guide-idle")).toBeInTheDocument();
+    expect(screen.getByText("Test Pattern")).toBeInTheDocument();
+    expect(screen.getByText("A test breath pattern")).toBeInTheDocument();
+    expect(screen.getByText("Inhale 1s")).toBeInTheDocument();
+    expect(screen.getByText("Exhale 1s")).toBeInTheDocument();
+    expect(screen.getByText("1 cycles")).toBeInTheDocument();
+  });
+
+  it("shows Begin and Back buttons in idle state", () => {
+    const onExit = jest.fn();
+    render(<BreathworkGuide pattern={shortPattern} onExit={onExit} />);
+
+    expect(screen.getByText("Begin")).toBeInTheDocument();
+    expect(screen.getByText("Back")).toBeInTheDocument();
+  });
+
+  it("transitions to running state on Begin click", () => {
+    render(<BreathworkGuide pattern={shortPattern} />);
+    fireEvent.click(screen.getByText("Begin"));
+
+    expect(screen.getByTestId("breathwork-guide-running")).toBeInTheDocument();
+    expect(screen.getByText("Cycle 1 of 1")).toBeInTheDocument();
+  });
+
+  it("displays current phase label while running", () => {
+    render(<BreathworkGuide pattern={shortPattern} />);
+    fireEvent.click(screen.getByText("Begin"));
+
+    expect(screen.getByText("Inhale")).toBeInTheDocument();
+  });
+
+  it("shows End Session button while running", () => {
+    render(<BreathworkGuide pattern={shortPattern} />);
+    fireEvent.click(screen.getByText("Begin"));
+
+    expect(screen.getByText("End Session")).toBeInTheDocument();
+  });
+
+  it("calls onExit when Back is clicked in idle", () => {
+    const onExit = jest.fn();
+    render(<BreathworkGuide pattern={shortPattern} onExit={onExit} />);
+    fireEvent.click(screen.getByText("Back"));
+
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it("exports DEFAULT_PATTERNS with known patterns", () => {
+    expect(DEFAULT_PATTERNS).toHaveLength(3);
+    expect(DEFAULT_PATTERNS.map((p) => p.name)).toContain(
+      "Box Breathing (4-4-4-4)",
+    );
+    expect(DEFAULT_PATTERNS.map((p) => p.name)).toContain(
+      "Coherence Breathing",
+    );
+  });
+
+  it("renders SVG circle elements for the breathing animation", () => {
+    render(<BreathworkGuide pattern={shortPattern} />);
+    fireEvent.click(screen.getByText("Begin"));
+
+    // The component renders an SVG with circle elements
+    const svg = screen.getByTestId("breathwork-guide-running").querySelector("svg");
+    expect(svg).toBeInTheDocument();
+  });
+
+  it("renders the animated breathing div", () => {
+    render(<BreathworkGuide pattern={shortPattern} />);
+    fireEvent.click(screen.getByText("Begin"));
+
+    // There should be a timer role element
+    const timer = screen.getByRole("timer");
+    expect(timer).toBeInTheDocument();
+  });
+});

--- a/alchymine/web/src/components/healing/__tests__/JournalEntryActions.test.tsx
+++ b/alchymine/web/src/components/healing/__tests__/JournalEntryActions.test.tsx
@@ -1,0 +1,159 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import JournalEntryActions from "../JournalEntryActions";
+import { JournalEntry } from "@/lib/api";
+
+// ── Mock the API module ──────────────────────────────────────────────
+
+jest.mock("@/lib/api", () => ({
+  updateJournalEntry: jest.fn(() =>
+    Promise.resolve({
+      ...mockEntry,
+      title: "Updated Title",
+      content: "Updated Content",
+    }),
+  ),
+  deleteJournalEntry: jest.fn(() => Promise.resolve()),
+}));
+
+const { updateJournalEntry, deleteJournalEntry } =
+  jest.requireMock("@/lib/api");
+
+// ── Test data ────────────────────────────────────────────────────────
+
+const mockEntry: JournalEntry = {
+  id: "entry-123",
+  user_id: "user-456",
+  system: "healing",
+  entry_type: "practice-log",
+  title: "Morning Breathwork",
+  content: "Completed 8 cycles of box breathing today.",
+  tags: ["breathwork", "morning"],
+  mood_score: 7,
+  created_at: "2026-04-08T09:00:00Z",
+  updated_at: "2026-04-08T09:00:00Z",
+};
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("JournalEntryActions", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the entry in view mode with edit/delete buttons", () => {
+    render(<JournalEntryActions entry={mockEntry} />);
+
+    expect(screen.getByText("Morning Breathwork")).toBeInTheDocument();
+    expect(
+      screen.getByText("Completed 8 cycles of box breathing today."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Mood: 7/10")).toBeInTheDocument();
+    expect(screen.getByText("breathwork")).toBeInTheDocument();
+    expect(screen.getByText("morning")).toBeInTheDocument();
+    expect(screen.getByTestId("journal-edit-btn")).toBeInTheDocument();
+    expect(screen.getByTestId("journal-delete-btn")).toBeInTheDocument();
+  });
+
+  it("shows edit form when Edit is clicked", () => {
+    render(<JournalEntryActions entry={mockEntry} />);
+    fireEvent.click(screen.getByTestId("journal-edit-btn"));
+
+    expect(screen.getByTestId("journal-edit-form")).toBeInTheDocument();
+    expect(screen.getByTestId("journal-edit-title")).toHaveValue(
+      "Morning Breathwork",
+    );
+    expect(screen.getByTestId("journal-edit-content")).toHaveValue(
+      "Completed 8 cycles of box breathing today.",
+    );
+    expect(screen.getByTestId("journal-edit-mood")).toHaveValue(7);
+  });
+
+  it("calls updateJournalEntry on save and invokes onUpdated", async () => {
+    const onUpdated = jest.fn();
+    render(<JournalEntryActions entry={mockEntry} onUpdated={onUpdated} />);
+
+    fireEvent.click(screen.getByTestId("journal-edit-btn"));
+
+    // Modify the title
+    fireEvent.change(screen.getByTestId("journal-edit-title"), {
+      target: { value: "Updated Title" },
+    });
+
+    fireEvent.click(screen.getByTestId("journal-save-btn"));
+
+    await waitFor(() => {
+      expect(updateJournalEntry).toHaveBeenCalledWith("entry-123", {
+        title: "Updated Title",
+        content: "Completed 8 cycles of box breathing today.",
+        mood_score: 7,
+      });
+    });
+
+    await waitFor(() => {
+      expect(onUpdated).toHaveBeenCalled();
+    });
+  });
+
+  it("returns to view mode on Cancel in edit form", () => {
+    render(<JournalEntryActions entry={mockEntry} />);
+    fireEvent.click(screen.getByTestId("journal-edit-btn"));
+
+    expect(screen.getByTestId("journal-edit-form")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Cancel"));
+
+    expect(screen.getByTestId("journal-entry-actions")).toBeInTheDocument();
+  });
+
+  it("shows delete confirmation when Delete is clicked", () => {
+    render(<JournalEntryActions entry={mockEntry} />);
+    fireEvent.click(screen.getByTestId("journal-delete-btn"));
+
+    expect(screen.getByTestId("journal-delete-confirm")).toBeInTheDocument();
+    expect(
+      screen.getByText("Delete this journal entry?"),
+    ).toBeInTheDocument();
+  });
+
+  it("calls deleteJournalEntry on confirm and invokes onDeleted", async () => {
+    const onDeleted = jest.fn();
+    render(<JournalEntryActions entry={mockEntry} onDeleted={onDeleted} />);
+
+    fireEvent.click(screen.getByTestId("journal-delete-btn"));
+    fireEvent.click(screen.getByTestId("journal-confirm-delete-btn"));
+
+    await waitFor(() => {
+      expect(deleteJournalEntry).toHaveBeenCalledWith("entry-123");
+    });
+
+    await waitFor(() => {
+      expect(onDeleted).toHaveBeenCalledWith("entry-123");
+    });
+  });
+
+  it("returns to view mode when Cancel is clicked on delete confirmation", () => {
+    render(<JournalEntryActions entry={mockEntry} />);
+    fireEvent.click(screen.getByTestId("journal-delete-btn"));
+
+    expect(screen.getByTestId("journal-delete-confirm")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Cancel"));
+
+    expect(screen.getByTestId("journal-entry-actions")).toBeInTheDocument();
+  });
+
+  it("handles entry without mood_score gracefully", () => {
+    const noMoodEntry = { ...mockEntry, mood_score: null };
+    render(<JournalEntryActions entry={noMoodEntry} />);
+
+    expect(screen.queryByText(/Mood:/)).not.toBeInTheDocument();
+  });
+
+  it("handles entry without tags gracefully", () => {
+    const noTagsEntry = { ...mockEntry, tags: [] };
+    render(<JournalEntryActions entry={noTagsEntry} />);
+
+    // No tag elements rendered
+    expect(screen.queryByText("breathwork")).not.toBeInTheDocument();
+  });
+});

--- a/alchymine/web/src/components/healing/__tests__/MoodSparkline.test.tsx
+++ b/alchymine/web/src/components/healing/__tests__/MoodSparkline.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen } from "@testing-library/react";
+import MoodSparkline from "../MoodSparkline";
+
+// ── Test data ────────────────────────────────────────────────────────
+
+const sampleData = [
+  { date: "2026-04-01", score: 5 },
+  { date: "2026-04-02", score: 7 },
+  { date: "2026-04-03", score: 6 },
+  { date: "2026-04-04", score: 8 },
+  { date: "2026-04-05", score: 7 },
+  { date: "2026-04-06", score: 9 },
+];
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("MoodSparkline", () => {
+  it("renders the sparkline with data", () => {
+    render(<MoodSparkline data={sampleData} />);
+
+    const container = screen.getByTestId("mood-sparkline");
+    expect(container).toBeInTheDocument();
+  });
+
+  it("renders an SVG element", () => {
+    render(<MoodSparkline data={sampleData} />);
+
+    const svg = screen.getByRole("img");
+    expect(svg).toBeInTheDocument();
+    expect(svg.tagName).toBe("svg");
+  });
+
+  it("shows average score", () => {
+    // average = (5+7+6+8+7+9)/6 = 7.0
+    render(<MoodSparkline data={sampleData} />);
+
+    expect(screen.getByText("avg 7.0")).toBeInTheDocument();
+  });
+
+  it("renders empty state when no data is provided", () => {
+    render(<MoodSparkline data={[]} />);
+
+    expect(screen.getByTestId("mood-sparkline-empty")).toBeInTheDocument();
+    expect(screen.getByText("No mood data")).toBeInTheDocument();
+  });
+
+  it("renders empty state for invalid scores", () => {
+    render(<MoodSparkline data={[{ date: "2026-04-01", score: 0 }]} />);
+
+    expect(screen.getByTestId("mood-sparkline-empty")).toBeInTheDocument();
+  });
+
+  it("displays optional label", () => {
+    render(<MoodSparkline data={sampleData} label="14d mood" />);
+
+    expect(screen.getByText("14d mood")).toBeInTheDocument();
+  });
+
+  it("uses custom dimensions", () => {
+    render(<MoodSparkline data={sampleData} width={200} height={50} />);
+
+    const svg = screen.getByRole("img");
+    expect(svg).toHaveAttribute("width", "200");
+    expect(svg).toHaveAttribute("height", "50");
+  });
+
+  it("renders dots for each data point", () => {
+    render(<MoodSparkline data={sampleData} />);
+
+    const svg = screen.getByRole("img");
+    const circles = svg.querySelectorAll("circle");
+    expect(circles).toHaveLength(6);
+  });
+
+  it("renders a polyline for the trend line", () => {
+    render(<MoodSparkline data={sampleData} />);
+
+    const svg = screen.getByRole("img");
+    const polyline = svg.querySelector("polyline");
+    expect(polyline).toBeInTheDocument();
+    expect(polyline?.getAttribute("stroke")).toBe("#20b2aa");
+  });
+
+  it("truncates to last 14 entries", () => {
+    const manyEntries = Array.from({ length: 20 }, (_, i) => ({
+      date: `2026-04-${String(i + 1).padStart(2, "0")}`,
+      score: (i % 10) + 1,
+    }));
+
+    render(<MoodSparkline data={manyEntries} />);
+
+    const svg = screen.getByRole("img");
+    const circles = svg.querySelectorAll("circle");
+    expect(circles).toHaveLength(14);
+  });
+
+  it("renders a filled area polygon under the line", () => {
+    render(<MoodSparkline data={sampleData} />);
+
+    const svg = screen.getByRole("img");
+    const polygon = svg.querySelector("polygon");
+    expect(polygon).toBeInTheDocument();
+  });
+
+  it("uses custom color for stroke", () => {
+    render(<MoodSparkline data={sampleData} color="#ff0000" />);
+
+    const svg = screen.getByRole("img");
+    const polyline = svg.querySelector("polyline");
+    expect(polyline?.getAttribute("stroke")).toBe("#ff0000");
+  });
+
+  it("includes accessible aria-label with average", () => {
+    render(<MoodSparkline data={sampleData} />);
+
+    const svg = screen.getByRole("img");
+    expect(svg.getAttribute("aria-label")).toContain("average 7.0");
+  });
+
+  it("renders a single data point without polygon (needs 2+ for area)", () => {
+    render(<MoodSparkline data={[{ date: "2026-04-01", score: 5 }]} />);
+
+    const svg = screen.getByRole("img");
+    const circles = svg.querySelectorAll("circle");
+    expect(circles).toHaveLength(1);
+
+    // polygon requires dots.length > 1
+    const polygon = svg.querySelector("polygon");
+    expect(polygon).not.toBeInTheDocument();
+  });
+});

--- a/alchymine/web/src/components/healing/__tests__/SkillDetailDrawer.test.tsx
+++ b/alchymine/web/src/components/healing/__tests__/SkillDetailDrawer.test.tsx
@@ -1,0 +1,155 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import SkillDetailDrawer from "../SkillDetailDrawer";
+
+// ── Mock the API module ──────────────────────────────────────────────
+
+const mockSkill = {
+  name: "breathwork-box-breathing",
+  modality: "breathwork",
+  title: "Box Breathing (4-4-4-4)",
+  description:
+    "A simple, evidence-based breathing pattern used by Navy SEALs.",
+  steps: [
+    "Sit upright with both feet on the floor.",
+    "Exhale fully through pursed lips.",
+    "Inhale slowly through the nose for a count of 4.",
+  ],
+  evidence_rating: "B" as const,
+  contraindications: ["severe asthma during an active flare"],
+  duration_minutes: 6,
+};
+
+jest.mock("@/lib/api", () => ({
+  getHealingSkill: jest.fn(() => Promise.resolve(mockSkill)),
+}));
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("SkillDetailDrawer", () => {
+  const onClose = jest.fn();
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    document.body.style.overflow = "";
+  });
+
+  it("renders hidden (off-screen) when skillName is null", () => {
+    render(<SkillDetailDrawer skillName={null} onClose={onClose} />);
+    const drawer = screen.getByTestId("skill-detail-drawer");
+    expect(drawer).toHaveClass("translate-x-full");
+  });
+
+  it("slides in and shows skill data when skillName is provided", async () => {
+    render(
+      <SkillDetailDrawer skillName="breathwork-box-breathing" onClose={onClose} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Box Breathing (4-4-4-4)")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(/evidence-based breathing pattern/),
+    ).toBeInTheDocument();
+    expect(screen.getByText("6 min")).toBeInTheDocument();
+    expect(screen.getByText("breathwork")).toBeInTheDocument();
+    expect(
+      screen.getByText("Moderate (Controlled Studies)"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders all steps as an ordered list", async () => {
+    render(
+      <SkillDetailDrawer skillName="breathwork-box-breathing" onClose={onClose} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Sit upright with both feet on the floor.")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText("Exhale fully through pursed lips."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows contraindications when present", async () => {
+    render(
+      <SkillDetailDrawer skillName="breathwork-box-breathing" onClose={onClose} />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("severe asthma during an active flare"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("calls onClose when close button is clicked", async () => {
+    render(
+      <SkillDetailDrawer skillName="breathwork-box-breathing" onClose={onClose} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Box Breathing (4-4-4-4)")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("drawer-close"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when backdrop is clicked", async () => {
+    render(
+      <SkillDetailDrawer skillName="breathwork-box-breathing" onClose={onClose} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("drawer-backdrop")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("drawer-backdrop"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose on Escape key press", async () => {
+    render(
+      <SkillDetailDrawer skillName="breathwork-box-breathing" onClose={onClose} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Box Breathing (4-4-4-4)")).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onStartPractice when Start Practice button is clicked", async () => {
+    const onStart = jest.fn();
+    render(
+      <SkillDetailDrawer
+        skillName="breathwork-box-breathing"
+        onClose={onClose}
+        onStartPractice={onStart}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Start Practice")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Start Practice"));
+    expect(onStart).toHaveBeenCalledWith(mockSkill);
+  });
+
+  it("does not show Start Practice button without onStartPractice prop", async () => {
+    render(
+      <SkillDetailDrawer skillName="breathwork-box-breathing" onClose={onClose} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Box Breathing (4-4-4-4)")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("Start Practice")).not.toBeInTheDocument();
+  });
+});

--- a/alchymine/web/src/lib/api.ts
+++ b/alchymine/web/src/lib/api.ts
@@ -506,6 +506,34 @@ export async function getBreathwork(
   );
 }
 
+// ─── Healing Skills ─────────────────────────────────────────────────
+
+export interface HealingSkill {
+  name: string;
+  modality: string;
+  title: string;
+  description: string;
+  steps: string[];
+  evidence_rating: "A" | "B" | "C" | "D";
+  contraindications: string[];
+  duration_minutes: number;
+}
+
+export async function listHealingSkills(
+  modality?: string,
+): Promise<HealingSkill[]> {
+  const params = modality
+    ? `?modality=${encodeURIComponent(modality)}`
+    : "";
+  return request<HealingSkill[]>(`${BASE}/healing/skills${params}`);
+}
+
+export async function getHealingSkill(name: string): Promise<HealingSkill> {
+  return request<HealingSkill>(
+    `${BASE}/healing/skills/${encodeURIComponent(name)}`,
+  );
+}
+
 // ─── Biorhythm ──────────────────────────────────────────────────────
 
 export interface BiorhythmResult {


### PR DESCRIPTION
## Summary
- **Issue:** #160 (T1-S5 Interactive healing UX)
- **SkillDetailDrawer**: slide-in drawer with full skill details, evidence rating, steps, contraindications
- **BreathworkGuide**: animated breathing circle with configurable patterns (Box, 4-7-8, Coherence), SVG progress ring, requestAnimationFrame-driven
- **JournalEntryActions**: inline edit form + delete confirmation dialog wired to PUT/DELETE endpoints
- **MoodSparkline**: pure SVG sparkline (last 14 entries), gradient fill, hover tooltips, computed average
- 41 new component tests, 215 frontend tests total

## Test plan
- [ ] `cd alchymine/web && npm test` — 215 tests
- [ ] `npm run lint` — lint clean

Stacked on #188. Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)