### PR TITLE
feat(healing): spiral banner, multi-dir skill loading, WCAG a11y polish

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,12 @@ STRIPE_WEBHOOK_SECRET=
 #   python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'
 ALCHYMINE_ENCRYPTION_KEY=
 
+# ─── Healing ────────────────────────────────────────────────────────────
+# Optional path to external healing skill YAML files (e.g. from
+# the healing-swarm-skills submodule).  Leave blank to use only
+# the bundled skills in alchymine/engine/healing/skills/yaml/.
+HEALING_SKILLS_EXTERNAL_DIR=
+
 # ─── Swiss Ephemeris ─────────────────────────────────────────────────────
 SWISSEPH_DATA_PATH=/usr/share/swisseph
 

--- a/alchymine/api/main.py
+++ b/alchymine/api/main.py
@@ -29,6 +29,7 @@ from alchymine.api.routers import (
     creative,
     feedback,
     healing,
+    healing_skills,
     health,
     integration,
     journal,
@@ -120,6 +121,7 @@ app.include_router(wealth.router, prefix="/api/v1", tags=["wealth"])
 app.include_router(compatibility.router, prefix="/api/v1", tags=["compatibility"])
 app.include_router(biorhythm.router, prefix="/api/v1", tags=["biorhythm"])
 app.include_router(healing.router, prefix="/api/v1", tags=["healing"])
+app.include_router(healing_skills.router, prefix="/api/v1", tags=["healing-skills"])
 app.include_router(creative.router, prefix="/api/v1", tags=["creative"])
 app.include_router(perspective.router, prefix="/api/v1", tags=["perspective"])
 app.include_router(personality.router, prefix="/api/v1", tags=["personality"])

--- a/alchymine/api/main.py
+++ b/alchymine/api/main.py
@@ -25,6 +25,7 @@ from alchymine.api.routers import (
     astrology,
     auth,
     biorhythm,
+    bridges,
     compatibility,
     creative,
     feedback,
@@ -122,6 +123,7 @@ app.include_router(compatibility.router, prefix="/api/v1", tags=["compatibility"
 app.include_router(biorhythm.router, prefix="/api/v1", tags=["biorhythm"])
 app.include_router(healing.router, prefix="/api/v1", tags=["healing"])
 app.include_router(healing_skills.router, prefix="/api/v1", tags=["healing-skills"])
+app.include_router(bridges.router, prefix="/api/v1", tags=["bridges"])
 app.include_router(creative.router, prefix="/api/v1", tags=["creative"])
 app.include_router(perspective.router, prefix="/api/v1", tags=["perspective"])
 app.include_router(personality.router, prefix="/api/v1", tags=["personality"])

--- a/alchymine/api/routers/bridges.py
+++ b/alchymine/api/routers/bridges.py
@@ -1,0 +1,106 @@
+"""Cross-system bridges API endpoints — public reference data, no auth required.
+
+Exposes the seven cross-system bridges (XS-01..XS-07) declared in
+:mod:`alchymine.engine.bridges.registry`.  Bridges are static reference
+data, so the registry is injected via a FastAPI dependency to make the
+endpoints trivially testable.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, ConfigDict, Field
+
+from alchymine.engine.bridges import (
+    BRIDGE_REGISTRY,
+    Bridge,
+    BridgeId,
+)
+
+router = APIRouter()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Response model
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class BridgeResponse(BaseModel):
+    """Wire-format representation of a :class:`Bridge`.
+
+    FastAPI cannot serialize frozen dataclasses without help, so we mirror
+    the dataclass fields here and convert via :meth:`from_bridge`.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str = Field(..., description="Stable bridge identifier, e.g. 'XS-01'")
+    name: str = Field(..., description="Short human-readable title")
+    source_system: str = Field(..., description="Producing pillar")
+    target_system: str = Field(..., description="Consuming pillar")
+    description: str = Field(..., description="What insight flows from source to target")
+    insight_keys: list[str] = Field(
+        ..., description="Source-system field names surfaced in the target"
+    )
+
+    @classmethod
+    def from_bridge(cls, bridge: Bridge) -> BridgeResponse:
+        return cls(
+            id=bridge.id,
+            name=bridge.name,
+            source_system=bridge.source_system,
+            target_system=bridge.target_system,
+            description=bridge.description,
+            insight_keys=list(bridge.insight_keys),
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Dependency
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def get_bridge_registry() -> dict[BridgeId, Bridge]:
+    """FastAPI dependency that returns the in-memory bridge registry.
+
+    Kept as a thin wrapper so tests can override it via
+    ``app.dependency_overrides`` if needed.
+    """
+    return BRIDGE_REGISTRY
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Endpoints
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@router.get("/bridges")
+async def list_bridges_endpoint(
+    source: str | None = Query(None, description="Filter by source_system"),
+    target: str | None = Query(None, description="Filter by target_system"),
+    registry: dict[BridgeId, Bridge] = Depends(get_bridge_registry),
+) -> list[BridgeResponse]:
+    """List all cross-system bridges, optionally filtered by source/target.
+
+    Filters are independent and may be combined.  An unknown system value
+    simply yields an empty list (not a 400).  Results are returned in
+    stable id order (XS-01 first).
+    """
+    bridges: list[Bridge] = [registry[bid] for bid in sorted(registry.keys())]
+    if source is not None:
+        bridges = [b for b in bridges if b.source_system == source]
+    if target is not None:
+        bridges = [b for b in bridges if b.target_system == target]
+    return [BridgeResponse.from_bridge(b) for b in bridges]
+
+
+@router.get("/bridges/{bridge_id}")
+async def get_bridge_endpoint(
+    bridge_id: str,
+    registry: dict[BridgeId, Bridge] = Depends(get_bridge_registry),
+) -> BridgeResponse:
+    """Return a single bridge by id, or 404 if not found."""
+    bridge = registry.get(bridge_id)  # type: ignore[call-overload]
+    if bridge is None:
+        raise HTTPException(status_code=404, detail=f"Bridge not found: {bridge_id}")
+    return BridgeResponse.from_bridge(bridge)

--- a/alchymine/api/routers/healing.py
+++ b/alchymine/api/routers/healing.py
@@ -1,7 +1,8 @@
 """Healing Engine API endpoints.
 
 Endpoints for healing modality listing, matching, breathwork pattern
-selection, and crisis detection. All calculations are deterministic.
+selection, crisis detection, and spiral-based healing recommendations.
+All calculations are deterministic.
 """
 
 from __future__ import annotations
@@ -30,6 +31,7 @@ from alchymine.engine.profile import (
     Intention,
     PracticeDifficulty,
 )
+from alchymine.engine.spiral.router import route_user
 
 router = APIRouter()
 
@@ -318,3 +320,135 @@ async def detect_crisis_endpoint(
     """
     result = detect_crisis(request.text)
     return _crisis_to_response(result)
+
+
+# --- Healing spiral route models -------------------------------------------------
+
+
+class HealingSpiralModality(BaseModel):
+    """A healing modality recommendation from the spiral router."""
+
+    modality: str
+    category: str
+    description: str
+    evidence_level: str
+    entry_action: str
+
+
+class HealingSpiralRouteResponse(BaseModel):
+    """Spiral-based healing recommendation response.
+
+    Combines the user's current Alchemical Spiral stage with
+    recommended healing modalities for that stage.
+    """
+
+    primary_system: str = Field(..., description="Highest-leverage system for this user")
+    healing_rank: int = Field(
+        ..., ge=1, le=5, description="Where healing ranks among the 5 systems (1=top)"
+    )
+    healing_score: float = Field(..., ge=0, le=100, description="Healing system relevance score")
+    healing_reason: str = Field(..., description="Why healing is recommended at this stage")
+    healing_entry_action: str = Field(
+        ..., description="Suggested first action for the healing system"
+    )
+    for_you_today: str = Field(..., description="Personalized daily suggestion")
+    recommended_modalities: list[HealingSpiralModality] = Field(
+        ..., description="Healing modalities matched to the user's spiral stage"
+    )
+    evidence_level: str = Field(default="strong")
+    calculation_type: str = Field(default="deterministic")
+
+
+# ── Healing-stage → modality mapping ────────────────────────────────────
+# Which modality categories are most useful given how healing ranks
+# in the spiral. If healing is primary, offer deeper modalities; if
+# it's secondary, focus on foundational ones.
+
+_HEALING_RANK_MODALITIES: dict[str, list[str]] = {
+    "primary": [
+        "breathwork",
+        "coherence_meditation",
+        "somatic_practice",
+        "consciousness_journey",
+        "resilience_training",
+    ],
+    "secondary": [
+        "breathwork",
+        "coherence_meditation",
+        "sleep_healing",
+        "nature_healing",
+        "sound_healing",
+    ],
+    "tertiary": [
+        "breathwork",
+        "sleep_healing",
+        "nature_healing",
+    ],
+}
+
+
+@router.get("/healing/spiral-route")
+async def get_healing_spiral_route(
+    intention: str = Query(
+        "health",
+        description="Primary intention (career, love, purpose, money, health, family, business, legacy)",
+    ),
+    life_path: int | None = Query(None, ge=1, le=33),
+    personality_openness: float | None = Query(None, ge=0, le=100),
+    personality_neuroticism: float | None = Query(None, ge=0, le=100),
+    current_user: dict = Depends(get_current_user),
+) -> HealingSpiralRouteResponse:
+    """Return the user's current Spiral stage with healing-specific recommendations.
+
+    Runs the full Spiral routing algorithm, then extracts the healing
+    system rank and augments it with concrete modality recommendations
+    based on the user's stage.
+    """
+    spiral = route_user(
+        intention=intention,
+        life_path=life_path,
+        personality_openness=personality_openness,
+        personality_neuroticism=personality_neuroticism,
+    )
+
+    # Find healing in the ranked recommendations
+    healing_rec = next((r for r in spiral.recommendations if r.system == "healing"), None)
+    healing_rank = healing_rec.priority if healing_rec else 5
+    healing_score = healing_rec.score if healing_rec else 0.0
+    healing_reason = healing_rec.reason if healing_rec else "Healing supports all areas of growth."
+    healing_entry_action = (
+        healing_rec.entry_action if healing_rec else "Start with a short breathwork session."
+    )
+
+    # Determine tier for modality selection
+    if healing_rank <= 1:
+        tier = "primary"
+    elif healing_rank <= 3:
+        tier = "secondary"
+    else:
+        tier = "tertiary"
+
+    modality_keys = _HEALING_RANK_MODALITIES[tier]
+    recommended: list[HealingSpiralModality] = []
+    for key in modality_keys:
+        mod_def = MODALITY_REGISTRY.get(key)
+        if mod_def:
+            recommended.append(
+                HealingSpiralModality(
+                    modality=mod_def.name,
+                    category=mod_def.category,
+                    description=mod_def.description,
+                    evidence_level=mod_def.evidence_level,
+                    entry_action=healing_entry_action,
+                )
+            )
+
+    return HealingSpiralRouteResponse(
+        primary_system=spiral.primary_system,
+        healing_rank=healing_rank,
+        healing_score=healing_score,
+        healing_reason=healing_reason,
+        healing_entry_action=healing_entry_action,
+        for_you_today=spiral.for_you_today,
+        recommended_modalities=recommended,
+    )

--- a/alchymine/api/routers/healing_skills.py
+++ b/alchymine/api/routers/healing_skills.py
@@ -2,15 +2,20 @@
 
 from __future__ import annotations
 
+import logging
+from pathlib import Path
+
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from alchymine.engine.healing.skills import (
     SkillDefinition,
     SkillNotFoundError,
     SkillRegistry,
+    SkillValidationError,
     get_default_yaml_dir,
 )
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
 
 # Module-level registry, loaded on first request and reused thereafter.
@@ -18,11 +23,33 @@ _registry: SkillRegistry | None = None
 
 
 def get_skill_registry() -> SkillRegistry:
-    """FastAPI dependency that returns the lazy-loaded SkillRegistry."""
+    """FastAPI dependency that returns the lazy-loaded SkillRegistry.
+
+    Loads skills from the bundled YAML directory first, then merges in
+    any external skills from ``HEALING_SKILLS_EXTERNAL_DIR`` (if
+    configured).
+    """
     global _registry
     if _registry is None:
+        from alchymine.config import get_settings
+
         reg = SkillRegistry()
         reg.load_directory(get_default_yaml_dir())
+
+        settings = get_settings()
+        ext_dir = settings.healing_skills_external_dir
+        if ext_dir:
+            ext_path = Path(ext_dir)
+            try:
+                reg.load_directory(ext_path, replace=False)
+                logger.info(
+                    "Loaded external healing skills from %s (%d total)",
+                    ext_path,
+                    len(reg),
+                )
+            except (FileNotFoundError, SkillValidationError) as exc:
+                logger.warning("Skipping external healing skills: %s", exc)
+
         _registry = reg
     return _registry
 

--- a/alchymine/api/routers/healing_skills.py
+++ b/alchymine/api/routers/healing_skills.py
@@ -1,0 +1,50 @@
+"""Healing skills API endpoints — public reference data, no auth required."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from alchymine.engine.healing.skills import (
+    SkillDefinition,
+    SkillNotFoundError,
+    SkillRegistry,
+    get_default_yaml_dir,
+)
+
+router = APIRouter()
+
+# Module-level registry, loaded on first request and reused thereafter.
+_registry: SkillRegistry | None = None
+
+
+def get_skill_registry() -> SkillRegistry:
+    """FastAPI dependency that returns the lazy-loaded SkillRegistry."""
+    global _registry
+    if _registry is None:
+        reg = SkillRegistry()
+        reg.load_directory(get_default_yaml_dir())
+        _registry = reg
+    return _registry
+
+
+@router.get("/healing/skills")
+async def list_healing_skills(
+    modality: str | None = Query(None, description="Optional modality filter"),
+    registry: SkillRegistry = Depends(get_skill_registry),
+) -> list[SkillDefinition]:
+    """List all healing skills, optionally filtered by modality."""
+    if modality is not None:
+        return registry.list_by_modality(modality)
+    return registry.list_all()
+
+
+@router.get("/healing/skills/{name}")
+async def get_healing_skill(
+    name: str,
+    registry: SkillRegistry = Depends(get_skill_registry),
+) -> SkillDefinition:
+    """Return a single healing skill by name."""
+    try:
+        return registry.get(name)
+    except SkillNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=f"Skill not found: {name}") from exc

--- a/alchymine/config.py
+++ b/alchymine/config.py
@@ -30,6 +30,12 @@ class Settings(BaseSettings):
         env_file=".env",
         env_file_encoding="utf-8",
         case_sensitive=False,
+        # Tolerate extra vars in .env files (e.g. production envs that include
+        # docker-compose service names, deployment secrets, or other tooling
+        # vars that Settings doesn't declare). Without this, a local dev
+        # running tests with a production-style .env hits extra_forbidden
+        # errors on every Settings() instantiation.
+        extra="ignore",
     )
 
     # ── App ──────────────────────────────────────────────────────────────

--- a/alchymine/config.py
+++ b/alchymine/config.py
@@ -78,6 +78,12 @@ class Settings(BaseSettings):
     email_from: str = "noreply@alchymine.app"
     frontend_url: str = "http://localhost:3000"
 
+    # ── Healing ─────────────────────────────────────────────────────────
+    # Optional path to an external directory of healing skill YAML files.
+    # When set, the SkillRegistry will load from both the bundled
+    # ``alchymine/engine/healing/skills/yaml/`` AND this directory.
+    healing_skills_external_dir: str | None = None
+
     # ── Misc ──────────────────────────────────────────────────────────────
     auto_create_tables: bool = False
 

--- a/alchymine/engine/bridges/__init__.py
+++ b/alchymine/engine/bridges/__init__.py
@@ -1,0 +1,31 @@
+"""Cross-system bridges sub-package.
+
+Defines the 7 cross-system insight bridges (XS-01..XS-07) that describe
+how data and insights flow between Alchymine's five pillars
+(intelligence, healing, wealth, creative, perspective).
+
+Bridges are pure in-code reference data — frozen dataclasses kept in a
+module-level registry. There is no DB persistence and no I/O involved.
+"""
+
+from .registry import (
+    BRIDGE_REGISTRY,
+    Bridge,
+    BridgeId,
+    BridgeNotFoundError,
+    get_bridge,
+    list_bridges,
+    list_bridges_from,
+    list_bridges_to,
+)
+
+__all__ = [
+    "BRIDGE_REGISTRY",
+    "Bridge",
+    "BridgeId",
+    "BridgeNotFoundError",
+    "get_bridge",
+    "list_bridges",
+    "list_bridges_from",
+    "list_bridges_to",
+]

--- a/alchymine/engine/bridges/registry.py
+++ b/alchymine/engine/bridges/registry.py
@@ -1,0 +1,209 @@
+"""Cross-system bridge definitions (XS-01..XS-07).
+
+Each :class:`Bridge` describes how an insight produced by one of the five
+Alchymine pillars (intelligence, healing, wealth, creative, perspective)
+informs a downstream pillar.  The seven bridges are static reference
+data, declared as frozen dataclasses and exposed through a registry
+mapping plus convenience filters.
+
+System enum values must match the directory names under
+``alchymine/engine/`` and the names used elsewhere in the codebase
+(e.g. routers, frontend ``currentSystem`` props).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final, Literal, TypeAlias
+
+# ─────────────────────────────────────────────────────────────────────────
+# System enum
+# ─────────────────────────────────────────────────────────────────────────
+
+#: Canonical names of the five Alchymine systems.  Bridges may only
+#: reference these as ``source_system`` or ``target_system``.
+VALID_SYSTEMS: Final[frozenset[str]] = frozenset(
+    {"intelligence", "healing", "wealth", "creative", "perspective"}
+)
+
+BridgeId: TypeAlias = Literal[
+    "XS-01",
+    "XS-02",
+    "XS-03",
+    "XS-04",
+    "XS-05",
+    "XS-06",
+    "XS-07",
+]
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Errors
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class BridgeNotFoundError(Exception):
+    """Raised when a bridge id is not present in :data:`BRIDGE_REGISTRY`."""
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Dataclass
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Bridge:
+    """A single cross-system bridge.
+
+    Attributes:
+        id: Stable identifier in the form ``XS-NN``.
+        name: Short human-readable title shown in UI cards.
+        source_system: The pillar that produces the insight.
+        target_system: The pillar that consumes / surfaces the insight.
+        description: Long-form sentence describing what insight flows
+            from ``source_system`` to ``target_system``.
+        insight_keys: Tuple of field names on the source system's output
+            that get surfaced in the target system.  These are stable
+            keys that downstream consumers (other engines, the chat
+            agent, the frontend bridge panel) can rely on.
+    """
+
+    id: str
+    name: str
+    source_system: str
+    target_system: str
+    description: str
+    insight_keys: tuple[str, ...]
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Registry
+# ─────────────────────────────────────────────────────────────────────────
+
+# Bridge content is sourced from
+# ``docs/superpowers/plans/2026-03-10-track-1-healing-skills-cross-system-ux.md``
+# (Sprint 3, Task 3.1).  ``insight_keys`` are derived from each bridge's
+# stated mechanism — they name the source-system fields that the target
+# system pulls in to personalize its output.
+BRIDGE_REGISTRY: Final[dict[BridgeId, Bridge]] = {
+    "XS-01": Bridge(
+        id="XS-01",
+        name="Healing Primes Perspective",
+        source_system="healing",
+        target_system="perspective",
+        description=(
+            "Breathwork and somatic work soften rigid thinking patterns, "
+            "making Kegan stage transitions more accessible."
+        ),
+        insight_keys=("regulation_state", "somatic_readiness"),
+    ),
+    "XS-02": Bridge(
+        id="XS-02",
+        name="Numerology Selects Modality",
+        source_system="intelligence",
+        target_system="healing",
+        description=(
+            "Your Life Path number has strong affinity with specific "
+            "healing traditions. The engine pre-selects modalities "
+            "aligned to your number."
+        ),
+        insight_keys=("life_path_number", "archetype_affinity"),
+    ),
+    "XS-03": Bridge(
+        id="XS-03",
+        name="Financial Stress Routes to Somatic Release",
+        source_system="wealth",
+        target_system="healing",
+        description=(
+            "Money anxiety activates the same stress circuits as physical "
+            "threat. Somatic and breathwork practices directly address "
+            "wealth-related cortisol."
+        ),
+        insight_keys=("financial_stress_score", "anxiety_indicators"),
+    ),
+    "XS-04": Bridge(
+        id="XS-04",
+        name="Creative Expression Heals",
+        source_system="creative",
+        target_system="healing",
+        description=(
+            "Expressive healing modalities use art, movement, and writing "
+            "to access pre-verbal experience — the same materials your "
+            "Creative system works with."
+        ),
+        insight_keys=("expression_modes", "creative_themes"),
+    ),
+    "XS-05": Bridge(
+        id="XS-05",
+        name="Kegan Stage Unlocks Money Mindset",
+        source_system="perspective",
+        target_system="wealth",
+        description=(
+            "Stage 4 development (self-authoring) is the psychological "
+            "prerequisite for the generative wealth mindset. Perspective "
+            "work directly enables wealth expansion."
+        ),
+        insight_keys=("kegan_stage", "self_authoring_score"),
+    ),
+    "XS-06": Bridge(
+        id="XS-06",
+        name="Healed Expression Flows",
+        source_system="healing",
+        target_system="creative",
+        description=(
+            "Clearing somatic blocks through healing practices removes "
+            "the psychological censorship that suppresses creative output."
+        ),
+        insight_keys=("regulation_state", "inhibition_level"),
+    ),
+    "XS-07": Bridge(
+        id="XS-07",
+        name="Archetype Shapes Stage Pathway",
+        source_system="intelligence",
+        target_system="perspective",
+        description=(
+            "Your Jungian archetype has natural affinity with specific "
+            "Kegan developmental stages. Intelligence data fast-tracks "
+            "your perspective growth path."
+        ),
+        insight_keys=("archetype", "life_path_number"),
+    ),
+}
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Module-level helpers
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def get_bridge(bridge_id: str) -> Bridge:
+    """Return the bridge with the given id.
+
+    Args:
+        bridge_id: Bridge identifier (e.g. ``"XS-01"``).
+
+    Returns:
+        The matching :class:`Bridge`.
+
+    Raises:
+        BridgeNotFoundError: if ``bridge_id`` is not in the registry.
+    """
+    try:
+        return BRIDGE_REGISTRY[bridge_id]  # type: ignore[index]
+    except KeyError as exc:
+        raise BridgeNotFoundError(f"Unknown bridge id: {bridge_id}") from exc
+
+
+def list_bridges() -> tuple[Bridge, ...]:
+    """Return all bridges in stable id order (XS-01 first, XS-07 last)."""
+    return tuple(BRIDGE_REGISTRY[bid] for bid in sorted(BRIDGE_REGISTRY.keys()))
+
+
+def list_bridges_from(source_system: str) -> tuple[Bridge, ...]:
+    """Return all bridges whose ``source_system`` matches, in id order."""
+    return tuple(b for b in list_bridges() if b.source_system == source_system)
+
+
+def list_bridges_to(target_system: str) -> tuple[Bridge, ...]:
+    """Return all bridges whose ``target_system`` matches, in id order."""
+    return tuple(b for b in list_bridges() if b.target_system == target_system)

--- a/alchymine/engine/healing/skills/__init__.py
+++ b/alchymine/engine/healing/skills/__init__.py
@@ -1,0 +1,22 @@
+"""Healing skills sub-package.
+
+YAML-defined practice cards (one per healing modality) loaded by a
+`SkillRegistry`. Each skill is a structured, evidence-rated practice
+that the API and chat agents can surface to users.
+"""
+
+from .loader import (
+    SkillNotFoundError,
+    SkillRegistry,
+    SkillValidationError,
+    get_default_yaml_dir,
+)
+from .schema import SkillDefinition
+
+__all__ = [
+    "SkillDefinition",
+    "SkillNotFoundError",
+    "SkillRegistry",
+    "SkillValidationError",
+    "get_default_yaml_dir",
+]

--- a/alchymine/engine/healing/skills/loader.py
+++ b/alchymine/engine/healing/skills/loader.py
@@ -1,0 +1,85 @@
+"""Loader and registry for healing skill YAML files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from pydantic import ValidationError
+
+from .schema import SkillDefinition
+
+
+class SkillNotFoundError(KeyError):
+    """Raised when a skill name is not present in the registry."""
+
+
+class SkillValidationError(ValueError):
+    """Raised when a YAML file fails schema validation."""
+
+
+def get_default_yaml_dir() -> Path:
+    """Return the package-relative directory of seed skill YAML files."""
+    return Path(__file__).parent / "yaml"
+
+
+class SkillRegistry:
+    """In-memory registry of healing skills loaded from YAML files."""
+
+    def __init__(self) -> None:
+        self._skills: dict[str, SkillDefinition] = {}
+
+    def load_directory(self, path: Path) -> None:
+        """Replace the registry contents with all *.yaml files under `path`.
+
+        Raises:
+            FileNotFoundError: if `path` does not exist.
+            SkillValidationError: if any file fails schema validation or
+                contains a duplicate skill name.
+        """
+        if not path.exists() or not path.is_dir():
+            raise FileNotFoundError(f"Skill YAML directory not found: {path}")
+
+        loaded: dict[str, SkillDefinition] = {}
+        for yaml_path in sorted(path.glob("*.yaml")):
+            skill = _load_one(yaml_path)
+            if skill.name in loaded:
+                raise SkillValidationError(
+                    f"Duplicate skill name '{skill.name}' in {yaml_path.name}"
+                )
+            loaded[skill.name] = skill
+
+        self._skills = loaded
+
+    def get(self, name: str) -> SkillDefinition:
+        try:
+            return self._skills[name]
+        except KeyError as exc:
+            raise SkillNotFoundError(name) from exc
+
+    def list_by_modality(self, modality: str) -> list[SkillDefinition]:
+        return [s for s in self._skills.values() if s.modality == modality]
+
+    def list_all(self) -> list[SkillDefinition]:
+        return list(self._skills.values())
+
+    def __len__(self) -> int:
+        return len(self._skills)
+
+
+def _load_one(yaml_path: Path) -> SkillDefinition:
+    try:
+        with open(yaml_path, encoding="utf-8") as f:
+            raw = yaml.safe_load(f)
+    except yaml.YAMLError as exc:
+        raise SkillValidationError(f"{yaml_path.name}: invalid YAML: {exc}") from exc
+
+    if not isinstance(raw, dict):
+        raise SkillValidationError(
+            f"{yaml_path.name}: top-level YAML must be a mapping, got {type(raw).__name__}"
+        )
+
+    try:
+        return SkillDefinition.model_validate(raw)
+    except ValidationError as exc:
+        raise SkillValidationError(f"{yaml_path.name}: {exc}") from exc

--- a/alchymine/engine/healing/skills/loader.py
+++ b/alchymine/engine/healing/skills/loader.py
@@ -24,18 +24,38 @@ def get_default_yaml_dir() -> Path:
 
 
 class SkillRegistry:
-    """In-memory registry of healing skills loaded from YAML files."""
+    """In-memory registry of healing skills loaded from YAML files.
+
+    Supports loading from multiple directories. Call
+    :meth:`load_directory` once per directory; skills accumulate across
+    calls. Use ``replace=True`` (the default for backward compatibility)
+    to clear previous entries, or ``replace=False`` to merge.
+    """
 
     def __init__(self) -> None:
         self._skills: dict[str, SkillDefinition] = {}
 
-    def load_directory(self, path: Path) -> None:
-        """Replace the registry contents with all *.yaml files under `path`.
+    def load_directory(self, path: Path, *, replace: bool = True) -> None:
+        """Load all ``*.yaml`` files under *path* into the registry.
 
-        Raises:
-            FileNotFoundError: if `path` does not exist.
-            SkillValidationError: if any file fails schema validation or
-                contains a duplicate skill name.
+        Parameters
+        ----------
+        path:
+            Directory containing YAML skill definitions.
+        replace:
+            If ``True`` (default), clear existing skills before loading.
+            If ``False``, merge new skills into the existing registry.
+            Duplicate skill names raise :class:`SkillValidationError`
+            regardless of mode.
+
+        Raises
+        ------
+        FileNotFoundError
+            If *path* does not exist or is not a directory.
+        SkillValidationError
+            If any file fails schema validation or contains a duplicate
+            skill name (within the directory or vs. existing skills when
+            ``replace=False``).
         """
         if not path.exists() or not path.is_dir():
             raise FileNotFoundError(f"Skill YAML directory not found: {path}")
@@ -49,7 +69,16 @@ class SkillRegistry:
                 )
             loaded[skill.name] = skill
 
-        self._skills = loaded
+        if replace:
+            self._skills = loaded
+        else:
+            # Merge — check for cross-directory duplicates
+            for name, _skill in loaded.items():
+                if name in self._skills:
+                    raise SkillValidationError(
+                        f"Duplicate skill name '{name}' conflicts with already-loaded skill"
+                    )
+            self._skills.update(loaded)
 
     def get(self, name: str) -> SkillDefinition:
         try:

--- a/alchymine/engine/healing/skills/schema.py
+++ b/alchymine/engine/healing/skills/schema.py
@@ -1,0 +1,63 @@
+"""Pydantic schema for healing skill YAML definitions."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from alchymine.engine.healing.modalities import MODALITY_REGISTRY
+
+# Source of truth: the 15 modality keys from the existing healing engine.
+ALLOWED_MODALITIES: frozenset[str] = frozenset(MODALITY_REGISTRY.keys())
+
+EvidenceRating = Literal["A", "B", "C", "D"]
+
+
+class SkillDefinition(BaseModel):
+    """A single healing skill loaded from YAML.
+
+    Evidence rating scale:
+        A — Strong RCT / meta-analytic support
+        B — Multiple controlled studies, moderate effect sizes
+        C — Limited / observational evidence, plausible mechanism
+        D — Traditional, anecdotal, or contemplative practice (not RCT-tested)
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    name: str = Field(..., min_length=1, description="Unique slug, lowercase-with-dashes")
+    modality: str = Field(..., description="One of the 15 healing modality keys")
+    title: str = Field(..., min_length=1, description="Display name")
+    description: str = Field(..., min_length=1)
+    steps: list[str] = Field(..., min_length=1)
+    evidence_rating: EvidenceRating
+    contraindications: list[str] = Field(default_factory=list)
+    duration_minutes: int = Field(..., gt=0)
+
+    @field_validator("name")
+    @classmethod
+    def _validate_name_slug(cls, v: str) -> str:
+        if v != v.lower():
+            raise ValueError("name must be lowercase")
+        if " " in v or "_" in v:
+            raise ValueError("name must use dashes (not spaces or underscores)")
+        if not all(c.isalnum() or c == "-" for c in v):
+            raise ValueError("name must contain only [a-z0-9-]")
+        return v
+
+    @field_validator("modality")
+    @classmethod
+    def _validate_modality(cls, v: str) -> str:
+        if v not in ALLOWED_MODALITIES:
+            raise ValueError(
+                f"unknown modality '{v}'. Must be one of: {sorted(ALLOWED_MODALITIES)}"
+            )
+        return v
+
+    @field_validator("steps")
+    @classmethod
+    def _validate_steps_nonempty(cls, v: list[str]) -> list[str]:
+        if any(not s.strip() for s in v):
+            raise ValueError("steps must not contain empty strings")
+        return v

--- a/alchymine/engine/healing/skills/yaml/breathwork-box-breathing.yaml
+++ b/alchymine/engine/healing/skills/yaml/breathwork-box-breathing.yaml
@@ -1,0 +1,23 @@
+name: breathwork-box-breathing
+modality: breathwork
+title: Box Breathing (4-4-4-4)
+description: >-
+  A simple, evidence-based breathing pattern used by Navy SEALs and clinicians
+  to down-regulate the sympathetic nervous system. Each phase is held for an
+  equal count of four, producing a steady "box" rhythm that improves heart-rate
+  variability and focus.
+steps:
+  - Sit upright with both feet on the floor and hands resting on your thighs.
+  - Exhale fully through pursed lips to empty the lungs.
+  - Inhale slowly through the nose for a count of 4.
+  - Hold the breath gently for a count of 4 (do not strain).
+  - Exhale through the mouth for a count of 4.
+  - Hold empty for a count of 4 before the next inhale.
+  - Repeat for 8 cycles, then breathe normally and notice any shift.
+evidence_rating: B
+contraindications:
+  - severe asthma during an active flare
+  - panic disorder triggered by breath retention
+  - uncontrolled epilepsy
+  - late-stage pregnancy (consult clinician before breath holds)
+duration_minutes: 6

--- a/alchymine/engine/healing/skills/yaml/coherence-heart-focused-breathing.yaml
+++ b/alchymine/engine/healing/skills/yaml/coherence-heart-focused-breathing.yaml
@@ -1,0 +1,20 @@
+name: coherence-heart-focused-breathing
+modality: coherence_meditation
+title: Heart-Focused Breathing for Coherence
+description: >-
+  A HeartMath-derived practice that combines slow rhythmic breathing with a
+  focus on the heart area and a sustained positive feeling. Multiple controlled
+  studies show it improves heart-rate variability coherence and self-reported
+  emotional regulation within minutes.
+steps:
+  - Find a quiet seat and bring your attention to the centre of the chest.
+  - Imagine the breath flowing in and out through the heart area.
+  - Inhale for 5 seconds, exhale for 5 seconds, in a smooth even rhythm.
+  - After 1-2 minutes of steady breathing, recall a feeling of appreciation, care, or gratitude — for a person, place, or moment.
+  - Hold that feeling alongside the rhythmic breathing for 3-5 minutes.
+  - Notice the texture of any shift before opening your eyes.
+evidence_rating: B
+contraindications:
+  - acute psychosis
+  - severe dissociative disorder
+duration_minutes: 7

--- a/alchymine/engine/healing/skills/yaml/community-deep-listening-pair.yaml
+++ b/alchymine/engine/healing/skills/yaml/community-deep-listening-pair.yaml
@@ -1,0 +1,22 @@
+name: community-deep-listening-pair
+modality: community_healing
+title: Deep Listening Pair Practice
+description: >-
+  A structured 20-minute pair practice in which two people take turns speaking
+  and listening without interruption, advice, or response. Drawn from talking-circle
+  traditions and group-therapy research, it builds relational repair, empathy,
+  and the experience of being heard without being fixed.
+steps:
+  - Find a willing partner — friend, family member, or peer support contact.
+  - Sit facing each other in a quiet space and put phones away.
+  - Decide who speaks first. Set a 6-minute timer.
+  - The speaker shares whatever is alive for them. The listener says nothing — only listens with soft eyes and an open posture.
+  - When the timer ends, the listener simply says, "Thank you for sharing." No advice, no questions, no rebuttal.
+  - Reset the timer and switch roles.
+  - After both rounds, take 1 minute of silence together before resuming normal conversation.
+evidence_rating: C
+contraindications:
+  - severe social anxiety disorder (try with a clinician first)
+  - active paranoid ideation
+  - relationships with active intimate-partner abuse (do not use within those relationships)
+duration_minutes: 20

--- a/alchymine/engine/healing/skills/yaml/consciousness-yoga-nidra.yaml
+++ b/alchymine/engine/healing/skills/yaml/consciousness-yoga-nidra.yaml
@@ -1,0 +1,22 @@
+name: consciousness-yoga-nidra
+modality: consciousness_journey
+title: Yoga Nidra Body Scan and Sankalpa
+description: >-
+  A traditional Yogic practice of "yogic sleep" — a guided body-scan that
+  brings the practitioner to the threshold between waking and sleep while
+  remaining aware. Modern research shows benefits for sleep quality, anxiety,
+  and parasympathetic tone.
+steps:
+  - Lie flat on your back with a small pillow under your head and a blanket nearby.
+  - Set a single short intention (sankalpa) in present tense — for example, "I am at ease".
+  - Beginning with the right thumb, move your attention slowly through every part of the body, naming each silently.
+  - Continue through fingers, hand, arm, shoulder, then repeat on the left side.
+  - Move through the back, front of the torso, legs, and feet at an unhurried pace.
+  - Rest in whole-body awareness for 2 minutes, then silently repeat your sankalpa three times.
+  - Bring small movements back to fingers and toes before opening the eyes.
+evidence_rating: B
+contraindications:
+  - schizophrenia or active psychotic episode
+  - unmedicated bipolar disorder
+  - severe dissociative disorder
+duration_minutes: 30

--- a/alchymine/engine/healing/skills/yaml/expressive-morning-pages.yaml
+++ b/alchymine/engine/healing/skills/yaml/expressive-morning-pages.yaml
@@ -1,0 +1,22 @@
+name: expressive-morning-pages
+modality: expressive_healing
+title: Morning Pages — Three Pages of Stream Writing
+description: >-
+  A daily expressive writing practice popularised by Julia Cameron — three pages
+  of unedited longhand writing first thing in the morning. Expressive writing
+  has solid evidence for reducing rumination, improving mood, and clarifying
+  decisions when practiced consistently.
+steps:
+  - Place a notebook and pen at your bedside the night before.
+  - On waking, sit up and start writing without checking your phone first.
+  - Write three full pages in longhand — whatever comes, exactly as it comes.
+  - Do not stop, edit, censor, or judge what appears on the page.
+  - If you have nothing to say, write "I have nothing to say" until something else surfaces.
+  - When the third page is complete, close the notebook and continue your morning.
+  - Do not re-read the pages for at least one week.
+evidence_rating: B
+contraindications:
+  - acute psychosis with disorganised thought
+  - severe perfectionism that turns the practice into self-criticism (try with a clinician)
+  - early-recovery from disordered eating where journaling triggers obsessive self-monitoring
+duration_minutes: 25

--- a/alchymine/engine/healing/skills/yaml/grief-letter-to-loss.yaml
+++ b/alchymine/engine/healing/skills/yaml/grief-letter-to-loss.yaml
@@ -1,0 +1,22 @@
+name: grief-letter-to-loss
+modality: grief_healing
+title: A Letter to What Has Been Lost
+description: >-
+  An expressive writing practice from grief therapy in which the bereaved
+  writes an unsent letter to the person, relationship, role, or place they
+  have lost. Expressive writing for grief has moderate research support for
+  reducing intrusive thoughts and improving meaning-making over weeks of practice.
+steps:
+  - Choose 30 quiet, uninterrupted minutes in a private space.
+  - Have tissues, water, and something to ground you nearby (a photo, an object).
+  - At the top of a page, write "Dear ____," addressing what or who you have lost.
+  - Write continuously for 15 minutes — what you miss, what you wish you had said, what you carry forward, what you release.
+  - Do not edit; spelling and grammar do not matter here.
+  - When you finish, sit quietly. You may keep, burn, or bury the letter as feels right.
+  - Take a slow walk or call a trusted person before returning to ordinary tasks.
+evidence_rating: B
+contraindications:
+  - bereavement within the last 48 hours (use crisis support instead)
+  - complicated grief with active suicidal ideation
+  - history of self-harm triggered by writing about loss (do with a clinician)
+duration_minutes: 35

--- a/alchymine/engine/healing/skills/yaml/inquiry-self-inquiry-who-am-i.yaml
+++ b/alchymine/engine/healing/skills/yaml/inquiry-self-inquiry-who-am-i.yaml
@@ -1,0 +1,24 @@
+name: inquiry-self-inquiry-who-am-i
+modality: contemplative_inquiry
+title: Atma Vichara — "Who Am I?" Self-Inquiry
+description: >-
+  A traditional Advaita Vedanta contemplative practice taught by Ramana
+  Maharshi. The practitioner repeatedly asks the question "Who am I?" and
+  rests in the silence the question opens, rather than seeking a verbal answer.
+  This is an advanced contemplative tradition with no RCT evidence base, but
+  centuries of contemplative use across Indian wisdom traditions.
+steps:
+  - Sit quietly with eyes closed or softly open in a comfortable upright posture.
+  - Take three slow breaths to settle attention in the body.
+  - Inwardly ask, "Who am I?" Do not try to answer with words.
+  - Whenever a thought, image, or self-concept arises, gently ask, "To whom does this arise?"
+  - Let attention rest on the source of the questioning, not on any answer.
+  - When attention drifts, return to the question without self-criticism.
+  - End by sitting in silence for 1 minute, then take three breaths and gently re-engage the room.
+evidence_rating: D
+contraindications:
+  - active depersonalisation or derealisation disorder
+  - acute existential crisis or suicidal ideation
+  - first weeks of grief (use grief-specific practices instead)
+  - history of dissociative episodes triggered by silent meditation
+duration_minutes: 20

--- a/alchymine/engine/healing/skills/yaml/language-cognitive-reframe.yaml
+++ b/alchymine/engine/healing/skills/yaml/language-cognitive-reframe.yaml
@@ -1,0 +1,20 @@
+name: language-cognitive-reframe
+modality: language_awareness
+title: Cognitive Reframe of an Automatic Thought
+description: >-
+  A short journaling practice from cognitive behavioural therapy that surfaces
+  habitual self-talk and rewrites it in language that is more accurate and less
+  catastrophising. The technique is well-supported by RCTs for mild-to-moderate
+  anxiety and low mood.
+steps:
+  - Notice a recent moment when you felt strong unpleasant emotion.
+  - Write down the automatic thought that ran through your mind in that moment, word-for-word.
+  - Underline any absolutist words ("always", "never", "must", "everyone", "nothing").
+  - Ask three questions in writing — What is the evidence for this? What is the evidence against? What would I tell a friend with this thought?
+  - Rewrite the thought in language that is true, fair, and uses concrete specifics instead of absolutes.
+  - Read the new sentence aloud once and notice how the body responds.
+evidence_rating: A
+contraindications:
+  - active speech therapy for trauma-related mutism
+  - acute trauma flashbacks (use grounding first)
+duration_minutes: 12

--- a/alchymine/engine/healing/skills/yaml/nature-shinrin-yoku-walk.yaml
+++ b/alchymine/engine/healing/skills/yaml/nature-shinrin-yoku-walk.yaml
@@ -1,0 +1,21 @@
+name: nature-shinrin-yoku-walk
+modality: nature_healing
+title: Shinrin-yoku Forest Bathing Walk
+description: >-
+  A slow, sensory-led walk in a forested or wooded area, drawn from the
+  Japanese practice of shinrin-yoku ("forest bathing"). RCTs show measurable
+  reductions in cortisol, blood pressure, and self-reported stress after a
+  single session of 1-2 hours in a wooded environment.
+steps:
+  - Find a wooded park, forest, or tree-lined trail and put your phone on silent.
+  - Walk much more slowly than usual — about half your normal pace.
+  - For the first 5 minutes, simply notice 3 sights, 3 sounds, and 3 smells.
+  - Pause beside a tree and place a hand on the bark. Stay for 1 minute.
+  - Continue walking, letting attention rest on textures, light through leaves, and the sensation of air on the skin.
+  - Sit somewhere quiet for the final 5 minutes and breathe normally before returning.
+evidence_rating: A
+contraindications:
+  - severe agoraphobia
+  - anaphylactic environmental allergies (insect stings, pollen) without medication on hand
+  - mobility impairment incompatible with uneven terrain
+duration_minutes: 60

--- a/alchymine/engine/healing/skills/yaml/pni-stress-recovery-mapping.yaml
+++ b/alchymine/engine/healing/skills/yaml/pni-stress-recovery-mapping.yaml
@@ -1,0 +1,20 @@
+name: pni-stress-recovery-mapping
+modality: pni_mapping
+title: Stress and Recovery Mapping (PNI Journal)
+description: >-
+  A weekly journaling exercise informed by psychoneuroimmunology research.
+  By tracking stress, sleep, immune symptoms, and mood together, the practitioner
+  surfaces patterns linking mental states to physical wellbeing — useful as
+  data for self-understanding, not as a diagnostic tool.
+steps:
+  - At the end of each day, rate today's stress (1-10), sleep quality last night (1-10), and mood (1-10) in a notebook or app.
+  - Write one sentence describing the most stressful event and one describing the most restorative moment.
+  - Note any physical symptoms (headache, digestive change, muscle tension, illness).
+  - At the end of the week, look back at all 7 entries and circle patterns that repeat.
+  - Choose ONE small experiment for the coming week (earlier sleep, mid-day walk, evening stretch) and commit in writing.
+  - Notice without judgement; this is observation, not self-improvement pressure.
+evidence_rating: C
+contraindications:
+  - active autoimmune flare without medical supervision
+  - history of using journaling to ruminate or self-monitor obsessively
+duration_minutes: 10

--- a/alchymine/engine/healing/skills/yaml/resilience-cold-exposure-protocol.yaml
+++ b/alchymine/engine/healing/skills/yaml/resilience-cold-exposure-protocol.yaml
@@ -1,0 +1,23 @@
+name: resilience-cold-exposure-protocol
+modality: resilience_training
+title: Graded Cold Exposure for Stress Inoculation
+description: >-
+  A graded shower protocol that uses brief, voluntary cold exposure to train
+  parasympathetic recovery and tolerance for discomfort. Multiple controlled
+  trials suggest modest but real benefits for mood, sick-day frequency, and
+  perceived resilience when practiced consistently.
+steps:
+  - Take your normal warm shower first, washing as usual.
+  - At the end, lower the temperature gradually until the water is cold but tolerable.
+  - Stand under the cold stream for 30 seconds, breathing slowly and deeply through the nose.
+  - Notice the urge to brace or gasp — instead, soften the jaw and shoulders.
+  - Step out and dry off vigorously to rewarm.
+  - Each subsequent day, add 15 seconds until you reach 2-3 minutes total.
+evidence_rating: B
+contraindications:
+  - cardiovascular disease (uncleared)
+  - Raynaud's phenomenon
+  - pregnancy without obstetric clearance
+  - cold urticaria
+  - acute PTSD without clinical supervision
+duration_minutes: 5

--- a/alchymine/engine/healing/skills/yaml/sleep-cbt-i-wind-down.yaml
+++ b/alchymine/engine/healing/skills/yaml/sleep-cbt-i-wind-down.yaml
@@ -1,0 +1,20 @@
+name: sleep-cbt-i-wind-down
+modality: sleep_healing
+title: CBT-I Wind-Down Routine
+description: >-
+  A 30-minute pre-sleep routine drawn from cognitive behavioural therapy for
+  insomnia (CBT-I), the first-line non-pharmacological treatment for chronic
+  insomnia. The protocol cues the nervous system that sleep is imminent through
+  light, temperature, and stimulus control.
+steps:
+  - 30 minutes before intended sleep, dim all bright lights and put screens away (or use a strict night filter).
+  - Lower the room temperature toward 18-19 C and ventilate if possible.
+  - Spend 10 minutes on a quiet, non-stimulating activity (reading paper, light stretching, journaling).
+  - Write a 3-line "tomorrow list" so the mind has nowhere new to wander.
+  - Get into bed only when sleepy. If awake after 20 minutes, get up, sit somewhere dim, and return when sleepy again.
+  - Keep a consistent wake time the next morning regardless of how the night went.
+evidence_rating: A
+contraindications:
+  - untreated sleep apnoea requiring CPAP titration
+  - severe restless leg syndrome (consult clinician)
+duration_minutes: 30

--- a/alchymine/engine/healing/skills/yaml/somatic-grounding-5-4-3-2-1.yaml
+++ b/alchymine/engine/healing/skills/yaml/somatic-grounding-5-4-3-2-1.yaml
@@ -1,0 +1,20 @@
+name: somatic-grounding-5-4-3-2-1
+modality: somatic_practice
+title: 5-4-3-2-1 Sensory Grounding
+description: >-
+  A trauma-informed grounding technique that interrupts dissociation, anxious
+  spirals, and panic by anchoring attention to the immediate sensory environment.
+  Widely used in clinical settings for its simplicity and quick effect.
+steps:
+  - Plant both feet on the floor and feel the contact between feet and ground.
+  - Name 5 things you can see in the room — describe each in one short phrase.
+  - Name 4 things you can physically feel (clothing, chair, air on skin, weight of hands).
+  - Name 3 things you can hear right now, near or far.
+  - Name 2 things you can smell, or two smells you can recall vividly.
+  - Name 1 thing you can taste, or take a sip of water and name what you taste.
+  - Take one slow breath and notice the difference from when you started.
+evidence_rating: B
+contraindications:
+  - recent major surgery preventing seated posture
+  - acute physical injury at the practice site
+duration_minutes: 5

--- a/alchymine/engine/healing/skills/yaml/sound-humming-vagal-toning.yaml
+++ b/alchymine/engine/healing/skills/yaml/sound-humming-vagal-toning.yaml
@@ -1,0 +1,21 @@
+name: sound-humming-vagal-toning
+modality: sound_healing
+title: Humming Bee Breath (Bhramari) for Vagal Toning
+description: >-
+  An ancient Yogic practice that uses extended humming on the exhale to
+  stimulate the vagus nerve and produce a soothing buzz felt in the head and
+  chest. Small studies show acute reductions in heart rate, blood pressure, and
+  self-reported anxiety.
+steps:
+  - Sit upright in a comfortable cross-legged or chair position.
+  - Place your index fingers gently on the cartilage flaps in front of the ears (do not press hard).
+  - Inhale slowly through the nose for a count of 4.
+  - On the exhale, keep the lips closed and produce a steady, low-pitched "mmm" hum until the breath is fully out.
+  - Notice the vibration in the lips, palate, and skull.
+  - Repeat for 7 cycles, then sit silently for 1 minute.
+evidence_rating: C
+contraindications:
+  - sound-triggered epilepsy
+  - severe hyperacusis
+  - acute middle-ear infection
+duration_minutes: 8

--- a/alchymine/engine/healing/skills/yaml/water-warm-bath-immersion.yaml
+++ b/alchymine/engine/healing/skills/yaml/water-warm-bath-immersion.yaml
@@ -1,0 +1,23 @@
+name: water-warm-bath-immersion
+modality: water_healing
+title: Mindful Warm Bath Immersion
+description: >-
+  A simple hydrotherapy practice — a 20-minute warm bath taken with full
+  sensory attention. Studies suggest evening warm immersion can shorten sleep
+  onset and lower core temperature on exit, supporting deeper sleep.
+steps:
+  - Run a warm (not hot) bath, around 38-40 C, with the bathroom dimly lit.
+  - Optional — add a handful of unscented epsom salts and stir to dissolve.
+  - Step in slowly and let the body acclimate before fully reclining.
+  - For the first 5 minutes, simply notice the sensation of warmth, weight, and buoyancy.
+  - For the next 10 minutes, breathe long and slow, letting attention rest on the sound of water.
+  - Stay no longer than 20 minutes total to avoid overheating.
+  - On exit, dry off in a warm towel and notice the contrast as the body cools.
+evidence_rating: B
+contraindications:
+  - severe aquaphobia
+  - open wounds or active skin infections
+  - cardiovascular conditions where heat is contraindicated
+  - first-trimester pregnancy without obstetric clearance for warm immersion
+  - uncontrolled epilepsy
+duration_minutes: 25

--- a/alchymine/web/src/app/healing/page.tsx
+++ b/alchymine/web/src/app/healing/page.tsx
@@ -22,6 +22,7 @@ import {
   HealingMatchListResponse,
   OutcomeSummary,
 } from "@/lib/api";
+import SpiralBanner from "@/components/healing/SpiralBanner";
 import { useApi, useIntake, useReportStatus } from "@/lib/useApi";
 import { useAuth } from "@/lib/AuthContext";
 import ProtectedRoute from "@/components/shared/ProtectedRoute";
@@ -561,6 +562,19 @@ export default function HealingPage() {
               </p>
             </header>
           </MotionReveal>
+
+          {/* Spiral Recommendation Banner — personalized system routing */}
+          {hasIntake && (
+            <MotionReveal delay={0.08}>
+              <div className="mb-10">
+                <SpiralBanner
+                  intention={
+                    intakeIntentions[0] ?? "health"
+                  }
+                />
+              </div>
+            </MotionReveal>
+          )}
 
           {/* Generation in progress */}
           {(reportStatus === "pending" || reportStatus === "generating") && (

--- a/alchymine/web/src/components/healing/BreathworkGuide.tsx
+++ b/alchymine/web/src/components/healing/BreathworkGuide.tsx
@@ -1,0 +1,345 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import Button from "@/components/shared/Button";
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface BreathPhase {
+  label: string;
+  seconds: number;
+}
+
+export interface BreathPattern {
+  name: string;
+  description: string;
+  phases: BreathPhase[];
+  cycles: number;
+}
+
+interface BreathworkGuideProps {
+  /** Breath pattern to run. */
+  pattern: BreathPattern;
+  /** Called when all cycles are completed. */
+  onComplete?: (durationSeconds: number) => void;
+  /** Called when user exits early. */
+  onExit?: () => void;
+}
+
+// ── Default patterns from common YAML skills ────────────────────────
+
+export const DEFAULT_PATTERNS: BreathPattern[] = [
+  {
+    name: "Box Breathing (4-4-4-4)",
+    description: "Equal inhale, hold, exhale, hold pattern used by Navy SEALs.",
+    phases: [
+      { label: "Inhale", seconds: 4 },
+      { label: "Hold", seconds: 4 },
+      { label: "Exhale", seconds: 4 },
+      { label: "Hold", seconds: 4 },
+    ],
+    cycles: 8,
+  },
+  {
+    name: "4-7-8 Relaxation",
+    description: "A calming pattern that extends the exhale for deeper relaxation.",
+    phases: [
+      { label: "Inhale", seconds: 4 },
+      { label: "Hold", seconds: 7 },
+      { label: "Exhale", seconds: 8 },
+    ],
+    cycles: 4,
+  },
+  {
+    name: "Coherence Breathing",
+    description: "Simple 5-in, 5-out rhythm for heart-rate variability coherence.",
+    phases: [
+      { label: "Inhale", seconds: 5 },
+      { label: "Exhale", seconds: 5 },
+    ],
+    cycles: 12,
+  },
+];
+
+// ── Phase → circle scale mapping ────────────────────────────────────
+
+function getScale(label: string, progress: number): number {
+  const normalized = label.toLowerCase();
+  if (normalized === "inhale") return 0.55 + progress * 0.45;
+  if (normalized === "exhale") return 1.0 - progress * 0.45;
+  return 0.75; // hold phases stay mid-size
+}
+
+function getPhaseColor(label: string): string {
+  const normalized = label.toLowerCase();
+  if (normalized === "inhale") return "#20b2aa";
+  if (normalized === "exhale") return "#7b2d8e";
+  return "#DAA520"; // hold
+}
+
+// ── Component ────────────────────────────────────────────────────────
+
+export default function BreathworkGuide({
+  pattern,
+  onComplete,
+  onExit,
+}: BreathworkGuideProps) {
+  const [state, setState] = useState<"idle" | "running" | "done">("idle");
+  const [phaseIndex, setPhaseIndex] = useState(0);
+  const [cycle, setCycle] = useState(1);
+  const [elapsed, setElapsed] = useState(0); // within current phase
+  const [totalElapsed, setTotalElapsed] = useState(0);
+  const rafRef = useRef<number | null>(null);
+  const lastTickRef = useRef<number>(0);
+  const stateRef = useRef({ phaseIndex: 0, cycle: 1, elapsed: 0 });
+
+  const currentPhase = pattern.phases[phaseIndex];
+  const phaseDuration = currentPhase.seconds;
+  const progress = Math.min(elapsed / phaseDuration, 1);
+  const scale = getScale(currentPhase.label, progress);
+  const color = getPhaseColor(currentPhase.label);
+
+  // Sync ref with state
+  useEffect(() => {
+    stateRef.current = { phaseIndex, cycle, elapsed };
+  }, [phaseIndex, cycle, elapsed]);
+
+  const stop = useCallback(() => {
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+  }, []);
+
+  const tick = useCallback(
+    (now: number) => {
+      const dt = (now - lastTickRef.current) / 1000;
+      lastTickRef.current = now;
+      const { phaseIndex: pi, cycle: cy, elapsed: el } = stateRef.current;
+
+      const newElapsed = el + dt;
+      const phase = pattern.phases[pi];
+
+      if (newElapsed >= phase.seconds) {
+        // Advance to next phase
+        let nextPhase = pi + 1;
+        let nextCycle = cy;
+        if (nextPhase >= pattern.phases.length) {
+          nextPhase = 0;
+          nextCycle = cy + 1;
+          if (nextCycle > pattern.cycles) {
+            // Session complete
+            stop();
+            setState("done");
+            return;
+          }
+          setCycle(nextCycle);
+        }
+        setPhaseIndex(nextPhase);
+        setElapsed(0);
+        setTotalElapsed((t) => t + dt);
+        stateRef.current = { phaseIndex: nextPhase, cycle: nextCycle, elapsed: 0 };
+      } else {
+        setElapsed(newElapsed);
+        setTotalElapsed((t) => t + dt);
+        stateRef.current = { ...stateRef.current, elapsed: newElapsed };
+      }
+
+      rafRef.current = requestAnimationFrame(tick);
+    },
+    [pattern, stop],
+  );
+
+  const start = useCallback(() => {
+    setState("running");
+    setPhaseIndex(0);
+    setCycle(1);
+    setElapsed(0);
+    setTotalElapsed(0);
+    stateRef.current = { phaseIndex: 0, cycle: 1, elapsed: 0 };
+    lastTickRef.current = performance.now();
+    rafRef.current = requestAnimationFrame(tick);
+  }, [tick]);
+
+  useEffect(() => {
+    return stop;
+  }, [stop]);
+
+  // ── Idle / pre-start ────────────────────────────────────────────
+
+  if (state === "idle") {
+    return (
+      <div className="card-surface p-6 text-center" data-testid="breathwork-guide-idle">
+        <h2 className="font-display text-xl font-light text-text mb-1">
+          {pattern.name}
+        </h2>
+        <p className="font-body text-sm text-text/50 mb-4">{pattern.description}</p>
+
+        <div className="flex flex-wrap justify-center gap-2 mb-4">
+          {pattern.phases.map((ph, i) => (
+            <span
+              key={i}
+              className="px-2.5 py-1 rounded-full text-xs font-body border border-white/10 text-text/60"
+            >
+              {ph.label} {ph.seconds}s
+            </span>
+          ))}
+          <span className="px-2.5 py-1 rounded-full text-xs font-body border border-white/10 text-text/40">
+            {pattern.cycles} cycles
+          </span>
+        </div>
+
+        <div className="flex gap-3 justify-center">
+          <Button variant="primary" onClick={start}>
+            Begin
+          </Button>
+          {onExit && (
+            <Button variant="ghost" onClick={onExit}>
+              Back
+            </Button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // ── Done ────────────────────────────────────────────────────────
+
+  if (state === "done") {
+    const totalSec = Math.round(totalElapsed);
+    return (
+      <div className="card-surface p-6 text-center" data-testid="breathwork-guide-done">
+        <h2 className="font-display text-xl font-light mb-2">
+          <span className="text-gradient-teal">Session Complete</span>
+        </h2>
+        <p className="font-body text-sm text-text/50 mb-2">{pattern.name}</p>
+        <p className="font-body text-xs text-text/40 mb-4">
+          {pattern.cycles} cycles in {Math.floor(totalSec / 60)}m {totalSec % 60}s
+        </p>
+        <div className="flex gap-3 justify-center">
+          <Button variant="primary" onClick={start}>
+            Repeat
+          </Button>
+          <Button
+            variant="ghost"
+            onClick={() => onComplete?.(totalSec)}
+          >
+            Done
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Running ─────────────────────────────────────────────────────
+
+  const remaining = Math.max(0, phaseDuration - elapsed);
+
+  return (
+    <div
+      className="card-surface p-6 text-center"
+      role="timer"
+      aria-live="polite"
+      data-testid="breathwork-guide-running"
+    >
+      <p className="font-body text-xs text-text/40 mb-6">
+        Cycle {cycle} of {pattern.cycles}
+      </p>
+
+      {/* Animated circle */}
+      <div className="relative w-48 h-48 mx-auto mb-6">
+        {/* Background ring */}
+        <svg className="absolute inset-0" viewBox="0 0 200 200" aria-hidden="true">
+          <circle
+            cx="100"
+            cy="100"
+            r="90"
+            fill="none"
+            stroke="rgba(255,255,255,0.06)"
+            strokeWidth="3"
+          />
+          <circle
+            cx="100"
+            cy="100"
+            r="90"
+            fill="none"
+            stroke={color}
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeDasharray={`${2 * Math.PI * 90}`}
+            strokeDashoffset={`${2 * Math.PI * 90 * (1 - progress)}`}
+            className="transition-none"
+            style={{ opacity: 0.5, transform: "rotate(-90deg)", transformOrigin: "center" }}
+          />
+        </svg>
+
+        {/* Breathing circle */}
+        <div
+          className="absolute rounded-full"
+          style={{
+            inset: 18,
+            background: `radial-gradient(circle at center, ${color}20, ${color}08)`,
+            border: `2px solid ${color}44`,
+            transform: `scale(${scale})`,
+            transition: "transform 0.05s linear",
+          }}
+          aria-hidden="true"
+        />
+
+        {/* Center text */}
+        <div className="absolute inset-0 flex flex-col items-center justify-center">
+          <span
+            className="font-body text-sm uppercase tracking-wider"
+            style={{ color }}
+            aria-label={`Phase: ${currentPhase.label}`}
+          >
+            {currentPhase.label}
+          </span>
+          <span
+            className="font-display text-3xl font-light mt-1 text-text"
+            aria-label={`${Math.ceil(remaining)} seconds remaining`}
+          >
+            {Math.ceil(remaining)}
+          </span>
+        </div>
+      </div>
+
+      {/* Phase indicators */}
+      <div className="flex justify-center gap-2 mb-4 flex-wrap">
+        {pattern.phases.map((ph, idx) => (
+          <span
+            key={idx}
+            className={`px-2.5 py-1 rounded-full text-xs font-body transition-all duration-200 ${
+              idx === phaseIndex
+                ? "font-semibold border"
+                : "text-text/30 border border-transparent"
+            }`}
+            style={
+              idx === phaseIndex
+                ? {
+                    color: getPhaseColor(ph.label),
+                    background: `${getPhaseColor(ph.label)}18`,
+                    borderColor: `${getPhaseColor(ph.label)}30`,
+                  }
+                : undefined
+            }
+          >
+            {ph.label} {ph.seconds}s
+          </span>
+        ))}
+      </div>
+
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => {
+          stop();
+          setState("idle");
+          onExit?.();
+        }}
+      >
+        End Session
+      </Button>
+    </div>
+  );
+}

--- a/alchymine/web/src/components/healing/BreathworkGuide.tsx
+++ b/alchymine/web/src/components/healing/BreathworkGuide.tsx
@@ -169,32 +169,49 @@ export default function BreathworkGuide({
 
   if (state === "idle") {
     return (
-      <div className="card-surface p-6 text-center" data-testid="breathwork-guide-idle">
+      <div
+        className="card-surface p-6 text-center"
+        data-testid="breathwork-guide-idle"
+        role="region"
+        aria-label={`${pattern.name} breathwork session`}
+      >
         <h2 className="font-display text-xl font-light text-text mb-1">
           {pattern.name}
         </h2>
         <p className="font-body text-sm text-text/50 mb-4">{pattern.description}</p>
 
-        <div className="flex flex-wrap justify-center gap-2 mb-4">
+        <div
+          className="flex flex-wrap justify-center gap-2 mb-4"
+          role="list"
+          aria-label="Breathing phases"
+        >
           {pattern.phases.map((ph, i) => (
             <span
               key={i}
+              role="listitem"
               className="px-2.5 py-1 rounded-full text-xs font-body border border-white/10 text-text/60"
             >
               {ph.label} {ph.seconds}s
             </span>
           ))}
-          <span className="px-2.5 py-1 rounded-full text-xs font-body border border-white/10 text-text/40">
+          <span
+            role="listitem"
+            className="px-2.5 py-1 rounded-full text-xs font-body border border-white/10 text-text/40"
+          >
             {pattern.cycles} cycles
           </span>
         </div>
 
         <div className="flex gap-3 justify-center">
-          <Button variant="primary" onClick={start}>
+          <Button
+            variant="primary"
+            onClick={start}
+            aria-label={`Begin ${pattern.name} session`}
+          >
             Begin
           </Button>
           {onExit && (
-            <Button variant="ghost" onClick={onExit}>
+            <Button variant="ghost" onClick={onExit} aria-label="Go back">
               Back
             </Button>
           )}
@@ -208,7 +225,12 @@ export default function BreathworkGuide({
   if (state === "done") {
     const totalSec = Math.round(totalElapsed);
     return (
-      <div className="card-surface p-6 text-center" data-testid="breathwork-guide-done">
+      <div
+        className="card-surface p-6 text-center"
+        data-testid="breathwork-guide-done"
+        role="status"
+        aria-label={`Session complete. ${pattern.cycles} cycles in ${Math.floor(totalSec / 60)} minutes ${totalSec % 60} seconds.`}
+      >
         <h2 className="font-display text-xl font-light mb-2">
           <span className="text-gradient-teal">Session Complete</span>
         </h2>
@@ -217,12 +239,17 @@ export default function BreathworkGuide({
           {pattern.cycles} cycles in {Math.floor(totalSec / 60)}m {totalSec % 60}s
         </p>
         <div className="flex gap-3 justify-center">
-          <Button variant="primary" onClick={start}>
+          <Button
+            variant="primary"
+            onClick={start}
+            aria-label={`Repeat ${pattern.name} session`}
+          >
             Repeat
           </Button>
           <Button
             variant="ghost"
             onClick={() => onComplete?.(totalSec)}
+            aria-label="Mark session as done"
           >
             Done
           </Button>
@@ -305,10 +332,17 @@ export default function BreathworkGuide({
       </div>
 
       {/* Phase indicators */}
-      <div className="flex justify-center gap-2 mb-4 flex-wrap">
+      <div
+        className="flex justify-center gap-2 mb-4 flex-wrap"
+        role="tablist"
+        aria-label="Current breathing phase"
+      >
         {pattern.phases.map((ph, idx) => (
           <span
             key={idx}
+            role="tab"
+            aria-selected={idx === phaseIndex}
+            aria-label={`${ph.label} phase, ${ph.seconds} seconds${idx === phaseIndex ? ", active" : ""}`}
             className={`px-2.5 py-1 rounded-full text-xs font-body transition-all duration-200 ${
               idx === phaseIndex
                 ? "font-semibold border"
@@ -337,6 +371,7 @@ export default function BreathworkGuide({
           setState("idle");
           onExit?.();
         }}
+        aria-label="End breathwork session early"
       >
         End Session
       </Button>

--- a/alchymine/web/src/components/healing/JournalEntryActions.tsx
+++ b/alchymine/web/src/components/healing/JournalEntryActions.tsx
@@ -78,7 +78,7 @@ export default function JournalEntryActions({
 
   if (mode === "view") {
     return (
-      <div data-testid="journal-entry-actions">
+      <div data-testid="journal-entry-actions" role="region" aria-label={`Journal entry: ${entry.title}`}>
         {/* Entry display */}
         <div className="mb-4">
           <h3 className="font-display text-lg font-light text-text mb-1">
@@ -99,10 +99,15 @@ export default function JournalEntryActions({
             {entry.content}
           </p>
           {entry.tags.length > 0 && (
-            <div className="flex flex-wrap gap-1.5 mt-3">
+            <div
+              className="flex flex-wrap gap-1.5 mt-3"
+              role="list"
+              aria-label="Tags"
+            >
               {entry.tags.map((tag) => (
                 <span
                   key={tag}
+                  role="listitem"
                   className="px-2 py-0.5 rounded-full text-xs font-body bg-white/5 text-text/50 border border-white/10"
                 >
                   {tag}
@@ -167,7 +172,7 @@ export default function JournalEntryActions({
 
   if (mode === "confirm-delete") {
     return (
-      <div data-testid="journal-delete-confirm">
+      <div data-testid="journal-delete-confirm" role="alertdialog" aria-label="Confirm deletion">
         <div className="bg-red-400/10 border border-red-400/20 rounded-xl p-4 mb-4">
           <p className="font-body text-sm text-red-400 mb-1 font-medium">
             Delete this journal entry?
@@ -186,6 +191,7 @@ export default function JournalEntryActions({
             disabled={deleting}
             className="inline-flex items-center gap-1 px-4 py-2 text-sm font-body font-medium rounded-lg bg-red-500 text-white hover:bg-red-600 disabled:opacity-50 transition-colors"
             data-testid="journal-confirm-delete-btn"
+            aria-label={deleting ? "Deleting journal entry" : `Confirm delete ${entry.title}`}
           >
             {deleting ? "Deleting..." : "Yes, Delete"}
           </button>
@@ -207,7 +213,7 @@ export default function JournalEntryActions({
   // ── Edit mode ──────────────────────────────────────────────────
 
   return (
-    <div data-testid="journal-edit-form">
+    <div data-testid="journal-edit-form" role="form" aria-label={`Edit journal entry: ${entry.title}`}>
       <div className="space-y-4 mb-4">
         {/* Title */}
         <div>

--- a/alchymine/web/src/components/healing/JournalEntryActions.tsx
+++ b/alchymine/web/src/components/healing/JournalEntryActions.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import {
+  updateJournalEntry,
+  deleteJournalEntry,
+  JournalEntry,
+} from "@/lib/api";
+import Button from "@/components/shared/Button";
+
+// ── Props ────────────────────────────────────────────────────────────
+
+interface JournalEntryActionsProps {
+  /** The journal entry to act on. */
+  entry: JournalEntry;
+  /** Called after a successful update with the updated entry. */
+  onUpdated?: (updated: JournalEntry) => void;
+  /** Called after a successful deletion. */
+  onDeleted?: (entryId: string) => void;
+}
+
+// ── Component ────────────────────────────────────────────────────────
+
+export default function JournalEntryActions({
+  entry,
+  onUpdated,
+  onDeleted,
+}: JournalEntryActionsProps) {
+  const [mode, setMode] = useState<"view" | "edit" | "confirm-delete">("view");
+  const [editTitle, setEditTitle] = useState(entry.title);
+  const [editContent, setEditContent] = useState(entry.content);
+  const [editMoodScore, setEditMoodScore] = useState<number | null>(
+    entry.mood_score,
+  );
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const updated = await updateJournalEntry(entry.id, {
+        title: editTitle,
+        content: editContent,
+        mood_score: editMoodScore,
+      });
+      onUpdated?.(updated);
+      setMode("view");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save changes");
+    } finally {
+      setSaving(false);
+    }
+  }, [entry.id, editTitle, editContent, editMoodScore, onUpdated]);
+
+  const handleDelete = useCallback(async () => {
+    setDeleting(true);
+    setError(null);
+    try {
+      await deleteJournalEntry(entry.id);
+      onDeleted?.(entry.id);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete entry");
+      setDeleting(false);
+    }
+  }, [entry.id, onDeleted]);
+
+  const handleCancelEdit = useCallback(() => {
+    setEditTitle(entry.title);
+    setEditContent(entry.content);
+    setEditMoodScore(entry.mood_score);
+    setError(null);
+    setMode("view");
+  }, [entry]);
+
+  // ── View mode: show entry with edit / delete buttons ──────────
+
+  if (mode === "view") {
+    return (
+      <div data-testid="journal-entry-actions">
+        {/* Entry display */}
+        <div className="mb-4">
+          <h3 className="font-display text-lg font-light text-text mb-1">
+            {entry.title}
+          </h3>
+          <div className="flex items-center gap-2 text-xs font-body text-text/40 mb-3">
+            <span>{entry.system}</span>
+            <span aria-hidden="true">|</span>
+            <span>{entry.entry_type}</span>
+            {entry.mood_score !== null && (
+              <>
+                <span aria-hidden="true">|</span>
+                <span>Mood: {entry.mood_score}/10</span>
+              </>
+            )}
+          </div>
+          <p className="font-body text-sm text-text/70 leading-relaxed whitespace-pre-wrap">
+            {entry.content}
+          </p>
+          {entry.tags.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 mt-3">
+              {entry.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="px-2 py-0.5 rounded-full text-xs font-body bg-white/5 text-text/50 border border-white/10"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Action buttons */}
+        <div className="flex gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setMode("edit")}
+            data-testid="journal-edit-btn"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="mr-1"
+            >
+              <path d="M17 3a2.83 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
+            </svg>
+            Edit
+          </Button>
+          <button
+            onClick={() => setMode("confirm-delete")}
+            className="inline-flex items-center gap-1 px-4 py-2 text-sm font-body font-medium rounded-lg border border-red-400/30 text-red-400 hover:bg-red-400/10 transition-colors"
+            data-testid="journal-delete-btn"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M3 6h18" />
+              <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
+              <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
+            </svg>
+            Delete
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Delete confirmation ────────────────────────────────────────
+
+  if (mode === "confirm-delete") {
+    return (
+      <div data-testid="journal-delete-confirm">
+        <div className="bg-red-400/10 border border-red-400/20 rounded-xl p-4 mb-4">
+          <p className="font-body text-sm text-red-400 mb-1 font-medium">
+            Delete this journal entry?
+          </p>
+          <p className="font-body text-xs text-text/50">
+            This action cannot be undone. The entry &ldquo;{entry.title}&rdquo;
+            will be permanently removed.
+          </p>
+        </div>
+        {error && (
+          <p className="font-body text-sm text-red-400 mb-3">{error}</p>
+        )}
+        <div className="flex gap-2">
+          <button
+            onClick={handleDelete}
+            disabled={deleting}
+            className="inline-flex items-center gap-1 px-4 py-2 text-sm font-body font-medium rounded-lg bg-red-500 text-white hover:bg-red-600 disabled:opacity-50 transition-colors"
+            data-testid="journal-confirm-delete-btn"
+          >
+            {deleting ? "Deleting..." : "Yes, Delete"}
+          </button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              setError(null);
+              setMode("view");
+            }}
+          >
+            Cancel
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Edit mode ──────────────────────────────────────────────────
+
+  return (
+    <div data-testid="journal-edit-form">
+      <div className="space-y-4 mb-4">
+        {/* Title */}
+        <div>
+          <label
+            htmlFor="edit-title"
+            className="block font-body text-xs text-text/40 uppercase tracking-wider mb-1"
+          >
+            Title
+          </label>
+          <input
+            id="edit-title"
+            type="text"
+            value={editTitle}
+            onChange={(e) => setEditTitle(e.target.value)}
+            className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 font-body text-sm text-text placeholder:text-text/30 focus:outline-none focus:border-accent/50"
+            data-testid="journal-edit-title"
+          />
+        </div>
+
+        {/* Content */}
+        <div>
+          <label
+            htmlFor="edit-content"
+            className="block font-body text-xs text-text/40 uppercase tracking-wider mb-1"
+          >
+            Content
+          </label>
+          <textarea
+            id="edit-content"
+            value={editContent}
+            onChange={(e) => setEditContent(e.target.value)}
+            rows={6}
+            className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 font-body text-sm text-text placeholder:text-text/30 focus:outline-none focus:border-accent/50 resize-y"
+            data-testid="journal-edit-content"
+          />
+        </div>
+
+        {/* Mood score */}
+        <div>
+          <label
+            htmlFor="edit-mood"
+            className="block font-body text-xs text-text/40 uppercase tracking-wider mb-1"
+          >
+            Mood Score (1-10)
+          </label>
+          <input
+            id="edit-mood"
+            type="number"
+            min={1}
+            max={10}
+            value={editMoodScore ?? ""}
+            onChange={(e) => {
+              const v = e.target.value;
+              setEditMoodScore(v === "" ? null : Math.min(10, Math.max(1, Number(v))));
+            }}
+            className="w-24 bg-white/5 border border-white/10 rounded-lg px-3 py-2 font-body text-sm text-text placeholder:text-text/30 focus:outline-none focus:border-accent/50"
+            placeholder="-"
+            data-testid="journal-edit-mood"
+          />
+        </div>
+      </div>
+
+      {error && (
+        <p className="font-body text-sm text-red-400 mb-3">{error}</p>
+      )}
+
+      <div className="flex gap-2">
+        <Button
+          variant="primary"
+          size="sm"
+          loading={saving}
+          onClick={handleSave}
+          data-testid="journal-save-btn"
+        >
+          Save Changes
+        </Button>
+        <Button variant="ghost" size="sm" onClick={handleCancelEdit}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/alchymine/web/src/components/healing/MoodSparkline.tsx
+++ b/alchymine/web/src/components/healing/MoodSparkline.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useMemo } from "react";
+
+// ── Types ────────────────────────────────────────────────────────────
+
+interface MoodDataPoint {
+  /** ISO date string or label. */
+  date: string;
+  /** Mood score (1-10). */
+  score: number;
+}
+
+interface MoodSparklineProps {
+  /** Mood data points to render (newest last). Max 14 shown. */
+  data: MoodDataPoint[];
+  /** SVG width in pixels. Default 180. */
+  width?: number;
+  /** SVG height in pixels. Default 40. */
+  height?: number;
+  /** Stroke color. Default "#20b2aa" (teal accent). */
+  color?: string;
+  /** Optional label shown to the left of the sparkline. */
+  label?: string;
+}
+
+// ── Component ────────────────────────────────────────────────────────
+
+export default function MoodSparkline({
+  data,
+  width = 180,
+  height = 40,
+  color = "#20b2aa",
+  label,
+}: MoodSparklineProps) {
+  // Use up to the last 14 entries that have scores
+  const points = useMemo(() => {
+    return data.filter((d) => d.score >= 1 && d.score <= 10).slice(-14);
+  }, [data]);
+
+  const { polyline, dots, average, gradientId } = useMemo(() => {
+    if (points.length === 0) {
+      return { polyline: "", dots: [], average: null, gradientId: "" };
+    }
+
+    const id = `mood-gradient-${Math.random().toString(36).slice(2, 8)}`;
+    const padX = 4;
+    const padY = 4;
+    const innerW = width - padX * 2;
+    const innerH = height - padY * 2;
+
+    const minScore = 1;
+    const maxScore = 10;
+
+    const coords = points.map((p, i) => {
+      const x =
+        points.length === 1
+          ? width / 2
+          : padX + (i / (points.length - 1)) * innerW;
+      const y =
+        padY +
+        innerH -
+        ((p.score - minScore) / (maxScore - minScore)) * innerH;
+      return { x, y, score: p.score, date: p.date };
+    });
+
+    const line = coords.map((c) => `${c.x},${c.y}`).join(" ");
+    const avg = points.reduce((s, p) => s + p.score, 0) / points.length;
+
+    return { polyline: line, dots: coords, average: avg, gradientId: id };
+  }, [points, width, height]);
+
+  if (points.length === 0) {
+    return (
+      <div
+        className="flex items-center gap-2"
+        data-testid="mood-sparkline-empty"
+      >
+        {label && (
+          <span className="font-body text-xs text-text/40">{label}</span>
+        )}
+        <span className="font-body text-xs text-text/30 italic">
+          No mood data
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="flex items-center gap-2"
+      data-testid="mood-sparkline"
+    >
+      {label && (
+        <span className="font-body text-xs text-text/40 whitespace-nowrap">
+          {label}
+        </span>
+      )}
+      <svg
+        width={width}
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+        role="img"
+        aria-label={`Mood trend over ${points.length} entries, average ${average?.toFixed(1)}`}
+        className="flex-shrink-0"
+      >
+        <defs>
+          <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={color} stopOpacity="0.3" />
+            <stop offset="100%" stopColor={color} stopOpacity="0.02" />
+          </linearGradient>
+        </defs>
+
+        {/* Filled area under the line */}
+        {dots.length > 1 && (
+          <polygon
+            points={`${dots[0].x},${height} ${polyline} ${dots[dots.length - 1].x},${height}`}
+            fill={`url(#${gradientId})`}
+          />
+        )}
+
+        {/* Polyline */}
+        <polyline
+          points={polyline}
+          fill="none"
+          stroke={color}
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+
+        {/* Dots */}
+        {dots.map((d, i) => (
+          <circle
+            key={i}
+            cx={d.x}
+            cy={d.y}
+            r={points.length <= 7 ? 2.5 : 1.5}
+            fill={color}
+          >
+            <title>
+              {d.date}: {d.score}/10
+            </title>
+          </circle>
+        ))}
+      </svg>
+
+      {average !== null && (
+        <span className="font-body text-xs text-text/50 whitespace-nowrap">
+          avg {average.toFixed(1)}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/alchymine/web/src/components/healing/MoodSparkline.tsx
+++ b/alchymine/web/src/components/healing/MoodSparkline.tsx
@@ -75,11 +75,13 @@ export default function MoodSparkline({
       <div
         className="flex items-center gap-2"
         data-testid="mood-sparkline-empty"
+        role="img"
+        aria-label={label ? `${label}: no mood data available` : "No mood data available"}
       >
         {label && (
           <span className="font-body text-xs text-text/40">{label}</span>
         )}
-        <span className="font-body text-xs text-text/30 italic">
+        <span className="font-body text-xs text-text/30 italic" aria-hidden="true">
           No mood data
         </span>
       </div>
@@ -146,10 +148,17 @@ export default function MoodSparkline({
       </svg>
 
       {average !== null && (
-        <span className="font-body text-xs text-text/50 whitespace-nowrap">
+        <span
+          className="font-body text-xs text-text/50 whitespace-nowrap"
+          aria-label={`Average mood score: ${average.toFixed(1)} out of 10`}
+        >
           avg {average.toFixed(1)}
         </span>
       )}
+      {/* Screen-reader-only data summary */}
+      <span className="sr-only">
+        Mood entries: {points.map((p) => `${p.date}: ${p.score} out of 10`).join(", ")}.
+      </span>
     </div>
   );
 }

--- a/alchymine/web/src/components/healing/SkillDetailDrawer.tsx
+++ b/alchymine/web/src/components/healing/SkillDetailDrawer.tsx
@@ -58,6 +58,8 @@ export default function SkillDetailDrawer({
 }: SkillDetailDrawerProps) {
   const open = skillName !== null;
   const drawerRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
 
   const { data: skill, loading, error } = useApi<HealingSkill>(
     skillName ? (signal) => getHealingSkill(skillName) : null,
@@ -67,7 +69,29 @@ export default function SkillDetailDrawer({
   // Close on Escape key
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
-      if (e.key === "Escape" && open) onClose();
+      if (e.key === "Escape" && open) {
+        onClose();
+        return;
+      }
+
+      // Focus trapping: Tab / Shift+Tab within drawer
+      if (e.key === "Tab" && open && drawerRef.current) {
+        const focusable = drawerRef.current.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        );
+        if (focusable.length === 0) return;
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
     },
     [open, onClose],
   );
@@ -77,12 +101,21 @@ export default function SkillDetailDrawer({
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [handleKeyDown]);
 
-  // Trap focus inside drawer when open
+  // Lock body scroll and manage focus when open
   useEffect(() => {
     if (open) {
+      // Save current focus to restore on close
+      previousFocusRef.current = document.activeElement as HTMLElement;
       document.body.style.overflow = "hidden";
+      // Move focus into the drawer after a brief delay for the
+      // slide transition to settle.
+      requestAnimationFrame(() => {
+        closeButtonRef.current?.focus();
+      });
     } else {
       document.body.style.overflow = "";
+      // Restore focus to the element that opened the drawer
+      previousFocusRef.current?.focus();
     }
     return () => {
       document.body.style.overflow = "";
@@ -118,9 +151,10 @@ export default function SkillDetailDrawer({
             {loading ? "Loading..." : skill?.title ?? "Skill Detail"}
           </h2>
           <button
+            ref={closeButtonRef}
             onClick={onClose}
             className="text-text/40 hover:text-text/70 transition-colors p-1"
-            aria-label="Close drawer"
+            aria-label="Close skill detail drawer"
             data-testid="drawer-close"
           >
             <svg
@@ -184,7 +218,7 @@ export default function SkillDetailDrawer({
                 <h3 className="font-body text-xs text-text/40 uppercase tracking-wider mb-3">
                   Steps
                 </h3>
-                <ol className="space-y-3">
+                <ol className="space-y-3" aria-label="Practice steps">
                   {skill.steps.map((step, idx) => (
                     <li key={idx} className="flex gap-3">
                       <span className="flex-shrink-0 w-6 h-6 rounded-full bg-accent/15 text-accent text-xs font-body flex items-center justify-center border border-accent/25 mt-0.5">
@@ -200,11 +234,11 @@ export default function SkillDetailDrawer({
 
               {/* Contraindications */}
               {skill.contraindications.length > 0 && (
-                <div>
+                <div role="alert" aria-label="Contraindications warning">
                   <h3 className="font-body text-xs text-text/40 uppercase tracking-wider mb-2">
                     Contraindications
                   </h3>
-                  <ul className="space-y-1.5">
+                  <ul className="space-y-1.5" aria-label="List of contraindications">
                     {skill.contraindications.map((ci, idx) => (
                       <li
                         key={idx}

--- a/alchymine/web/src/components/healing/SkillDetailDrawer.tsx
+++ b/alchymine/web/src/components/healing/SkillDetailDrawer.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import { useEffect, useRef, useCallback } from "react";
+import { useApi } from "@/lib/useApi";
+import { getHealingSkill, HealingSkill } from "@/lib/api";
+import Button from "@/components/shared/Button";
+
+// ── Evidence rating display ─────────────────────────────────────────
+
+const EVIDENCE_LABELS: Record<string, { label: string; color: string }> = {
+  A: { label: "Strong (RCT / Meta-Analytic)", color: "#22c55e" },
+  B: { label: "Moderate (Controlled Studies)", color: "#eab308" },
+  C: { label: "Limited (Observational)", color: "#f97316" },
+  D: { label: "Traditional / Anecdotal", color: "#a78bfa" },
+};
+
+function EvidenceTag({ rating }: { rating: string }) {
+  const info = EVIDENCE_LABELS[rating] ?? {
+    label: rating,
+    color: "#94a3b8",
+  };
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-body font-medium"
+      style={{
+        background: `${info.color}18`,
+        color: info.color,
+        border: `1px solid ${info.color}30`,
+      }}
+    >
+      <span
+        className="w-1.5 h-1.5 rounded-full"
+        style={{ background: info.color }}
+        aria-hidden="true"
+      />
+      {info.label}
+    </span>
+  );
+}
+
+// ── Props ────────────────────────────────────────────────────────────
+
+interface SkillDetailDrawerProps {
+  /** Skill name slug to fetch detail for. `null` closes the drawer. */
+  skillName: string | null;
+  /** Called when the drawer should close. */
+  onClose: () => void;
+  /** Optional callback when user wants to start a practice. */
+  onStartPractice?: (skill: HealingSkill) => void;
+}
+
+// ── Component ────────────────────────────────────────────────────────
+
+export default function SkillDetailDrawer({
+  skillName,
+  onClose,
+  onStartPractice,
+}: SkillDetailDrawerProps) {
+  const open = skillName !== null;
+  const drawerRef = useRef<HTMLDivElement>(null);
+
+  const { data: skill, loading, error } = useApi<HealingSkill>(
+    skillName ? (signal) => getHealingSkill(skillName) : null,
+    [skillName],
+  );
+
+  // Close on Escape key
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape" && open) onClose();
+    },
+    [open, onClose],
+  );
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
+
+  // Trap focus inside drawer when open
+  useEffect(() => {
+    if (open) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  return (
+    <>
+      {/* Backdrop */}
+      {open && (
+        <div
+          className="fixed inset-0 bg-black/50 backdrop-blur-sm z-40 transition-opacity"
+          onClick={onClose}
+          data-testid="drawer-backdrop"
+          aria-hidden="true"
+        />
+      )}
+
+      {/* Drawer panel */}
+      <div
+        ref={drawerRef}
+        role="dialog"
+        aria-modal={open}
+        aria-label={skill?.title ?? "Skill details"}
+        className={`fixed top-0 right-0 h-full w-full max-w-md bg-bg border-l border-white/10 z-50 transform transition-transform duration-300 ease-out overflow-y-auto ${
+          open ? "translate-x-0" : "translate-x-full"
+        }`}
+        data-testid="skill-detail-drawer"
+      >
+        {/* Header */}
+        <div className="sticky top-0 bg-bg/90 backdrop-blur-md border-b border-white/5 px-6 py-4 flex items-center justify-between z-10">
+          <h2 className="font-display text-lg font-light text-text truncate">
+            {loading ? "Loading..." : skill?.title ?? "Skill Detail"}
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-text/40 hover:text-text/70 transition-colors p-1"
+            aria-label="Close drawer"
+            data-testid="drawer-close"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M18 6 6 18" />
+              <path d="m6 6 12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="p-6 space-y-6">
+          {loading && (
+            <div className="animate-pulse space-y-4" data-testid="drawer-loading">
+              <div className="h-4 bg-white/10 rounded w-3/4" />
+              <div className="h-4 bg-white/10 rounded w-1/2" />
+              <div className="h-20 bg-white/10 rounded" />
+            </div>
+          )}
+
+          {error && (
+            <div className="text-red-400 font-body text-sm" data-testid="drawer-error">
+              Failed to load skill: {error}
+            </div>
+          )}
+
+          {skill && !loading && (
+            <>
+              {/* Meta badges */}
+              <div className="flex flex-wrap gap-2">
+                <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-body bg-white/5 text-text/60 border border-white/10">
+                  {skill.modality.replace(/_/g, " ")}
+                </span>
+                <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-body bg-white/5 text-text/60 border border-white/10">
+                  {skill.duration_minutes} min
+                </span>
+                <EvidenceTag rating={skill.evidence_rating} />
+              </div>
+
+              {/* Description */}
+              <div>
+                <h3 className="font-body text-xs text-text/40 uppercase tracking-wider mb-2">
+                  Description
+                </h3>
+                <p className="font-body text-sm text-text/70 leading-relaxed">
+                  {skill.description}
+                </p>
+              </div>
+
+              {/* Steps */}
+              <div>
+                <h3 className="font-body text-xs text-text/40 uppercase tracking-wider mb-3">
+                  Steps
+                </h3>
+                <ol className="space-y-3">
+                  {skill.steps.map((step, idx) => (
+                    <li key={idx} className="flex gap-3">
+                      <span className="flex-shrink-0 w-6 h-6 rounded-full bg-accent/15 text-accent text-xs font-body flex items-center justify-center border border-accent/25 mt-0.5">
+                        {idx + 1}
+                      </span>
+                      <span className="font-body text-sm text-text/70 leading-relaxed">
+                        {step}
+                      </span>
+                    </li>
+                  ))}
+                </ol>
+              </div>
+
+              {/* Contraindications */}
+              {skill.contraindications.length > 0 && (
+                <div>
+                  <h3 className="font-body text-xs text-text/40 uppercase tracking-wider mb-2">
+                    Contraindications
+                  </h3>
+                  <ul className="space-y-1.5">
+                    {skill.contraindications.map((ci, idx) => (
+                      <li
+                        key={idx}
+                        className="flex items-start gap-2 font-body text-sm text-red-400/80"
+                      >
+                        <span className="mt-1 w-1.5 h-1.5 rounded-full bg-red-400/60 flex-shrink-0" />
+                        {ci}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {/* Action button */}
+              {onStartPractice && (
+                <div className="pt-2">
+                  <Button
+                    variant="primary"
+                    className="w-full"
+                    onClick={() => onStartPractice(skill)}
+                  >
+                    Start Practice
+                  </Button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/alchymine/web/src/components/healing/SpiralBanner.tsx
+++ b/alchymine/web/src/components/healing/SpiralBanner.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { useApi } from "@/lib/useApi";
+import {
+  getHealingSpiralRoute,
+  HealingSpiralRouteResponse,
+} from "@/lib/api";
+
+// ── System display mapping ──────────────────────────────────────────
+
+const SYSTEM_LABELS: Record<string, { label: string; icon: string }> = {
+  intelligence: { label: "Personalized Intelligence", icon: "\u{1F9E0}" },
+  healing: { label: "Ethical Healing", icon: "\u{1F33F}" },
+  wealth: { label: "Generational Wealth", icon: "\u{1F4B0}" },
+  creative: { label: "Creative Development", icon: "\u{1F3A8}" },
+  perspective: { label: "Perspective Enhancement", icon: "\u{1F52D}" },
+};
+
+const EVIDENCE_COLORS: Record<string, string> = {
+  strong: "#22c55e",
+  moderate: "#eab308",
+  emerging: "#f97316",
+  traditional: "#a78bfa",
+};
+
+// ── Props ───────────────────────────────────────────────────────────
+
+interface SpiralBannerProps {
+  /** User's primary intention for routing. */
+  intention?: string;
+  /** Numerology life path number. */
+  lifePath?: number;
+  /** Big Five openness score. */
+  personalityOpenness?: number;
+  /** Big Five neuroticism score. */
+  personalityNeuroticism?: number;
+}
+
+// ── Component ───────────────────────────────────────────────────────
+
+export default function SpiralBanner({
+  intention = "health",
+  lifePath,
+  personalityOpenness,
+  personalityNeuroticism,
+}: SpiralBannerProps) {
+  const { data, loading, error } = useApi<HealingSpiralRouteResponse>(
+    (signal) =>
+      getHealingSpiralRoute({
+        intention,
+        lifePath,
+        personalityOpenness,
+        personalityNeuroticism,
+      }),
+    [intention, lifePath, personalityOpenness, personalityNeuroticism],
+  );
+
+  // Loading state
+  if (loading) {
+    return (
+      <div
+        className="card-surface border border-accent/10 p-6 animate-pulse"
+        data-testid="spiral-banner-loading"
+        role="status"
+        aria-label="Loading spiral recommendations"
+      >
+        <div className="h-5 bg-white/10 rounded w-1/3 mb-3" />
+        <div className="h-4 bg-white/10 rounded w-2/3 mb-2" />
+        <div className="h-4 bg-white/10 rounded w-1/2" />
+      </div>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <div
+        className="card-surface border border-red-400/20 p-6"
+        data-testid="spiral-banner-error"
+        role="alert"
+      >
+        <p className="font-body text-sm text-red-400">
+          Could not load spiral recommendations.
+        </p>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const primaryInfo = SYSTEM_LABELS[data.primary_system] ?? {
+    label: data.primary_system,
+    icon: "\u{2728}",
+  };
+
+  return (
+    <section
+      className="card-surface border border-accent/10 p-6 glow-teal"
+      data-testid="spiral-banner"
+      aria-labelledby="spiral-banner-heading"
+    >
+      {/* Header row */}
+      <div className="flex items-start justify-between gap-4 mb-4">
+        <div>
+          <h2
+            id="spiral-banner-heading"
+            className="font-display text-lg font-light text-text/80 flex items-center gap-2"
+          >
+            <span
+              className="w-8 h-8 rounded-lg bg-accent/10 flex items-center justify-center flex-shrink-0"
+              aria-hidden="true"
+            >
+              <svg
+                className="w-4 h-4 text-accent"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M12 2a10 10 0 0 1 0 20 10 10 0 0 1 0-20" />
+                <path d="M12 2a7 7 0 0 1 0 14 7 7 0 0 1 0-14" />
+                <path d="M12 2a4 4 0 0 1 0 8 4 4 0 0 1 0-8" />
+              </svg>
+            </span>
+            Your Alchemical Spiral
+          </h2>
+          <p className="font-body text-sm text-text/40 mt-1 ml-10">
+            Personalized recommendations based on your profile
+          </p>
+        </div>
+
+        {/* Primary system badge */}
+        <div
+          className="flex-shrink-0 text-center"
+          aria-label={`Primary system: ${primaryInfo.label}`}
+        >
+          <span className="text-2xl" aria-hidden="true">
+            {primaryInfo.icon}
+          </span>
+          <p className="font-body text-[0.65rem] text-text/40 mt-0.5">
+            Primary
+          </p>
+        </div>
+      </div>
+
+      {/* Healing stage info */}
+      <div className="bg-white/[0.03] border border-white/[0.06] rounded-xl p-4 mb-4">
+        <div className="flex items-center justify-between mb-2">
+          <h3 className="font-body text-sm font-medium text-text/70">
+            Healing System
+          </h3>
+          <div className="flex items-center gap-2">
+            <span
+              className="font-body text-xs px-2 py-0.5 rounded-full bg-accent/10 text-accent border border-accent/20"
+              aria-label={`Rank ${data.healing_rank} of 5`}
+            >
+              #{data.healing_rank} of 5
+            </span>
+            <span
+              className="font-body text-xs text-accent/70"
+              aria-label={`Score ${Math.round(data.healing_score)}`}
+            >
+              {Math.round(data.healing_score)}%
+            </span>
+          </div>
+        </div>
+        <p className="font-body text-sm text-text/50 leading-relaxed">
+          {data.healing_reason}
+        </p>
+        <p className="font-body text-xs text-accent mt-2">
+          {data.healing_entry_action}
+        </p>
+      </div>
+
+      {/* For You Today */}
+      <div className="bg-accent/5 border border-accent/10 rounded-xl p-4 mb-5">
+        <p className="font-body text-xs text-text/40 uppercase tracking-wider mb-1">
+          For You Today
+        </p>
+        <p className="font-body text-sm text-text/70 leading-relaxed">
+          {data.for_you_today}
+        </p>
+      </div>
+
+      {/* Recommended modalities */}
+      {data.recommended_modalities.length > 0 && (
+        <div>
+          <h3 className="font-body text-xs text-text/40 uppercase tracking-wider mb-3">
+            Recommended Modalities
+          </h3>
+          <ul
+            className="grid sm:grid-cols-2 gap-3"
+            role="list"
+            aria-label="Recommended healing modalities"
+          >
+            {data.recommended_modalities.map((mod) => {
+              const evColor =
+                EVIDENCE_COLORS[mod.evidence_level] ?? "#94a3b8";
+              return (
+                <li
+                  key={mod.modality}
+                  className="bg-white/[0.03] border border-white/[0.06] rounded-xl p-3 hover:border-accent/20 transition-colors"
+                >
+                  <div className="flex items-center justify-between mb-1">
+                    <h4 className="font-body text-sm font-medium text-text/70">
+                      {mod.modality.replace(/_/g, " ")}
+                    </h4>
+                    <span
+                      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[0.65rem] font-body"
+                      style={{
+                        background: `${evColor}15`,
+                        color: evColor,
+                        border: `1px solid ${evColor}25`,
+                      }}
+                      aria-label={`Evidence: ${mod.evidence_level}`}
+                    >
+                      <span
+                        className="w-1 h-1 rounded-full"
+                        style={{ background: evColor }}
+                        aria-hidden="true"
+                      />
+                      {mod.evidence_level}
+                    </span>
+                  </div>
+                  <p className="font-body text-xs text-text/40 leading-relaxed line-clamp-2">
+                    {mod.description}
+                  </p>
+                  <span className="font-body text-[0.65rem] text-text/25 mt-1 inline-block">
+                    {mod.category}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/alchymine/web/src/components/healing/__tests__/BreathworkGuide.test.tsx
+++ b/alchymine/web/src/components/healing/__tests__/BreathworkGuide.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import BreathworkGuide, {
+  BreathPattern,
+  DEFAULT_PATTERNS,
+} from "../BreathworkGuide";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const shortPattern: BreathPattern = {
+  name: "Test Pattern",
+  description: "A test breath pattern",
+  phases: [
+    { label: "Inhale", seconds: 1 },
+    { label: "Exhale", seconds: 1 },
+  ],
+  cycles: 1,
+};
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("BreathworkGuide", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("renders idle state with pattern details", () => {
+    render(<BreathworkGuide pattern={shortPattern} />);
+
+    expect(screen.getByTestId("breathwork-guide-idle")).toBeInTheDocument();
+    expect(screen.getByText("Test Pattern")).toBeInTheDocument();
+    expect(screen.getByText("A test breath pattern")).toBeInTheDocument();
+    expect(screen.getByText("Inhale 1s")).toBeInTheDocument();
+    expect(screen.getByText("Exhale 1s")).toBeInTheDocument();
+    expect(screen.getByText("1 cycles")).toBeInTheDocument();
+  });
+
+  it("shows Begin and Back buttons in idle state", () => {
+    const onExit = jest.fn();
+    render(<BreathworkGuide pattern={shortPattern} onExit={onExit} />);
+
+    expect(screen.getByText("Begin")).toBeInTheDocument();
+    expect(screen.getByText("Back")).toBeInTheDocument();
+  });
+
+  it("transitions to running state on Begin click", () => {
+    render(<BreathworkGuide pattern={shortPattern} />);
+    fireEvent.click(screen.getByText("Begin"));
+
+    expect(screen.getByTestId("breathwork-guide-running")).toBeInTheDocument();
+    expect(screen.getByText("Cycle 1 of 1")).toBeInTheDocument();
+  });
+
+  it("displays current phase label while running", () => {
+    render(<BreathworkGuide pattern={shortPattern} />);
+    fireEvent.click(screen.getByText("Begin"));
+
+    expect(screen.getByText("Inhale")).toBeInTheDocument();
+  });
+
+  it("shows End Session button while running", () => {
+    render(<BreathworkGuide pattern={shortPattern} />);
+    fireEvent.click(screen.getByText("Begin"));
+
+    expect(screen.getByText("End Session")).toBeInTheDocument();
+  });
+
+  it("calls onExit when Back is clicked in idle", () => {
+    const onExit = jest.fn();
+    render(<BreathworkGuide pattern={shortPattern} onExit={onExit} />);
+    fireEvent.click(screen.getByText("Back"));
+
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it("exports DEFAULT_PATTERNS with known patterns", () => {
+    expect(DEFAULT_PATTERNS).toHaveLength(3);
+    expect(DEFAULT_PATTERNS.map((p) => p.name)).toContain(
+      "Box Breathing (4-4-4-4)",
+    );
+    expect(DEFAULT_PATTERNS.map((p) => p.name)).toContain(
+      "Coherence Breathing",
+    );
+  });
+
+  it("renders SVG circle elements for the breathing animation", () => {
+    render(<BreathworkGuide pattern={shortPattern} />);
+    fireEvent.click(screen.getByText("Begin"));
+
+    // The component renders an SVG with circle elements
+    const svg = screen.getByTestId("breathwork-guide-running").querySelector("svg");
+    expect(svg).toBeInTheDocument();
+  });
+
+  it("renders the animated breathing div", () => {
+    render(<BreathworkGuide pattern={shortPattern} />);
+    fireEvent.click(screen.getByText("Begin"));
+
+    // There should be a timer role element
+    const timer = screen.getByRole("timer");
+    expect(timer).toBeInTheDocument();
+  });
+});

--- a/alchymine/web/src/components/healing/__tests__/JournalEntryActions.test.tsx
+++ b/alchymine/web/src/components/healing/__tests__/JournalEntryActions.test.tsx
@@ -1,0 +1,159 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import JournalEntryActions from "../JournalEntryActions";
+import { JournalEntry } from "@/lib/api";
+
+// ── Mock the API module ──────────────────────────────────────────────
+
+jest.mock("@/lib/api", () => ({
+  updateJournalEntry: jest.fn(() =>
+    Promise.resolve({
+      ...mockEntry,
+      title: "Updated Title",
+      content: "Updated Content",
+    }),
+  ),
+  deleteJournalEntry: jest.fn(() => Promise.resolve()),
+}));
+
+const { updateJournalEntry, deleteJournalEntry } =
+  jest.requireMock("@/lib/api");
+
+// ── Test data ────────────────────────────────────────────────────────
+
+const mockEntry: JournalEntry = {
+  id: "entry-123",
+  user_id: "user-456",
+  system: "healing",
+  entry_type: "practice-log",
+  title: "Morning Breathwork",
+  content: "Completed 8 cycles of box breathing today.",
+  tags: ["breathwork", "morning"],
+  mood_score: 7,
+  created_at: "2026-04-08T09:00:00Z",
+  updated_at: "2026-04-08T09:00:00Z",
+};
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("JournalEntryActions", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the entry in view mode with edit/delete buttons", () => {
+    render(<JournalEntryActions entry={mockEntry} />);
+
+    expect(screen.getByText("Morning Breathwork")).toBeInTheDocument();
+    expect(
+      screen.getByText("Completed 8 cycles of box breathing today."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Mood: 7/10")).toBeInTheDocument();
+    expect(screen.getByText("breathwork")).toBeInTheDocument();
+    expect(screen.getByText("morning")).toBeInTheDocument();
+    expect(screen.getByTestId("journal-edit-btn")).toBeInTheDocument();
+    expect(screen.getByTestId("journal-delete-btn")).toBeInTheDocument();
+  });
+
+  it("shows edit form when Edit is clicked", () => {
+    render(<JournalEntryActions entry={mockEntry} />);
+    fireEvent.click(screen.getByTestId("journal-edit-btn"));
+
+    expect(screen.getByTestId("journal-edit-form")).toBeInTheDocument();
+    expect(screen.getByTestId("journal-edit-title")).toHaveValue(
+      "Morning Breathwork",
+    );
+    expect(screen.getByTestId("journal-edit-content")).toHaveValue(
+      "Completed 8 cycles of box breathing today.",
+    );
+    expect(screen.getByTestId("journal-edit-mood")).toHaveValue(7);
+  });
+
+  it("calls updateJournalEntry on save and invokes onUpdated", async () => {
+    const onUpdated = jest.fn();
+    render(<JournalEntryActions entry={mockEntry} onUpdated={onUpdated} />);
+
+    fireEvent.click(screen.getByTestId("journal-edit-btn"));
+
+    // Modify the title
+    fireEvent.change(screen.getByTestId("journal-edit-title"), {
+      target: { value: "Updated Title" },
+    });
+
+    fireEvent.click(screen.getByTestId("journal-save-btn"));
+
+    await waitFor(() => {
+      expect(updateJournalEntry).toHaveBeenCalledWith("entry-123", {
+        title: "Updated Title",
+        content: "Completed 8 cycles of box breathing today.",
+        mood_score: 7,
+      });
+    });
+
+    await waitFor(() => {
+      expect(onUpdated).toHaveBeenCalled();
+    });
+  });
+
+  it("returns to view mode on Cancel in edit form", () => {
+    render(<JournalEntryActions entry={mockEntry} />);
+    fireEvent.click(screen.getByTestId("journal-edit-btn"));
+
+    expect(screen.getByTestId("journal-edit-form")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Cancel"));
+
+    expect(screen.getByTestId("journal-entry-actions")).toBeInTheDocument();
+  });
+
+  it("shows delete confirmation when Delete is clicked", () => {
+    render(<JournalEntryActions entry={mockEntry} />);
+    fireEvent.click(screen.getByTestId("journal-delete-btn"));
+
+    expect(screen.getByTestId("journal-delete-confirm")).toBeInTheDocument();
+    expect(
+      screen.getByText("Delete this journal entry?"),
+    ).toBeInTheDocument();
+  });
+
+  it("calls deleteJournalEntry on confirm and invokes onDeleted", async () => {
+    const onDeleted = jest.fn();
+    render(<JournalEntryActions entry={mockEntry} onDeleted={onDeleted} />);
+
+    fireEvent.click(screen.getByTestId("journal-delete-btn"));
+    fireEvent.click(screen.getByTestId("journal-confirm-delete-btn"));
+
+    await waitFor(() => {
+      expect(deleteJournalEntry).toHaveBeenCalledWith("entry-123");
+    });
+
+    await waitFor(() => {
+      expect(onDeleted).toHaveBeenCalledWith("entry-123");
+    });
+  });
+
+  it("returns to view mode when Cancel is clicked on delete confirmation", () => {
+    render(<JournalEntryActions entry={mockEntry} />);
+    fireEvent.click(screen.getByTestId("journal-delete-btn"));
+
+    expect(screen.getByTestId("journal-delete-confirm")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Cancel"));
+
+    expect(screen.getByTestId("journal-entry-actions")).toBeInTheDocument();
+  });
+
+  it("handles entry without mood_score gracefully", () => {
+    const noMoodEntry = { ...mockEntry, mood_score: null };
+    render(<JournalEntryActions entry={noMoodEntry} />);
+
+    expect(screen.queryByText(/Mood:/)).not.toBeInTheDocument();
+  });
+
+  it("handles entry without tags gracefully", () => {
+    const noTagsEntry = { ...mockEntry, tags: [] };
+    render(<JournalEntryActions entry={noTagsEntry} />);
+
+    // No tag elements rendered
+    expect(screen.queryByText("breathwork")).not.toBeInTheDocument();
+  });
+});

--- a/alchymine/web/src/components/healing/__tests__/MoodSparkline.test.tsx
+++ b/alchymine/web/src/components/healing/__tests__/MoodSparkline.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen } from "@testing-library/react";
+import MoodSparkline from "../MoodSparkline";
+
+// ── Test data ────────────────────────────────────────────────────────
+
+const sampleData = [
+  { date: "2026-04-01", score: 5 },
+  { date: "2026-04-02", score: 7 },
+  { date: "2026-04-03", score: 6 },
+  { date: "2026-04-04", score: 8 },
+  { date: "2026-04-05", score: 7 },
+  { date: "2026-04-06", score: 9 },
+];
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("MoodSparkline", () => {
+  it("renders the sparkline with data", () => {
+    render(<MoodSparkline data={sampleData} />);
+
+    const container = screen.getByTestId("mood-sparkline");
+    expect(container).toBeInTheDocument();
+  });
+
+  it("renders an SVG element", () => {
+    render(<MoodSparkline data={sampleData} />);
+
+    const svg = screen.getByRole("img");
+    expect(svg).toBeInTheDocument();
+    expect(svg.tagName).toBe("svg");
+  });
+
+  it("shows average score", () => {
+    // average = (5+7+6+8+7+9)/6 = 7.0
+    render(<MoodSparkline data={sampleData} />);
+
+    expect(screen.getByText("avg 7.0")).toBeInTheDocument();
+  });
+
+  it("renders empty state when no data is provided", () => {
+    render(<MoodSparkline data={[]} />);
+
+    expect(screen.getByTestId("mood-sparkline-empty")).toBeInTheDocument();
+    expect(screen.getByText("No mood data")).toBeInTheDocument();
+  });
+
+  it("renders empty state for invalid scores", () => {
+    render(<MoodSparkline data={[{ date: "2026-04-01", score: 0 }]} />);
+
+    expect(screen.getByTestId("mood-sparkline-empty")).toBeInTheDocument();
+  });
+
+  it("displays optional label", () => {
+    render(<MoodSparkline data={sampleData} label="14d mood" />);
+
+    expect(screen.getByText("14d mood")).toBeInTheDocument();
+  });
+
+  it("uses custom dimensions", () => {
+    render(<MoodSparkline data={sampleData} width={200} height={50} />);
+
+    const svg = screen.getByRole("img");
+    expect(svg).toHaveAttribute("width", "200");
+    expect(svg).toHaveAttribute("height", "50");
+  });
+
+  it("renders dots for each data point", () => {
+    render(<MoodSparkline data={sampleData} />);
+
+    const svg = screen.getByRole("img");
+    const circles = svg.querySelectorAll("circle");
+    expect(circles).toHaveLength(6);
+  });
+
+  it("renders a polyline for the trend line", () => {
+    render(<MoodSparkline data={sampleData} />);
+
+    const svg = screen.getByRole("img");
+    const polyline = svg.querySelector("polyline");
+    expect(polyline).toBeInTheDocument();
+    expect(polyline?.getAttribute("stroke")).toBe("#20b2aa");
+  });
+
+  it("truncates to last 14 entries", () => {
+    const manyEntries = Array.from({ length: 20 }, (_, i) => ({
+      date: `2026-04-${String(i + 1).padStart(2, "0")}`,
+      score: (i % 10) + 1,
+    }));
+
+    render(<MoodSparkline data={manyEntries} />);
+
+    const svg = screen.getByRole("img");
+    const circles = svg.querySelectorAll("circle");
+    expect(circles).toHaveLength(14);
+  });
+
+  it("renders a filled area polygon under the line", () => {
+    render(<MoodSparkline data={sampleData} />);
+
+    const svg = screen.getByRole("img");
+    const polygon = svg.querySelector("polygon");
+    expect(polygon).toBeInTheDocument();
+  });
+
+  it("uses custom color for stroke", () => {
+    render(<MoodSparkline data={sampleData} color="#ff0000" />);
+
+    const svg = screen.getByRole("img");
+    const polyline = svg.querySelector("polyline");
+    expect(polyline?.getAttribute("stroke")).toBe("#ff0000");
+  });
+
+  it("includes accessible aria-label with average", () => {
+    render(<MoodSparkline data={sampleData} />);
+
+    const svg = screen.getByRole("img");
+    expect(svg.getAttribute("aria-label")).toContain("average 7.0");
+  });
+
+  it("renders a single data point without polygon (needs 2+ for area)", () => {
+    render(<MoodSparkline data={[{ date: "2026-04-01", score: 5 }]} />);
+
+    const svg = screen.getByRole("img");
+    const circles = svg.querySelectorAll("circle");
+    expect(circles).toHaveLength(1);
+
+    // polygon requires dots.length > 1
+    const polygon = svg.querySelector("polygon");
+    expect(polygon).not.toBeInTheDocument();
+  });
+});

--- a/alchymine/web/src/components/healing/__tests__/SkillDetailDrawer.test.tsx
+++ b/alchymine/web/src/components/healing/__tests__/SkillDetailDrawer.test.tsx
@@ -1,0 +1,155 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import SkillDetailDrawer from "../SkillDetailDrawer";
+
+// ── Mock the API module ──────────────────────────────────────────────
+
+const mockSkill = {
+  name: "breathwork-box-breathing",
+  modality: "breathwork",
+  title: "Box Breathing (4-4-4-4)",
+  description:
+    "A simple, evidence-based breathing pattern used by Navy SEALs.",
+  steps: [
+    "Sit upright with both feet on the floor.",
+    "Exhale fully through pursed lips.",
+    "Inhale slowly through the nose for a count of 4.",
+  ],
+  evidence_rating: "B" as const,
+  contraindications: ["severe asthma during an active flare"],
+  duration_minutes: 6,
+};
+
+jest.mock("@/lib/api", () => ({
+  getHealingSkill: jest.fn(() => Promise.resolve(mockSkill)),
+}));
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("SkillDetailDrawer", () => {
+  const onClose = jest.fn();
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    document.body.style.overflow = "";
+  });
+
+  it("renders hidden (off-screen) when skillName is null", () => {
+    render(<SkillDetailDrawer skillName={null} onClose={onClose} />);
+    const drawer = screen.getByTestId("skill-detail-drawer");
+    expect(drawer).toHaveClass("translate-x-full");
+  });
+
+  it("slides in and shows skill data when skillName is provided", async () => {
+    render(
+      <SkillDetailDrawer skillName="breathwork-box-breathing" onClose={onClose} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Box Breathing (4-4-4-4)")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(/evidence-based breathing pattern/),
+    ).toBeInTheDocument();
+    expect(screen.getByText("6 min")).toBeInTheDocument();
+    expect(screen.getByText("breathwork")).toBeInTheDocument();
+    expect(
+      screen.getByText("Moderate (Controlled Studies)"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders all steps as an ordered list", async () => {
+    render(
+      <SkillDetailDrawer skillName="breathwork-box-breathing" onClose={onClose} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Sit upright with both feet on the floor.")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText("Exhale fully through pursed lips."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows contraindications when present", async () => {
+    render(
+      <SkillDetailDrawer skillName="breathwork-box-breathing" onClose={onClose} />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("severe asthma during an active flare"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("calls onClose when close button is clicked", async () => {
+    render(
+      <SkillDetailDrawer skillName="breathwork-box-breathing" onClose={onClose} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Box Breathing (4-4-4-4)")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("drawer-close"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when backdrop is clicked", async () => {
+    render(
+      <SkillDetailDrawer skillName="breathwork-box-breathing" onClose={onClose} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("drawer-backdrop")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("drawer-backdrop"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose on Escape key press", async () => {
+    render(
+      <SkillDetailDrawer skillName="breathwork-box-breathing" onClose={onClose} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Box Breathing (4-4-4-4)")).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onStartPractice when Start Practice button is clicked", async () => {
+    const onStart = jest.fn();
+    render(
+      <SkillDetailDrawer
+        skillName="breathwork-box-breathing"
+        onClose={onClose}
+        onStartPractice={onStart}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Start Practice")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Start Practice"));
+    expect(onStart).toHaveBeenCalledWith(mockSkill);
+  });
+
+  it("does not show Start Practice button without onStartPractice prop", async () => {
+    render(
+      <SkillDetailDrawer skillName="breathwork-box-breathing" onClose={onClose} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Box Breathing (4-4-4-4)")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("Start Practice")).not.toBeInTheDocument();
+  });
+});

--- a/alchymine/web/src/components/healing/__tests__/SpiralBanner.test.tsx
+++ b/alchymine/web/src/components/healing/__tests__/SpiralBanner.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import SpiralBanner from "../SpiralBanner";
+
+// ── Mock data ──────────────────────────────────────────────────────
+
+const mockResponse = {
+  primary_system: "healing",
+  healing_rank: 1,
+  healing_score: 100,
+  healing_reason:
+    "Your health intention aligns directly with the healing system's modalities.",
+  healing_entry_action: "Start your personalized healing modality match",
+  for_you_today:
+    "Your body and mind are ready for renewal. Start with a short breathwork session.",
+  recommended_modalities: [
+    {
+      modality: "breathwork",
+      category: "somatic",
+      description: "Conscious breathing techniques for nervous system regulation.",
+      evidence_level: "strong",
+      entry_action: "Start your personalized healing modality match",
+    },
+    {
+      modality: "coherence_meditation",
+      category: "contemplative",
+      description: "Heart-brain coherence practice with rhythmic breathing.",
+      evidence_level: "strong",
+      entry_action: "Start your personalized healing modality match",
+    },
+  ],
+  evidence_level: "strong",
+  calculation_type: "deterministic",
+};
+
+jest.mock("@/lib/api", () => ({
+  getHealingSpiralRoute: jest.fn(() => Promise.resolve(mockResponse)),
+}));
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+describe("SpiralBanner", () => {
+  it("shows loading state initially", () => {
+    render(<SpiralBanner intention="health" />);
+    expect(screen.getByTestId("spiral-banner-loading")).toBeInTheDocument();
+  });
+
+  it("renders spiral banner with recommendation data", async () => {
+    render(<SpiralBanner intention="health" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("spiral-banner")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Your Alchemical Spiral")).toBeInTheDocument();
+    expect(
+      screen.getByText(/health intention aligns/),
+    ).toBeInTheDocument();
+  });
+
+  it("displays the healing rank and score", async () => {
+    render(<SpiralBanner intention="health" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("spiral-banner")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("#1 of 5")).toBeInTheDocument();
+    expect(screen.getByText("100%")).toBeInTheDocument();
+  });
+
+  it("displays the For You Today suggestion", async () => {
+    render(<SpiralBanner intention="health" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("spiral-banner")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("For You Today")).toBeInTheDocument();
+    expect(
+      screen.getByText(/body and mind are ready/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders recommended modalities list", async () => {
+    render(<SpiralBanner intention="health" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("spiral-banner")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Recommended Modalities")).toBeInTheDocument();
+    expect(screen.getByText("breathwork")).toBeInTheDocument();
+    expect(screen.getByText("coherence meditation")).toBeInTheDocument();
+  });
+
+  it("has proper ARIA landmarks", async () => {
+    render(<SpiralBanner intention="health" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("spiral-banner")).toBeInTheDocument();
+    });
+
+    const section = screen.getByTestId("spiral-banner");
+    expect(section.tagName).toBe("SECTION");
+    expect(section).toHaveAttribute("aria-labelledby", "spiral-banner-heading");
+    expect(
+      screen.getByRole("list", { name: /recommended healing modalities/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders error state when API fails", async () => {
+    const { getHealingSpiralRoute } = jest.requireMock("@/lib/api");
+    getHealingSpiralRoute.mockRejectedValueOnce(new Error("Network error"));
+
+    render(<SpiralBanner intention="health" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("spiral-banner-error")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText("Could not load spiral recommendations."),
+    ).toBeInTheDocument();
+  });
+});

--- a/alchymine/web/src/lib/api.ts
+++ b/alchymine/web/src/lib/api.ts
@@ -923,6 +923,47 @@ export async function getSpiralRoute(
   });
 }
 
+// ─── Healing Spiral Route ─────────────────────────────────────────────
+
+export interface HealingSpiralModality {
+  modality: string;
+  category: string;
+  description: string;
+  evidence_level: string;
+  entry_action: string;
+}
+
+export interface HealingSpiralRouteResponse {
+  primary_system: string;
+  healing_rank: number;
+  healing_score: number;
+  healing_reason: string;
+  healing_entry_action: string;
+  for_you_today: string;
+  recommended_modalities: HealingSpiralModality[];
+  evidence_level: string;
+  calculation_type: string;
+}
+
+export async function getHealingSpiralRoute(opts?: {
+  intention?: string;
+  lifePath?: number;
+  personalityOpenness?: number;
+  personalityNeuroticism?: number;
+}): Promise<HealingSpiralRouteResponse> {
+  const params = new URLSearchParams();
+  if (opts?.intention) params.set("intention", opts.intention);
+  if (opts?.lifePath != null) params.set("life_path", String(opts.lifePath));
+  if (opts?.personalityOpenness != null)
+    params.set("personality_openness", String(opts.personalityOpenness));
+  if (opts?.personalityNeuroticism != null)
+    params.set("personality_neuroticism", String(opts.personalityNeuroticism));
+  const query = params.toString();
+  return request<HealingSpiralRouteResponse>(
+    `${BASE}/healing/spiral-route${query ? `?${query}` : ""}`,
+  );
+}
+
 // ─── Profile API functions ────────────────────────────────────────
 
 export async function getProfile(userId: string): Promise<ProfileResponse> {

--- a/alchymine/web/src/lib/api.ts
+++ b/alchymine/web/src/lib/api.ts
@@ -506,6 +506,34 @@ export async function getBreathwork(
   );
 }
 
+// ─── Healing Skills ─────────────────────────────────────────────────
+
+export interface HealingSkill {
+  name: string;
+  modality: string;
+  title: string;
+  description: string;
+  steps: string[];
+  evidence_rating: "A" | "B" | "C" | "D";
+  contraindications: string[];
+  duration_minutes: number;
+}
+
+export async function listHealingSkills(
+  modality?: string,
+): Promise<HealingSkill[]> {
+  const params = modality
+    ? `?modality=${encodeURIComponent(modality)}`
+    : "";
+  return request<HealingSkill[]>(`${BASE}/healing/skills${params}`);
+}
+
+export async function getHealingSkill(name: string): Promise<HealingSkill> {
+  return request<HealingSkill>(
+    `${BASE}/healing/skills/${encodeURIComponent(name)}`,
+  );
+}
+
 // ─── Biorhythm ──────────────────────────────────────────────────────
 
 export interface BiorhythmResult {

--- a/skills/healing-swarm-skills/README.md
+++ b/skills/healing-swarm-skills/README.md
@@ -1,0 +1,35 @@
+# healing-swarm-skills
+
+Placeholder for the upstream `github.com/realsammyt/healing-swarm-skills` git submodule.
+
+## Intended Integration
+
+When the upstream repository is available, this directory will be replaced by a git submodule:
+
+```bash
+git submodule add https://github.com/realsammyt/healing-swarm-skills.git skills/healing-swarm-skills
+```
+
+## How It Works
+
+The `SkillRegistry` in `alchymine/engine/healing/skills/loader.py` supports loading
+from multiple directories. Set the `HEALING_SKILLS_EXTERNAL_DIR` environment variable
+to point at this directory (or any directory containing YAML skill files):
+
+```env
+HEALING_SKILLS_EXTERNAL_DIR=skills/healing-swarm-skills
+```
+
+The API will load:
+1. Bundled skills from `alchymine/engine/healing/skills/yaml/` (always loaded first)
+2. External skills from this directory (merged in, no duplicates allowed)
+
+## Adding Skills
+
+Place YAML files in this directory following the schema defined in
+`alchymine/engine/healing/skills/schema.py`. Each file must contain:
+
+- `name` (lowercase-with-dashes slug, must be unique across all directories)
+- `modality` (one of the 15 registered modality keys)
+- `title`, `description`, `steps`, `evidence_rating`, `duration_minutes`
+- Optional: `contraindications`

--- a/tests/api/test_bridges.py
+++ b/tests/api/test_bridges.py
@@ -1,0 +1,165 @@
+"""Tests for the public cross-system bridges API endpoints."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from alchymine.api.main import app
+
+EXPECTED_IDS = {"XS-01", "XS-02", "XS-03", "XS-04", "XS-05", "XS-06", "XS-07"}
+REQUIRED_FIELDS = (
+    "id",
+    "name",
+    "source_system",
+    "target_system",
+    "description",
+    "insight_keys",
+)
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# GET /api/v1/bridges
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestListBridges:
+    def test_list_all_bridges(self, client: TestClient) -> None:
+        response = client.get("/api/v1/bridges")
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) == 7
+
+    def test_list_bridges_structure(self, client: TestClient) -> None:
+        response = client.get("/api/v1/bridges")
+        assert response.status_code == 200
+        for bridge in response.json():
+            for field in REQUIRED_FIELDS:
+                assert field in bridge, f"missing {field} in {bridge}"
+            assert isinstance(bridge["insight_keys"], list)
+            assert len(bridge["insight_keys"]) >= 1
+
+    def test_all_bridge_ids_present(self, client: TestClient) -> None:
+        response = client.get("/api/v1/bridges")
+        ids = {b["id"] for b in response.json()}
+        assert ids == EXPECTED_IDS
+
+    def test_list_returns_stable_order(self, client: TestClient) -> None:
+        response = client.get("/api/v1/bridges")
+        ids = [b["id"] for b in response.json()]
+        assert ids == sorted(ids)
+        assert ids[0] == "XS-01"
+        assert ids[-1] == "XS-07"
+
+    def test_filter_by_source_system(self, client: TestClient) -> None:
+        response = client.get("/api/v1/bridges", params={"source": "healing"})
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) >= 1
+        for b in data:
+            assert b["source_system"] == "healing"
+        # XS-01 (healing→perspective) and XS-06 (healing→creative)
+        assert {b["id"] for b in data} == {"XS-01", "XS-06"}
+
+    def test_filter_by_target_system(self, client: TestClient) -> None:
+        response = client.get("/api/v1/bridges", params={"target": "wealth"})
+        assert response.status_code == 200
+        data = response.json()
+        for b in data:
+            assert b["target_system"] == "wealth"
+        # XS-05 (perspective→wealth)
+        assert {b["id"] for b in data} == {"XS-05"}
+
+    def test_filter_by_both(self, client: TestClient) -> None:
+        response = client.get(
+            "/api/v1/bridges",
+            params={"source": "intelligence", "target": "perspective"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        # XS-07 (intelligence→perspective)
+        assert len(data) == 1
+        assert data[0]["id"] == "XS-07"
+
+    def test_filter_unknown_source_returns_empty(self, client: TestClient) -> None:
+        response = client.get("/api/v1/bridges", params={"source": "definitely-not-real"})
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_filter_unknown_target_returns_empty(self, client: TestClient) -> None:
+        response = client.get("/api/v1/bridges", params={"target": "definitely-not-real"})
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_filter_combo_with_no_matches_returns_empty(self, client: TestClient) -> None:
+        # healing→healing doesn't exist
+        response = client.get(
+            "/api/v1/bridges",
+            params={"source": "healing", "target": "healing"},
+        )
+        assert response.status_code == 200
+        assert response.json() == []
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# GET /api/v1/bridges/{bridge_id}
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestGetSingleBridge:
+    def test_get_single_bridge(self, client: TestClient) -> None:
+        response = client.get("/api/v1/bridges/XS-01")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == "XS-01"
+        assert data["source_system"] == "healing"
+        assert data["target_system"] == "perspective"
+        for field in REQUIRED_FIELDS:
+            assert field in data
+
+    def test_get_unknown_bridge(self, client: TestClient) -> None:
+        response = client.get("/api/v1/bridges/XS-99")
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+
+    def test_get_bridge_with_garbage_id(self, client: TestClient) -> None:
+        response = client.get("/api/v1/bridges/not-a-bridge")
+        assert response.status_code == 404
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Auth: endpoints are public reference data
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_list_endpoint_is_public() -> None:
+    """Bridges are open reference data — must work even when the auth
+    override fixture is bypassed by clearing dependency overrides.
+    """
+    app.dependency_overrides.clear()
+    try:
+        with TestClient(app) as client:
+            response = client.get("/api/v1/bridges")
+            assert response.status_code == 200
+            assert isinstance(response.json(), list)
+            assert len(response.json()) == 7
+    finally:
+        # conftest's autouse fixtures will re-install overrides next test.
+        pass
+
+
+def test_get_endpoint_is_public() -> None:
+    app.dependency_overrides.clear()
+    try:
+        with TestClient(app) as client:
+            response = client.get("/api/v1/bridges/XS-02")
+            assert response.status_code == 200
+            assert response.json()["id"] == "XS-02"
+    finally:
+        pass

--- a/tests/api/test_healing_skills.py
+++ b/tests/api/test_healing_skills.py
@@ -1,0 +1,101 @@
+"""Tests for the public healing skills API endpoints."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from alchymine.api.main import app
+from alchymine.engine.healing.modalities import MODALITY_REGISTRY
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+# ── GET /api/v1/healing/skills ─────────────────────────────────────────
+
+
+class TestListHealingSkills:
+    def test_returns_200_and_15_skills(self, client: TestClient) -> None:
+        response = client.get("/api/v1/healing/skills")
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) == 15
+
+    def test_skill_payload_has_required_fields(self, client: TestClient) -> None:
+        response = client.get("/api/v1/healing/skills")
+        assert response.status_code == 200
+        skill = response.json()[0]
+        for field in (
+            "name",
+            "modality",
+            "title",
+            "description",
+            "steps",
+            "evidence_rating",
+            "contraindications",
+            "duration_minutes",
+        ):
+            assert field in skill, f"missing {field}"
+        assert isinstance(skill["steps"], list)
+        assert len(skill["steps"]) >= 1
+
+    def test_filter_by_modality(self, client: TestClient) -> None:
+        response = client.get("/api/v1/healing/skills", params={"modality": "breathwork"})
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) >= 1
+        for skill in data:
+            assert skill["modality"] == "breathwork"
+
+    def test_unknown_modality_returns_empty_list(self, client: TestClient) -> None:
+        response = client.get(
+            "/api/v1/healing/skills",
+            params={"modality": "definitely-not-a-modality"},
+        )
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_every_modality_represented(self, client: TestClient) -> None:
+        response = client.get("/api/v1/healing/skills")
+        modalities = {s["modality"] for s in response.json()}
+        assert modalities == set(MODALITY_REGISTRY.keys())
+
+
+# ── GET /api/v1/healing/skills/{name} ──────────────────────────────────
+
+
+class TestGetHealingSkill:
+    def test_returns_skill_when_found(self, client: TestClient) -> None:
+        response = client.get("/api/v1/healing/skills/breathwork-box-breathing")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "breathwork-box-breathing"
+        assert data["modality"] == "breathwork"
+        assert data["evidence_rating"] in {"A", "B", "C", "D"}
+
+    def test_returns_404_when_not_found(self, client: TestClient) -> None:
+        response = client.get("/api/v1/healing/skills/no-such-skill")
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+
+
+# ── Auth: endpoints are public reference data ─────────────────────────
+
+
+def test_list_endpoint_does_not_require_auth() -> None:
+    """Skills are open reference data — must work even when the auth
+    override fixture is bypassed by clearing dependency overrides.
+    """
+    app.dependency_overrides.clear()
+    try:
+        with TestClient(app) as client:
+            response = client.get("/api/v1/healing/skills")
+            assert response.status_code == 200
+            assert isinstance(response.json(), list)
+    finally:
+        # conftest's autouse fixtures will re-install overrides next test.
+        pass

--- a/tests/api/test_healing_spiral_route.py
+++ b/tests/api/test_healing_spiral_route.py
@@ -1,0 +1,139 @@
+"""Tests for GET /api/v1/healing/spiral-route endpoint (Task 6.1).
+
+Validates that the healing-specific spiral route endpoint returns
+the correct structure with healing rank, score, reason, and
+recommended modalities.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from alchymine.api.auth import get_current_user
+from alchymine.api.main import app
+
+
+async def _test_current_user() -> dict:
+    return {"sub": "test-user", "email": "test@example.com"}
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app.dependency_overrides[get_current_user] = _test_current_user
+    yield TestClient(app)
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+class TestHealingSpiralRoute:
+    """Tests for GET /api/v1/healing/spiral-route"""
+
+    def test_returns_200_with_defaults(self, client: TestClient) -> None:
+        response = client.get("/api/v1/healing/spiral-route")
+        assert response.status_code == 200
+
+    def test_returns_healing_rank_and_score(self, client: TestClient) -> None:
+        response = client.get("/api/v1/healing/spiral-route?intention=health")
+        data = response.json()
+        assert "healing_rank" in data
+        assert "healing_score" in data
+        assert 1 <= data["healing_rank"] <= 5
+        assert 0 <= data["healing_score"] <= 100
+
+    def test_health_intention_gives_healing_top_rank(self, client: TestClient) -> None:
+        response = client.get("/api/v1/healing/spiral-route?intention=health")
+        data = response.json()
+        # With health intention, healing should be primary
+        assert data["healing_rank"] == 1
+        assert data["primary_system"] == "healing"
+
+    def test_returns_recommended_modalities(self, client: TestClient) -> None:
+        response = client.get("/api/v1/healing/spiral-route?intention=health")
+        data = response.json()
+        assert "recommended_modalities" in data
+        assert len(data["recommended_modalities"]) > 0
+        # Each modality should have required fields
+        for mod in data["recommended_modalities"]:
+            assert "modality" in mod
+            assert "category" in mod
+            assert "description" in mod
+            assert "evidence_level" in mod
+
+    def test_returns_for_you_today(self, client: TestClient) -> None:
+        response = client.get("/api/v1/healing/spiral-route?intention=health")
+        data = response.json()
+        assert "for_you_today" in data
+        assert len(data["for_you_today"]) > 10
+
+    def test_returns_healing_reason(self, client: TestClient) -> None:
+        response = client.get("/api/v1/healing/spiral-route?intention=health")
+        data = response.json()
+        assert "healing_reason" in data
+        assert len(data["healing_reason"]) > 10
+
+    def test_returns_healing_entry_action(self, client: TestClient) -> None:
+        response = client.get("/api/v1/healing/spiral-route?intention=health")
+        data = response.json()
+        assert "healing_entry_action" in data
+        assert len(data["healing_entry_action"]) > 5
+
+    def test_money_intention_gives_lower_healing_rank(self, client: TestClient) -> None:
+        response = client.get("/api/v1/healing/spiral-route?intention=money")
+        data = response.json()
+        # With money intention, healing should not be primary
+        assert data["healing_rank"] > 1
+        assert data["primary_system"] == "wealth"
+
+    def test_with_personality_params(self, client: TestClient) -> None:
+        response = client.get(
+            "/api/v1/healing/spiral-route"
+            "?intention=career"
+            "&personality_neuroticism=90"
+            "&personality_openness=30"
+        )
+        data = response.json()
+        assert response.status_code == 200
+        # High neuroticism should boost healing, verify it's scored
+        assert data["healing_score"] > 0
+        assert 1 <= data["healing_rank"] <= 5
+
+        # Compare with low neuroticism — healing score should be higher
+        response_low = client.get(
+            "/api/v1/healing/spiral-route"
+            "?intention=career"
+            "&personality_neuroticism=10"
+            "&personality_openness=30"
+        )
+        data_low = response_low.json()
+        assert data["healing_score"] >= data_low["healing_score"]
+
+    def test_with_life_path(self, client: TestClient) -> None:
+        response = client.get(
+            "/api/v1/healing/spiral-route?intention=career&life_path=6"
+        )
+        data = response.json()
+        assert response.status_code == 200
+        # LP 6 (Nurturer) boosts healing
+        assert "healing_rank" in data
+
+    def test_evidence_level_metadata(self, client: TestClient) -> None:
+        response = client.get("/api/v1/healing/spiral-route?intention=health")
+        data = response.json()
+        assert data["evidence_level"] == "strong"
+        assert data["calculation_type"] == "deterministic"
+
+    def test_primary_rank_gives_deeper_modalities(self, client: TestClient) -> None:
+        """When healing is primary, recommended modalities include consciousness_journey."""
+        response = client.get("/api/v1/healing/spiral-route?intention=health")
+        data = response.json()
+        modality_names = [m["modality"] for m in data["recommended_modalities"]]
+        # Primary tier includes consciousness_journey
+        assert "consciousness_journey" in modality_names
+
+    def test_lower_rank_gives_foundational_modalities(self, client: TestClient) -> None:
+        """When healing ranks low, recommended modalities focus on basics."""
+        response = client.get("/api/v1/healing/spiral-route?intention=money")
+        data = response.json()
+        modality_names = [m["modality"] for m in data["recommended_modalities"]]
+        # Lower tier should include basics like breathwork, sleep, nature
+        assert "breathwork" in modality_names

--- a/tests/engine/healing/test_multi_dir_loading.py
+++ b/tests/engine/healing/test_multi_dir_loading.py
@@ -1,0 +1,201 @@
+"""Tests for SkillRegistry multi-directory loading (Task 6.2).
+
+Covers:
+- Loading from a single directory (backward compat)
+- Loading from multiple directories with replace=False
+- Duplicate detection across directories
+- Empty external directory handling
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from alchymine.engine.healing.skills import (
+    SkillNotFoundError,
+    SkillRegistry,
+    SkillValidationError,
+)
+
+
+def _write_yaml(directory: Path, filename: str, content: str) -> Path:
+    file_path = directory / filename
+    file_path.write_text(dedent(content).strip() + "\n", encoding="utf-8")
+    return file_path
+
+
+@pytest.fixture
+def bundled_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "bundled"
+    d.mkdir()
+    _write_yaml(
+        d,
+        "breath.yaml",
+        """
+        name: bundled-breathwork
+        modality: breathwork
+        title: Bundled Breathwork
+        description: A bundled breathwork skill.
+        steps:
+          - Inhale
+          - Exhale
+        evidence_rating: A
+        contraindications: []
+        duration_minutes: 5
+        """,
+    )
+    _write_yaml(
+        d,
+        "somatic.yaml",
+        """
+        name: bundled-somatic
+        modality: somatic_practice
+        title: Bundled Somatic
+        description: A bundled somatic skill.
+        steps:
+          - Move gently
+        evidence_rating: B
+        contraindications: []
+        duration_minutes: 10
+        """,
+    )
+    return d
+
+
+@pytest.fixture
+def external_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "external"
+    d.mkdir()
+    _write_yaml(
+        d,
+        "nature.yaml",
+        """
+        name: external-nature
+        modality: nature_healing
+        title: External Nature Walk
+        description: An externally defined nature healing skill.
+        steps:
+          - Go outside
+          - Walk slowly
+        evidence_rating: B
+        contraindications: []
+        duration_minutes: 30
+        """,
+    )
+    return d
+
+
+class TestMultiDirectoryLoading:
+    """Test that SkillRegistry supports loading from multiple directories."""
+
+    def test_load_single_directory_still_works(self, bundled_dir: Path) -> None:
+        """Backward compatibility: load_directory with default replace=True."""
+        reg = SkillRegistry()
+        reg.load_directory(bundled_dir)
+        assert len(reg) == 2
+        assert reg.get("bundled-breathwork").modality == "breathwork"
+
+    def test_load_second_directory_with_replace_false(
+        self, bundled_dir: Path, external_dir: Path
+    ) -> None:
+        """Loading a second directory with replace=False merges skills."""
+        reg = SkillRegistry()
+        reg.load_directory(bundled_dir)
+        assert len(reg) == 2
+
+        reg.load_directory(external_dir, replace=False)
+        assert len(reg) == 3
+        # All skills accessible
+        assert reg.get("bundled-breathwork").modality == "breathwork"
+        assert reg.get("bundled-somatic").modality == "somatic_practice"
+        assert reg.get("external-nature").modality == "nature_healing"
+
+    def test_load_second_directory_with_replace_true_clears(
+        self, bundled_dir: Path, external_dir: Path
+    ) -> None:
+        """Loading a second directory with replace=True replaces all skills."""
+        reg = SkillRegistry()
+        reg.load_directory(bundled_dir)
+        assert len(reg) == 2
+
+        reg.load_directory(external_dir, replace=True)
+        assert len(reg) == 1
+        assert reg.get("external-nature").modality == "nature_healing"
+        with pytest.raises(SkillNotFoundError):
+            reg.get("bundled-breathwork")
+
+    def test_cross_directory_duplicate_raises(
+        self, bundled_dir: Path, tmp_path: Path
+    ) -> None:
+        """Duplicate skill name across directories raises SkillValidationError."""
+        dup_dir = tmp_path / "dup"
+        dup_dir.mkdir()
+        _write_yaml(
+            dup_dir,
+            "conflict.yaml",
+            """
+            name: bundled-breathwork
+            modality: nature_healing
+            title: Conflicting Name
+            description: Same name as bundled skill.
+            steps:
+              - Conflict
+            evidence_rating: C
+            contraindications: []
+            duration_minutes: 5
+            """,
+        )
+
+        reg = SkillRegistry()
+        reg.load_directory(bundled_dir)
+        with pytest.raises(SkillValidationError, match="Duplicate"):
+            reg.load_directory(dup_dir, replace=False)
+
+    def test_empty_external_directory_is_fine(
+        self, bundled_dir: Path, tmp_path: Path
+    ) -> None:
+        """Loading an empty external directory adds nothing."""
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+
+        reg = SkillRegistry()
+        reg.load_directory(bundled_dir)
+        reg.load_directory(empty_dir, replace=False)
+        # Original skills untouched
+        assert len(reg) == 2
+
+    def test_missing_external_directory_raises(self, bundled_dir: Path) -> None:
+        """A non-existent external path raises FileNotFoundError."""
+        reg = SkillRegistry()
+        reg.load_directory(bundled_dir)
+        with pytest.raises(FileNotFoundError):
+            reg.load_directory(Path("/nonexistent/path"), replace=False)
+
+    def test_list_by_modality_spans_both_dirs(
+        self, bundled_dir: Path, external_dir: Path
+    ) -> None:
+        """list_by_modality works across merged directories."""
+        reg = SkillRegistry()
+        reg.load_directory(bundled_dir)
+        reg.load_directory(external_dir, replace=False)
+
+        breath = reg.list_by_modality("breathwork")
+        nature = reg.list_by_modality("nature_healing")
+        assert len(breath) == 1
+        assert len(nature) == 1
+        assert breath[0].name == "bundled-breathwork"
+        assert nature[0].name == "external-nature"
+
+    def test_list_all_spans_both_dirs(
+        self, bundled_dir: Path, external_dir: Path
+    ) -> None:
+        """list_all returns all skills from all loaded directories."""
+        reg = SkillRegistry()
+        reg.load_directory(bundled_dir)
+        reg.load_directory(external_dir, replace=False)
+        all_skills = reg.list_all()
+        names = {s.name for s in all_skills}
+        assert names == {"bundled-breathwork", "bundled-somatic", "external-nature"}

--- a/tests/engine/healing/test_seed_skills.py
+++ b/tests/engine/healing/test_seed_skills.py
@@ -1,0 +1,44 @@
+"""Smoke tests for the bundled healing skill YAML files.
+
+These tests load the real directory at
+``alchymine/engine/healing/skills/yaml/`` and verify that all 15 seed
+skills parse cleanly and that each modality is represented exactly once.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+from alchymine.engine.healing.modalities import MODALITY_REGISTRY
+from alchymine.engine.healing.skills import SkillRegistry, get_default_yaml_dir
+
+
+def test_seed_directory_loads_all_files() -> None:
+    reg = SkillRegistry()
+    reg.load_directory(get_default_yaml_dir())
+    assert len(reg) == 15
+
+
+def test_each_modality_has_exactly_one_seed_skill() -> None:
+    reg = SkillRegistry()
+    reg.load_directory(get_default_yaml_dir())
+
+    counts = Counter(skill.modality for skill in reg.list_all())
+    expected = set(MODALITY_REGISTRY.keys())
+
+    assert set(counts.keys()) == expected, (
+        f"missing modalities: {expected - set(counts.keys())}; "
+        f"extra modalities: {set(counts.keys()) - expected}"
+    )
+    duplicates = {m: c for m, c in counts.items() if c != 1}
+    assert not duplicates, f"modalities with !=1 seed skill: {duplicates}"
+
+
+def test_seed_skills_have_meaningful_content() -> None:
+    reg = SkillRegistry()
+    reg.load_directory(get_default_yaml_dir())
+
+    for skill in reg.list_all():
+        assert skill.duration_minutes > 0
+        assert len(skill.steps) >= 3, f"{skill.name}: needs at least 3 steps"
+        assert len(skill.description) >= 40, f"{skill.name}: description too short"

--- a/tests/engine/healing/test_skill_loader.py
+++ b/tests/engine/healing/test_skill_loader.py
@@ -1,0 +1,316 @@
+"""Tests for the healing SkillRegistry loader and SkillDefinition schema."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+from pydantic import ValidationError
+
+from alchymine.engine.healing.skills import (
+    SkillDefinition,
+    SkillNotFoundError,
+    SkillRegistry,
+    SkillValidationError,
+)
+
+# ── Schema validation ──────────────────────────────────────────────────
+
+
+def _valid_payload(**overrides: object) -> dict:
+    base: dict = {
+        "name": "box-breath-foundation",
+        "modality": "breathwork",
+        "title": "Box Breathing Foundation",
+        "description": "A baseline 4-4-4-4 breathing protocol.",
+        "steps": [
+            "Sit comfortably and close your eyes.",
+            "Inhale through the nose for 4 counts.",
+            "Hold for 4 counts.",
+            "Exhale through the mouth for 4 counts.",
+        ],
+        "evidence_rating": "B",
+        "contraindications": ["severe asthma"],
+        "duration_minutes": 5,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_valid_skill_parses() -> None:
+    skill = SkillDefinition.model_validate(_valid_payload())
+    assert skill.name == "box-breath-foundation"
+    assert skill.modality == "breathwork"
+    assert skill.duration_minutes == 5
+
+
+def test_skill_is_frozen() -> None:
+    skill = SkillDefinition.model_validate(_valid_payload())
+    with pytest.raises(ValidationError):
+        skill.name = "different-name"  # type: ignore[misc]
+
+
+def test_extra_fields_forbidden() -> None:
+    with pytest.raises(ValidationError):
+        SkillDefinition.model_validate(_valid_payload(unexpected_field="oops"))
+
+
+@pytest.mark.parametrize(
+    "missing",
+    [
+        "name",
+        "modality",
+        "title",
+        "description",
+        "steps",
+        "evidence_rating",
+        "duration_minutes",
+    ],
+)
+def test_missing_required_field_raises(missing: str) -> None:
+    payload = _valid_payload()
+    payload.pop(missing)
+    with pytest.raises(ValidationError):
+        SkillDefinition.model_validate(payload)
+
+
+def test_unknown_modality_rejected() -> None:
+    with pytest.raises(ValidationError):
+        SkillDefinition.model_validate(_valid_payload(modality="not-a-real-modality"))
+
+
+def test_invalid_evidence_rating_rejected() -> None:
+    with pytest.raises(ValidationError):
+        SkillDefinition.model_validate(_valid_payload(evidence_rating="Z"))
+
+
+def test_zero_duration_rejected() -> None:
+    with pytest.raises(ValidationError):
+        SkillDefinition.model_validate(_valid_payload(duration_minutes=0))
+
+
+def test_empty_steps_rejected() -> None:
+    with pytest.raises(ValidationError):
+        SkillDefinition.model_validate(_valid_payload(steps=[]))
+
+
+def test_blank_step_rejected() -> None:
+    with pytest.raises(ValidationError):
+        SkillDefinition.model_validate(_valid_payload(steps=["good step", "   "]))
+
+
+def test_uppercase_name_rejected() -> None:
+    with pytest.raises(ValidationError):
+        SkillDefinition.model_validate(_valid_payload(name="BoxBreath"))
+
+
+def test_underscore_name_rejected() -> None:
+    with pytest.raises(ValidationError):
+        SkillDefinition.model_validate(_valid_payload(name="box_breath"))
+
+
+def test_steps_must_be_list_of_strings() -> None:
+    with pytest.raises(ValidationError):
+        SkillDefinition.model_validate(_valid_payload(steps="just one string"))
+
+
+# ── Registry / loader ──────────────────────────────────────────────────
+
+
+def _write_yaml(directory: Path, filename: str, content: str) -> Path:
+    file_path = directory / filename
+    file_path.write_text(dedent(content).strip() + "\n", encoding="utf-8")
+    return file_path
+
+
+@pytest.fixture
+def fake_skills_dir(tmp_path: Path) -> Path:
+    yaml_dir = tmp_path / "yaml"
+    yaml_dir.mkdir()
+    _write_yaml(
+        yaml_dir,
+        "alpha.yaml",
+        """
+        name: alpha-skill
+        modality: breathwork
+        title: Alpha Skill
+        description: First skill.
+        steps:
+          - Step one
+          - Step two
+        evidence_rating: A
+        contraindications: []
+        duration_minutes: 10
+        """,
+    )
+    _write_yaml(
+        yaml_dir,
+        "beta.yaml",
+        """
+        name: beta-skill
+        modality: somatic_practice
+        title: Beta Skill
+        description: Second skill.
+        steps:
+          - Move slowly
+        evidence_rating: B
+        contraindications:
+          - acute injury
+        duration_minutes: 15
+        """,
+    )
+    _write_yaml(
+        yaml_dir,
+        "gamma.yaml",
+        """
+        name: gamma-skill
+        modality: breathwork
+        title: Gamma Skill
+        description: Third skill.
+        steps:
+          - Inhale
+          - Exhale
+        evidence_rating: C
+        contraindications: []
+        duration_minutes: 7
+        """,
+    )
+    return yaml_dir
+
+
+def test_load_directory_loads_all_files(fake_skills_dir: Path) -> None:
+    reg = SkillRegistry()
+    reg.load_directory(fake_skills_dir)
+    assert len(reg) == 3
+
+
+def test_get_returns_skill(fake_skills_dir: Path) -> None:
+    reg = SkillRegistry()
+    reg.load_directory(fake_skills_dir)
+    skill = reg.get("alpha-skill")
+    assert skill.title == "Alpha Skill"
+
+
+def test_get_missing_raises_skill_not_found(fake_skills_dir: Path) -> None:
+    reg = SkillRegistry()
+    reg.load_directory(fake_skills_dir)
+    with pytest.raises(SkillNotFoundError):
+        reg.get("does-not-exist")
+
+
+def test_list_by_modality_filters_correctly(fake_skills_dir: Path) -> None:
+    reg = SkillRegistry()
+    reg.load_directory(fake_skills_dir)
+    breath = reg.list_by_modality("breathwork")
+    somatic = reg.list_by_modality("somatic_practice")
+    assert {s.name for s in breath} == {"alpha-skill", "gamma-skill"}
+    assert {s.name for s in somatic} == {"beta-skill"}
+
+
+def test_list_all_returns_every_skill(fake_skills_dir: Path) -> None:
+    reg = SkillRegistry()
+    reg.load_directory(fake_skills_dir)
+    assert len(reg.list_all()) == 3
+
+
+def test_load_twice_replaces_registry(tmp_path: Path, fake_skills_dir: Path) -> None:
+    reg = SkillRegistry()
+    reg.load_directory(fake_skills_dir)
+    assert len(reg) == 3
+
+    smaller = tmp_path / "smaller"
+    smaller.mkdir()
+    _write_yaml(
+        smaller,
+        "only.yaml",
+        """
+        name: only-skill
+        modality: nature_healing
+        title: Only Skill
+        description: Sole entry.
+        steps:
+          - Walk outside
+        evidence_rating: B
+        contraindications: []
+        duration_minutes: 20
+        """,
+    )
+    reg.load_directory(smaller)
+    assert len(reg) == 1
+    assert reg.get("only-skill").modality == "nature_healing"
+    with pytest.raises(SkillNotFoundError):
+        reg.get("alpha-skill")
+
+
+def test_invalid_yaml_raises_validation_error(tmp_path: Path) -> None:
+    yaml_dir = tmp_path / "bad"
+    yaml_dir.mkdir()
+    _write_yaml(
+        yaml_dir,
+        "broken.yaml",
+        """
+        name: broken
+        modality: not-a-real-modality
+        title: Broken
+        description: Bad modality.
+        steps:
+          - Step
+        evidence_rating: A
+        duration_minutes: 5
+        """,
+    )
+    reg = SkillRegistry()
+    with pytest.raises(SkillValidationError, match="broken.yaml"):
+        reg.load_directory(yaml_dir)
+
+
+def test_malformed_yaml_raises(tmp_path: Path) -> None:
+    yaml_dir = tmp_path / "malformed"
+    yaml_dir.mkdir()
+    (yaml_dir / "garbage.yaml").write_text("name: [unbalanced\n", encoding="utf-8")
+    reg = SkillRegistry()
+    with pytest.raises(SkillValidationError, match="garbage.yaml"):
+        reg.load_directory(yaml_dir)
+
+
+def test_duplicate_skill_names_rejected(tmp_path: Path) -> None:
+    yaml_dir = tmp_path / "dupes"
+    yaml_dir.mkdir()
+    _write_yaml(
+        yaml_dir,
+        "one.yaml",
+        """
+        name: same-name
+        modality: breathwork
+        title: One
+        description: First.
+        steps:
+          - A
+        evidence_rating: A
+        duration_minutes: 5
+        """,
+    )
+    _write_yaml(
+        yaml_dir,
+        "two.yaml",
+        """
+        name: same-name
+        modality: somatic_practice
+        title: Two
+        description: Second.
+        steps:
+          - B
+        evidence_rating: B
+        duration_minutes: 6
+        """,
+    )
+    reg = SkillRegistry()
+    with pytest.raises(SkillValidationError, match="Duplicate"):
+        reg.load_directory(yaml_dir)
+
+
+def test_missing_directory_raises(tmp_path: Path) -> None:
+    reg = SkillRegistry()
+    with pytest.raises(FileNotFoundError):
+        reg.load_directory(tmp_path / "nope")

--- a/tests/engine/test_bridges_registry.py
+++ b/tests/engine/test_bridges_registry.py
@@ -1,0 +1,166 @@
+"""Unit tests for the cross-system bridges registry."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from alchymine.engine.bridges import (
+    BRIDGE_REGISTRY,
+    Bridge,
+    BridgeNotFoundError,
+    get_bridge,
+    list_bridges,
+    list_bridges_from,
+    list_bridges_to,
+)
+from alchymine.engine.bridges.registry import VALID_SYSTEMS
+
+EXPECTED_IDS = ("XS-01", "XS-02", "XS-03", "XS-04", "XS-05", "XS-06", "XS-07")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Registry composition
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestRegistryComposition:
+    def test_registry_has_all_seven_bridges(self) -> None:
+        assert len(BRIDGE_REGISTRY) == 7
+        assert set(BRIDGE_REGISTRY.keys()) == set(EXPECTED_IDS)
+
+    def test_bridge_ids_are_unique(self) -> None:
+        ids = [b.id for b in BRIDGE_REGISTRY.values()]
+        assert len(ids) == len(set(ids))
+
+    def test_dict_key_matches_bridge_id_field(self) -> None:
+        for key, bridge in BRIDGE_REGISTRY.items():
+            assert key == bridge.id
+
+    def test_source_systems_are_valid(self) -> None:
+        for bridge in BRIDGE_REGISTRY.values():
+            assert bridge.source_system in VALID_SYSTEMS, (
+                f"{bridge.id} has invalid source_system={bridge.source_system!r}"
+            )
+
+    def test_target_systems_are_valid(self) -> None:
+        for bridge in BRIDGE_REGISTRY.values():
+            assert bridge.target_system in VALID_SYSTEMS, (
+                f"{bridge.id} has invalid target_system={bridge.target_system!r}"
+            )
+
+    def test_source_and_target_differ(self) -> None:
+        for bridge in BRIDGE_REGISTRY.values():
+            assert bridge.source_system != bridge.target_system, (
+                f"{bridge.id} has source==target ({bridge.source_system})"
+            )
+
+    def test_every_bridge_has_nonempty_metadata(self) -> None:
+        for bridge in BRIDGE_REGISTRY.values():
+            assert bridge.name.strip(), f"{bridge.id} has empty name"
+            assert bridge.description.strip(), f"{bridge.id} has empty description"
+            assert len(bridge.insight_keys) >= 1, f"{bridge.id} has no insight_keys"
+
+    def test_insight_keys_is_a_tuple(self) -> None:
+        # Frozen dataclass + tuple makes the entry effectively immutable.
+        for bridge in BRIDGE_REGISTRY.values():
+            assert isinstance(bridge.insight_keys, tuple)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# get_bridge
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestGetBridge:
+    def test_get_bridge_returns_known_id(self) -> None:
+        bridge = get_bridge("XS-01")
+        assert bridge.id == "XS-01"
+        assert bridge.source_system == "healing"
+        assert bridge.target_system == "perspective"
+
+    def test_get_bridge_raises_on_unknown_id(self) -> None:
+        with pytest.raises(BridgeNotFoundError):
+            get_bridge("XS-99")
+
+    def test_get_bridge_raises_on_empty_string(self) -> None:
+        with pytest.raises(BridgeNotFoundError):
+            get_bridge("")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# list_bridges* helpers
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestListBridges:
+    def test_list_bridges_returns_seven(self) -> None:
+        bridges = list_bridges()
+        assert len(bridges) == 7
+
+    def test_list_bridges_returns_stable_order(self) -> None:
+        bridges = list_bridges()
+        ids = tuple(b.id for b in bridges)
+        assert ids == EXPECTED_IDS
+
+    def test_list_bridges_returns_tuple(self) -> None:
+        bridges = list_bridges()
+        assert isinstance(bridges, tuple)
+
+    def test_list_bridges_from_filters_correctly(self) -> None:
+        healing_sources = list_bridges_from("healing")
+        # XS-01 (healing→perspective) and XS-06 (healing→creative)
+        assert {b.id for b in healing_sources} == {"XS-01", "XS-06"}
+        for b in healing_sources:
+            assert b.source_system == "healing"
+
+    def test_list_bridges_from_unknown_returns_empty(self) -> None:
+        assert list_bridges_from("not-a-system") == ()
+
+    def test_list_bridges_to_filters_correctly(self) -> None:
+        healing_targets = list_bridges_to("healing")
+        # XS-02 (intelligence→healing), XS-03 (wealth→healing),
+        # XS-04 (creative→healing)
+        assert {b.id for b in healing_targets} == {"XS-02", "XS-03", "XS-04"}
+        for b in healing_targets:
+            assert b.target_system == "healing"
+
+    def test_list_bridges_to_unknown_returns_empty(self) -> None:
+        assert list_bridges_to("not-a-system") == ()
+
+    def test_list_bridges_from_preserves_id_order(self) -> None:
+        bridges = list_bridges_from("intelligence")
+        ids = [b.id for b in bridges]
+        assert ids == sorted(ids)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Frozenness
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestBridgeIsFrozen:
+    def test_bridge_attributes_cannot_be_mutated(self) -> None:
+        bridge = get_bridge("XS-01")
+        with pytest.raises(FrozenInstanceError):
+            bridge.name = "Hacked"  # type: ignore[misc]
+
+    def test_cannot_add_new_attribute(self) -> None:
+        bridge = get_bridge("XS-01")
+        with pytest.raises(FrozenInstanceError):
+            bridge.foo = "bar"  # type: ignore[attr-defined]
+
+    def test_bridge_dataclass_is_frozen_class_level(self) -> None:
+        # Sanity: instantiating a fresh Bridge and trying to mutate it
+        # should also raise.
+        b = Bridge(
+            id="XS-XX",
+            name="Test",
+            source_system="healing",
+            target_system="creative",
+            description="d",
+            insight_keys=("k",),
+        )
+        with pytest.raises(FrozenInstanceError):
+            b.id = "XS-YY"  # type: ignore[misc]


### PR DESCRIPTION
## Summary
- **Issue:** #161 (T1-S6 Spiral integration, submodule, polish)
- **SpiralBanner**: personalized recommendations based on user's Alchemical Spiral stage + healing rank
- **Backend**: `GET /api/v1/healing/spiral-route` runs full Spiral routing with tiered modality recommendations
- **Multi-dir SkillRegistry**: `load_directory(replace=False)` merges skills from external dir; `HEALING_SKILLS_EXTERNAL_DIR` config; placeholder for healing-swarm-skills submodule
- **WCAG 2.1 AA audit**: focus trapping in SkillDetailDrawer, aria roles on BreathworkGuide/JournalEntryActions/MoodSparkline, screen-reader summaries
- 29 new tests (14 backend + 7 + 8 frontend), 2079 backend + 222 frontend total

## Test plan
- [ ] `pytest tests/ -v` — 2079 backend tests
- [ ] `cd alchymine/web && npm test` — 222 frontend tests
- [ ] `ruff check && ruff format --check` — lint clean

Stacked on #192. Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)