### PR TITLE
fix(web): add API request timeout so a hung backend no longer freezes the app after login

### DIFF
--- a/alchymine/web/src/lib/__tests__/api.timeout.test.ts
+++ b/alchymine/web/src/lib/__tests__/api.timeout.test.ts
@@ -1,0 +1,69 @@
+import { getMe, ApiError } from "@/lib/api";
+
+/**
+ * Regression test for the request timeout added to the API client.
+ *
+ * Previously `request()` called `fetch` with no timeout, so a hung
+ * connection (an unreachable/unresponsive API origin on a deployed site)
+ * never settled — leaving the UI stuck on a loading spinner forever after
+ * login. The client now aborts requests that exceed REQUEST_TIMEOUT_MS and
+ * surfaces a recoverable ApiError instead.
+ */
+describe("API request timeout", () => {
+  const realFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = realFetch;
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it("rejects with a timeout ApiError when the request hangs", async () => {
+    jest.useFakeTimers();
+
+    // A fetch that never resolves on its own, but rejects (like a real
+    // browser) when its AbortSignal fires.
+    global.fetch = jest.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("Aborted", "AbortError"));
+        });
+      });
+    }) as unknown as typeof fetch;
+
+    const promise = getMe();
+    // Attach the assertion before advancing timers so the rejection is handled.
+    const assertion = expect(promise).rejects.toMatchObject({
+      name: "ApiError",
+      status: 0,
+      message: expect.stringMatching(/timed out/i),
+    });
+
+    // Advance past the timeout budget to trigger the abort.
+    await jest.advanceTimersByTimeAsync(20000);
+    await assertion;
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not time out a request that resolves promptly", async () => {
+    jest.useFakeTimers();
+
+    global.fetch = jest.fn(async () => {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ id: "u1", email: "a@b.co" }),
+      } as Response;
+    }) as unknown as typeof fetch;
+
+    const me = await getMe();
+    expect(me).toMatchObject({ id: "u1", email: "a@b.co" });
+    // The pending timeout timer must be cleared so it never fires.
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it("exports ApiError for callers to narrow on", () => {
+    expect(new ApiError(0, "x")).toBeInstanceOf(Error);
+  });
+});

--- a/alchymine/web/src/lib/api.ts
+++ b/alchymine/web/src/lib/api.ts
@@ -291,6 +291,56 @@ class ApiError extends Error {
   }
 }
 
+// Maximum time to wait for any single API request before giving up.  Without
+// this, a hung connection (e.g. an unreachable or unresponsive API origin on a
+// deployed site) never settles, so callers that gate UI on the promise — the
+// dashboard "Loading your profile…" spinner, ProtectedRoute, etc. — spin
+// forever with no error and no recovery.  Aborting turns an indefinite hang
+// into a recoverable ApiError the UI can surface.
+const REQUEST_TIMEOUT_MS = 20000;
+
+/**
+ * `fetch` with a hard timeout.  Aborts the request after
+ * `REQUEST_TIMEOUT_MS` and converts the resulting abort into an ApiError so
+ * the UI fails gracefully instead of hanging.  If the caller supplies its own
+ * `signal` (e.g. for unmount cancellation), it is honoured as well.
+ */
+async function fetchWithTimeout(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  const callerSignal = init?.signal ?? undefined;
+  if (callerSignal) {
+    if (callerSignal.aborted) controller.abort();
+    else
+      callerSignal.addEventListener("abort", () => controller.abort(), {
+        once: true,
+      });
+  }
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } catch (err) {
+    // Distinguish our timeout from a caller-initiated abort: rethrow the
+    // latter untouched so callers can ignore it, but surface the former as a
+    // friendly, recoverable error.
+    if (
+      err instanceof DOMException &&
+      err.name === "AbortError" &&
+      !callerSignal?.aborted
+    ) {
+      throw new ApiError(
+        0,
+        "Request timed out. Please check your connection and try again.",
+      );
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 /** Map an ApiError from an auth endpoint to a user-friendly message. */
 export function friendlyAuthError(
   err: unknown,
@@ -334,7 +384,7 @@ async function request<T>(
   options?: RequestInit,
   allow202 = false,
 ): Promise<T> {
-  const res = await fetch(url, {
+  const res = await fetchWithTimeout(url, {
     ...options,
     credentials: "include",
     headers: {
@@ -358,7 +408,7 @@ async function request<T>(
   if (res.status === 401 && typeof window !== "undefined") {
     const legacyRefreshToken = localStorage.getItem("refresh_token");
     try {
-      const refreshRes = await fetch(`${BASE}/auth/refresh`, {
+      const refreshRes = await fetchWithTimeout(`${BASE}/auth/refresh`, {
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
@@ -373,7 +423,7 @@ async function request<T>(
         localStorage.setItem("access_token", tokens.access_token);
         localStorage.setItem("refresh_token", tokens.refresh_token);
         // Retry the original request
-        const retryRes = await fetch(url, {
+        const retryRes = await fetchWithTimeout(url, {
           ...options,
           credentials: "include",
           headers: {
@@ -1323,7 +1373,7 @@ export interface WaitlistInviteResponse {
 export async function joinWaitlist(
   email: string,
 ): Promise<{ message: string; already_registered: boolean }> {
-  const res = await fetch(`${BASE}/auth/waitlist`, {
+  const res = await fetchWithTimeout(`${BASE}/auth/waitlist`, {
     method: "POST",
     credentials: "include",
     headers: { "Content-Type": "application/json" },
@@ -1400,7 +1450,7 @@ export interface PaginatedFeedback {
 export async function submitFeedback(
   payload: FeedbackPayload,
 ): Promise<{ id: number; message: string }> {
-  const res = await fetch(`${BASE}/feedback`, {
+  const res = await fetchWithTimeout(`${BASE}/feedback`, {
     method: "POST",
     credentials: "include",
     headers: {


### PR DESCRIPTION
## Problem

On the **deployed site**, signing in could leave the dashboard stuck on the **"Loading your profile…" spinner indefinitely** — the app appeared to "fail after login."

Root cause: the API client's `request()` wrapper (and a few other call sites) called `fetch` with **no timeout**. When a connection hangs — an unreachable or unresponsive API origin, a stalled proxy, a cross-origin request that never completes — the promise never settles (neither resolves nor rejects). The UI gates rendering on that promise settling:

- `useIntake` → dashboard "Loading your profile…" spinner (`getProfile`)
- `AuthContext` → `ProtectedRoute` full-screen spinner (`getMe`)
- `useApi` sections (outcomes, journal stats, cross-system insights)

So a request that never settles spins **forever**, with no error message and no recovery path.

## Fix

- Add `fetchWithTimeout`, which aborts any request exceeding `REQUEST_TIMEOUT_MS` (20s) via `AbortController` and converts the abort into a recoverable `ApiError` (`"Request timed out…"`).
- Route **all** `fetch` calls in the client through it: the main request path, the 401 token-refresh + retry, plus the waitlist and feedback submits.
- A caller-supplied `AbortSignal` (e.g. unmount cancellation from `useApi`) is still honoured, and **its** aborts are rethrown untouched so they aren't misreported as timeouts.

This turns an indefinite hang into a **visible, recoverable error**: the dashboard falls back to its empty/error states, `ProtectedRoute` resolves (redirecting to login if unauthenticated) instead of freezing, and the underlying connectivity problem becomes diagnosable instead of silent.

## Tests

New `src/lib/__tests__/api.timeout.test.ts`:
- a hung request rejects with a timeout `ApiError` (status 0, "timed out")
- a prompt success does **not** time out and clears its pending timer
- `ApiError` is exported for callers to narrow on

## Verification

- `tsc --noEmit` ✅  ·  `next lint` ✅  ·  `next build` ✅
- `jest` ✅ — **336 passed** (333 existing + 3 new)

## Note on the underlying cause

This is the client-side robustness fix. The *reason* the API hangs on your deployment is environment-side — most likely the API origin (`NEXT_PUBLIC_API_URL`) being unreachable/slow/misconfigured, or cross-origin cookie/CORS setup. With this change the app will now **show** that failure (timeout/connect error) within 20s rather than spinning silently, which should make the root deployment issue much easier to pin down. Happy to dig into the API/CORS/env config next if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165ZGjKsewPM93HdNWL4n4a

---
_Generated by [Claude Code](https://claude.ai/code/session_0165ZGjKsewPM93HdNWL4n4a)_